### PR TITLE
parquet: restructure reader to speed up processing on multi-core systems;

### DIFF
--- a/pkg/blob/client.go
+++ b/pkg/blob/client.go
@@ -40,13 +40,17 @@ func ProvideS3Client(config cfg.Config) s3iface.S3API {
 func GetS3ClientConfig(config cfg.Config) *aws.Config {
 	endpoint := config.GetString("aws_s3_endpoint")
 	maxRetries := config.GetInt("aws_sdk_retries")
+	timeout := 1 * time.Minute
+	if config.IsSet("aws_s3_timeout") {
+		timeout = config.GetDuration("aws_s3_timeout")
+	}
 
 	return &aws.Config{
 		CredentialsChainVerboseErrors: aws.Bool(true),
 		Endpoint:                      aws.String(endpoint),
 		Region:                        aws.String(endpoints.EuCentral1RegionID),
 		HTTPClient: &http.Client{
-			Timeout: 1 * time.Minute,
+			Timeout: timeout,
 		},
 		MaxRetries: aws.Int(maxRetries),
 	}

--- a/pkg/parquet/mocks/Reader.go
+++ b/pkg/parquet/mocks/Reader.go
@@ -12,13 +12,13 @@ type Reader struct {
 	mock.Mock
 }
 
-// ReadDate provides a mock function with given fields: ctx, datetime, target
-func (_m *Reader) ReadDate(ctx context.Context, datetime time.Time, target interface{}) error {
-	ret := _m.Called(ctx, datetime, target)
+// ReadDates provides a mock function with given fields: ctx, dates, target
+func (_m *Reader) ReadDates(ctx context.Context, dates []time.Time, target interface{}) error {
+	ret := _m.Called(ctx, dates, target)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, time.Time, interface{}) error); ok {
-		r0 = rf(ctx, datetime, target)
+	if rf, ok := ret.Get(0).(func(context.Context, []time.Time, interface{}) error); ok {
+		r0 = rf(ctx, dates, target)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -26,13 +26,13 @@ func (_m *Reader) ReadDate(ctx context.Context, datetime time.Time, target inter
 	return r0
 }
 
-// ReadDateAsync provides a mock function with given fields: ctx, datetime, target, callback
-func (_m *Reader) ReadDateAsync(ctx context.Context, datetime time.Time, target interface{}, callback parquet.ResultCallback) error {
-	ret := _m.Called(ctx, datetime, target, callback)
+// ReadDatesAsync provides a mock function with given fields: ctx, dates, target, callback
+func (_m *Reader) ReadDatesAsync(ctx context.Context, dates []time.Time, target interface{}, callback parquet.ResultCallback) error {
+	ret := _m.Called(ctx, dates, target, callback)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, time.Time, interface{}, parquet.ResultCallback) error); ok {
-		r0 = rf(ctx, datetime, target, callback)
+	if rf, ok := ret.Get(0).(func(context.Context, []time.Time, interface{}, parquet.ResultCallback) error); ok {
+		r0 = rf(ctx, dates, target, callback)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -40,25 +40,16 @@ func (_m *Reader) ReadDateAsync(ctx context.Context, datetime time.Time, target 
 	return r0
 }
 
-// ReadFile provides a mock function with given fields: ctx, file
-func (_m *Reader) ReadFile(ctx context.Context, file string) (parquet.ReadResults, error) {
-	ret := _m.Called(ctx, file)
+// ReadFile provides a mock function with given fields: ctx, file, callback
+func (_m *Reader) ReadFile(ctx context.Context, file string, callback func(parquet.ReadResults, bool) error) error {
+	ret := _m.Called(ctx, file, callback)
 
-	var r0 parquet.ReadResults
-	if rf, ok := ret.Get(0).(func(context.Context, string) parquet.ReadResults); ok {
-		r0 = rf(ctx, file)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, func(parquet.ReadResults, bool) error) error); ok {
+		r0 = rf(ctx, file, callback)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(parquet.ReadResults)
-		}
+		r0 = ret.Error(0)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, file)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }

--- a/pkg/parquet/parquet.go
+++ b/pkg/parquet/parquet.go
@@ -20,12 +20,6 @@ var s3PrefixNamingStrategies = map[string]s3PrefixNamingStrategy{
 	NamingStrategyDtSeparated: dtSeparated,
 }
 
-type ReaderSettings struct {
-	ModelId        mdl.ModelId
-	NamingStrategy string
-	Recorder       FileRecorder
-}
-
 type S3BucketNamingStrategy func(appId cfg.AppId) string
 
 func WithS3BucketNamingStrategy(strategy S3BucketNamingStrategy) {

--- a/pkg/parquet/reader.go
+++ b/pkg/parquet/reader.go
@@ -2,9 +2,12 @@ package parquet
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"github.com/applike/gosoline/pkg/blob"
 	"github.com/applike/gosoline/pkg/cfg"
+	"github.com/applike/gosoline/pkg/coffin"
 	"github.com/applike/gosoline/pkg/mdl"
 	"github.com/applike/gosoline/pkg/mon"
 	"github.com/applike/gosoline/pkg/refl"
@@ -13,30 +16,41 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
-	parquetS3 "github.com/xitongsys/parquet-go-source/s3"
+	parquetBuffer "github.com/xitongsys/parquet-go-source/buffer"
 	"github.com/xitongsys/parquet-go/reader"
+	"github.com/xitongsys/parquet-go/source"
 	"golang.org/x/sync/semaphore"
+	"io/ioutil"
+	"os"
 	"reflect"
+	"runtime"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"time"
 )
 
 type Progress struct {
-	FileCount int
-	Current   int
+	FileCount    int
+	BytesCount   int64
+	Current      int
+	CurrentBytes int64
+	LastChunk    bool
 }
 
 type ReadResult map[string]interface{}
 type ReadResults []ReadResult
 type ResultCallback func(progress Progress, results interface{}) (bool, error)
 
+var CallbackStopErr = errors.New("callback returned false")
+
 //go:generate mockery -name Reader
 type Reader interface {
-	ReadDate(ctx context.Context, datetime time.Time, target interface{}) error
-	ReadDateAsync(ctx context.Context, datetime time.Time, target interface{}, callback ResultCallback) error
-	ReadFile(ctx context.Context, file string) (ReadResults, error)
+	ReadDates(ctx context.Context, dates []time.Time, target interface{}) error
+	ReadDatesAsync(ctx context.Context, dates []time.Time, target interface{}, callback ResultCallback) error
+	ReadFile(ctx context.Context, file string, callback func(chunk ReadResults, lastChunk bool) error) error
 }
+
+type ReaderOption func(s *s3Reader) error
 
 type s3Reader struct {
 	logger   mon.Logger
@@ -46,24 +60,40 @@ type s3Reader struct {
 	modelId              mdl.ModelId
 	prefixNamingStrategy s3PrefixNamingStrategy
 	recorder             FileRecorder
+	batchSize            int
+	maxConcurrentRows    int64
+	cacheDirectory       *string
 }
 
-func NewReader(config cfg.Config, logger mon.Logger, settings *ReaderSettings) *s3Reader {
+func NewReader(config cfg.Config, logger mon.Logger, opts ...ReaderOption) *s3Reader {
 	s3Cfg := blob.GetS3ClientConfig(config)
 	s3Client := blob.ProvideS3Client(config)
 
-	prefixNaming, exists := s3PrefixNamingStrategies[settings.NamingStrategy]
+	s := NewReaderWithInterfaces(
+		logger,
+		s3Cfg,
+		s3Client,
+		mdl.ModelId{},
+		s3PrefixNamingStrategies[NamingStrategyDtSeparated],
+		NewNopRecorder(),
+		10_000,
+		1_000_000,
+		nil,
+	)
 
-	if !exists {
-		panic(fmt.Sprintf("Unknown prefix naming strategy '%s'", settings.NamingStrategy))
+	for _, opt := range opts {
+		if err := opt(s); err != nil {
+			logger.Panic(err, "failed to configure S3 parquet reader")
+		}
 	}
 
-	recorder := settings.Recorder
-	if recorder == nil {
-		recorder = NewNopRecorder()
+	s.modelId.PadFromConfig(config)
+	if len(s.modelId.Name) == 0 {
+		err := errors.New("model may not be empty")
+		logger.Panic(err, "failed to configure S3 parquet reader")
 	}
 
-	return NewReaderWithInterfaces(logger, s3Cfg, s3Client, settings.ModelId, prefixNaming, recorder)
+	return s
 }
 
 func NewReaderWithInterfaces(
@@ -73,6 +103,9 @@ func NewReaderWithInterfaces(
 	modelId mdl.ModelId,
 	prefixNaming s3PrefixNamingStrategy,
 	recorder FileRecorder,
+	batchSize int,
+	maxConcurrentRows int64,
+	cacheDirectory *string,
 ) *s3Reader {
 	return &s3Reader{
 		logger:               logger,
@@ -81,10 +114,101 @@ func NewReaderWithInterfaces(
 		modelId:              modelId,
 		prefixNamingStrategy: prefixNaming,
 		recorder:             recorder,
+		batchSize:            batchSize,
+		maxConcurrentRows:    maxConcurrentRows,
+		cacheDirectory:       cacheDirectory,
 	}
 }
 
-func (r *s3Reader) ReadDate(ctx context.Context, datetime time.Time, target interface{}) error {
+func ReaderModelId(modelId mdl.ModelId) ReaderOption {
+	return func(s *s3Reader) error {
+		s.modelId = modelId
+
+		return nil
+	}
+}
+
+func ReaderNamingStrategy(namingStrategy string) ReaderOption {
+	return func(s *s3Reader) error {
+		prefixNaming, exists := s3PrefixNamingStrategies[namingStrategy]
+
+		if !exists {
+			return fmt.Errorf("unknown prefix naming strategy '%s'", namingStrategy)
+		}
+
+		s.prefixNamingStrategy = prefixNaming
+
+		return nil
+	}
+}
+
+func ReaderFileRecorder(recorder FileRecorder) ReaderOption {
+	return func(s *s3Reader) error {
+		if recorder == nil {
+			recorder = NewNopRecorder()
+		}
+
+		s.recorder = recorder
+
+		return nil
+	}
+}
+
+// how many rows do you want to receive at once in your callback?
+// if e.g. the file you are reading has 400k rows (could be around
+// 30mb) and we instantiate all of them at once, we create quite a
+// lot of objects at the same time, causing memory explosion (10gb)
+// instead, if we only parse 400k rows and then convert them in
+// batches of 10k to your application type, we can reduce memory
+// usage quite a bit
+// default: 10 000
+func ReaderBatchSize(batchSize int) ReaderOption {
+	return func(s *s3Reader) error {
+		if batchSize <= 0 {
+			return fmt.Errorf("batch size needs to be positive")
+		}
+
+		s.batchSize = batchSize
+
+		return nil
+	}
+}
+
+// how many rows should we try to keep in memory at once? if multiple
+// workers are processing big files, you can easily multiply your memory
+// usage by the number of your workers. instead, each worker now
+// has to keep track of the number of rows it is processing
+// default: 1 000 000, should result in 2-3gb memory usage
+func ReaderMaxConcurrentRows(maxConcurrentRows int64) ReaderOption {
+	return func(s *s3Reader) error {
+		if maxConcurrentRows <= 0 {
+			return fmt.Errorf("max concurrent rows needs to be positive")
+		}
+
+		s.maxConcurrentRows = maxConcurrentRows
+
+		return nil
+	}
+}
+
+// allow the reader to store downloaded files in some directory on your hard disk.
+// if you process the same files multiple times this will allow you to skip downloading
+// them again and again.
+// you should have a few gb to spare in this directory
+// default: do not cache downloaded files
+func ReaderCacheDirectory(cacheDirectory string) ReaderOption {
+	return func(s *s3Reader) error {
+		if len(cacheDirectory) == 0 {
+			return fmt.Errorf("can not set cache directory to empty string")
+		}
+
+		s.cacheDirectory = &cacheDirectory
+
+		return nil
+	}
+}
+
+func (r *s3Reader) ReadDates(ctx context.Context, dates []time.Time, target interface{}) error {
 	if !refl.IsPointerToSlice(target) {
 		return fmt.Errorf("target needs to be a pointer to a slice, but is %T", target)
 	}
@@ -93,7 +217,7 @@ func (r *s3Reader) ReadDate(ctx context.Context, datetime time.Time, target inte
 	tp := reflect.ValueOf(tmp)
 	t := tp.Elem()
 
-	err := r.ReadDateAsync(ctx, datetime, target, func(progress Progress, result interface{}) (bool, error) {
+	err := r.ReadDatesAsync(ctx, dates, target, func(progress Progress, result interface{}) (bool, error) {
 		rp := reflect.ValueOf(result)
 		r := rp.Elem()
 
@@ -111,93 +235,225 @@ func (r *s3Reader) ReadDate(ctx context.Context, datetime time.Time, target inte
 	return nil
 }
 
-func (r *s3Reader) ReadDateAsync(ctx context.Context, datetime time.Time, target interface{}, callback ResultCallback) error {
+func (r *s3Reader) ReadDatesAsync(ctx context.Context, dates []time.Time, target interface{}, callback ResultCallback) error {
 	if !refl.IsPointerToSlice(target) {
 		return fmt.Errorf("target needs to be a pointer to a slice, but is %T", target)
 	}
 
-	files, err := r.listFilesFromDate(datetime)
+	files := make([]string, 0, len(dates))
+	var totalSize int64
 
-	if err != nil {
-		return err
-	}
-
-	fileCount := len(files)
-	stop := false
-
-	sem := semaphore.NewWeighted(int64(10))
-	wg := sync.WaitGroup{}
-	wg.Add(fileCount)
-
-	for i, file := range files {
-		err := sem.Acquire(ctx, int64(1))
+	for _, date := range dates {
+		newFiles, newSize, err := r.listFilesFromDate(date)
 
 		if err != nil {
 			return err
 		}
 
-		go func(i int, file string) {
-			defer sem.Release(int64(1))
-			defer wg.Done()
-
-			if stop {
-				return
-			}
-
-			r.logger.Debugf("reading file %d of %d: %s", i, fileCount, file)
-
-			result, err := r.ReadFile(ctx, file)
-
-			if err != nil {
-				r.logger.Fatal(err, "can not read file")
-
-				return
-			}
-
-			decoded := refl.CreatePointerToSliceOfTypeAndSize(target, len(result))
-			err = r.decode(result, decoded)
-
-			if err != nil {
-				r.logger.Error(err, "could not decode results")
-
-				return
-			}
-
-			ok, err := callback(Progress{
-				FileCount: fileCount,
-				Current:   i,
-			}, decoded)
-
-			if !ok {
-				stop = true
-
-				return
-			}
-
-			r.recorder.RecordFile(r.getBucketName(), file)
-		}(i, file)
+		files = append(files, newFiles...)
+		totalSize += newSize
 	}
 
-	wg.Wait()
-
-	return nil
+	return r.readFilesAsync(ctx, files, totalSize, target, callback)
 }
 
-func (r *s3Reader) ReadFile(ctx context.Context, file string) (ReadResults, error) {
-	bucket := r.getBucketName()
-	fr, err := parquetS3.NewS3FileReader(ctx, bucket, file, r.s3Cfg)
+func (r *s3Reader) readFilesAsync(ctx context.Context, files []string, totalSize int64, target interface{}, callback ResultCallback) error {
+	fileCount := len(files)
+
+	// amount of concurrent workers who can download new files
+	dlSem := semaphore.NewWeighted(int64(runtime.NumCPU() * 2))
+	// amount of concurrent workers processing the files
+	cbSem := semaphore.NewWeighted(int64(runtime.NumCPU()))
+	// amount of rows we want to process at once (avoids too high memory pressure)
+	rowsSem := semaphore.NewWeighted(r.maxConcurrentRows)
+	cfn, cfnCtx := coffin.WithContext(ctx)
+	var progress int32
+	var progressBytes int64
+
+	for _, file := range files {
+		file := file
+		cfn.GoWithContext(cfnCtx, func(ctx context.Context) error {
+			if err := dlSem.Acquire(ctx, 1); err != nil {
+				return err
+			}
+			defer dlSem.Release(1)
+
+			logger := r.logger.WithContext(ctx)
+			logger.Infof("reading file %s", file)
+
+			size, err := r.readFile(ctx, file, func(result ReadResults, last bool) error {
+				if err := cbSem.Acquire(ctx, 1); err != nil {
+					return err
+				}
+				defer cbSem.Release(1)
+
+				decoded := refl.CreatePointerToSliceOfTypeAndSize(target, len(result))
+
+				if err := r.decode(result, decoded); err != nil {
+					return fmt.Errorf("can not decode results for file %s: %w", file, err)
+				}
+
+				ok, err := callback(Progress{
+					FileCount:    fileCount,
+					BytesCount:   totalSize,
+					Current:      int(progress),
+					CurrentBytes: progressBytes,
+					LastChunk:    last,
+				}, decoded)
+
+				if !ok {
+					cfn.Kill(CallbackStopErr)
+				}
+
+				return err
+			}, rowsSem, r.maxConcurrentRows)
+
+			atomic.AddInt32(&progress, 1)
+			atomic.AddInt64(&progressBytes, size)
+			logger.Infof("processed file: %s", file)
+			r.recorder.RecordFile(r.getBucketName(), file)
+
+			if err != nil {
+				return fmt.Errorf("can not process file %s: %w", file, err)
+			}
+
+			return nil
+		})
+	}
+
+	return cfn.Wait()
+}
+
+func (r *s3Reader) downloadFile(bucket string, file string) ([]byte, error) {
+	if r.cacheDirectory == nil {
+		return r.downloadFileFromS3(bucket, file)
+	}
+
+	byteKey := sha256.Sum256([]byte(fmt.Sprintf("%s/%s", bucket, file)))
+	key := hex.EncodeToString(byteKey[:])
+	fullPath := fmt.Sprintf("%s/%s", *r.cacheDirectory, key)
+
+	// we don't really care why we could not read the file, most likely it did not exist
+	// but even if something else was the reason, we just download a fresh copy and are done
+	if contents, err := ioutil.ReadFile(fullPath); err == nil {
+		return contents, nil
+	}
+
+	contents, err := r.downloadFileFromS3(bucket, file)
 
 	if err != nil {
 		return nil, err
+	}
+
+	if err := os.Mkdir(*r.cacheDirectory, 0755); !os.IsExist(err) {
+		// we can not write to the cache, so lets just ignore the cache
+		return contents, nil
+	}
+
+	// write to a temp file first - if we get interrupted while writing (crash in another thread, SIGTERM),
+	// we will have only a partial file written. Instead, if we write to another file first, we only corrupt
+	// that file, but no one will ever read it
+	tmpPath := fmt.Sprintf("%s.tmp", fullPath)
+
+	// again we don't really care about any errors - if we fail to write to the cache, so be it
+	// however, if we e.g. run out of space, we want to make sure we are not leaving behind partial
+	// files, so we better delete the file again
+	if err := ioutil.WriteFile(tmpPath, contents, 0644); err != nil {
+		_ = os.Remove(tmpPath)
+
+		return contents, nil
+	}
+
+	// try to make it official. if it fails, just clean everything and try again next time
+	if err := os.Rename(tmpPath, fullPath); err != nil {
+		_ = os.Remove(tmpPath)
+		_ = os.Remove(fullPath)
+	}
+
+	return contents, nil
+}
+
+func (r *s3Reader) downloadFileFromS3(bucket string, file string) ([]byte, error) {
+	input := &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(file),
+	}
+
+	out, err := r.s3Client.GetObject(input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	contents, readErr := ioutil.ReadAll(out.Body)
+
+	if err := out.Body.Close(); err != nil {
+		return nil, err
+	}
+
+	return contents, readErr
+}
+
+func (r *s3Reader) newS3FileReader(ctx context.Context, file string) (source.ParquetFile, int64, error) {
+	bucket := r.getBucketName()
+
+	logger := r.logger.WithContext(ctx)
+	logger.Infof("downloading file %s/%s", bucket, file)
+	start := time.Now()
+
+	contents, err := r.downloadFile(bucket, file)
+
+	if err != nil {
+		return nil, 0, err
+	}
+
+	took := time.Now().Sub(start)
+	logger.Infof("download took %v for %d bytes; reading file %s/%s", took, len(contents), bucket, file)
+
+	fr, err := parquetBuffer.NewBufferFile(contents)
+
+	return fr, int64(len(contents)), err
+}
+
+func (r *s3Reader) ReadFile(ctx context.Context, file string, callback func(chunk ReadResults, lastChunk bool) error) error {
+	_, err := r.readFile(ctx, file, callback, nil, 0)
+
+	return err
+}
+
+func (r *s3Reader) readFile(
+	ctx context.Context,
+	file string,
+	callback func(chunk ReadResults, lastChunk bool) error,
+	rowsSem *semaphore.Weighted,
+	rowsSemSize int64,
+) (int64, error) {
+	fr, fileSize, err := r.newS3FileReader(ctx, file)
+
+	if err != nil {
+		return 0, err
 	}
 
 	pr, err := reader.NewParquetColumnReader(fr, 4)
 
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 
 	size := int(pr.GetNumRows())
+
+	if rowsSem != nil {
+		toAcquire := int64(size)
+		if toAcquire > rowsSemSize {
+			toAcquire = rowsSemSize
+		}
+
+		if err := rowsSem.Acquire(ctx, toAcquire); err != nil {
+			return 0, err
+		}
+		defer rowsSem.Release(toAcquire)
+	}
+
 	columnNames := pr.SchemaHandler.ValueColumns
 	columns := make(map[string][]interface{})
 	rootName := pr.Footer.Schema[0].Name
@@ -206,7 +462,7 @@ func (r *s3Reader) ReadFile(ctx context.Context, file string) (ReadResults, erro
 		values, _, _, err := pr.ReadColumnByPath(colSchema, size)
 
 		if err != nil {
-			return nil, err
+			return 0, err
 		}
 
 		key := strings.ToLower(colSchema[len(rootName)+1:])
@@ -216,36 +472,47 @@ func (r *s3Reader) ReadFile(ctx context.Context, file string) (ReadResults, erro
 
 	pr.ReadStop()
 	if err = fr.Close(); err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	results := make(ReadResults, size)
+	for offset := 0; offset < size; offset += r.batchSize {
+		remaining := size - offset
+		if remaining > r.batchSize {
+			remaining = r.batchSize
+		}
 
-	for key, values := range columns {
-		for i := 0; i < size; i++ {
-			if results[i] == nil {
-				results[i] = make(ReadResult, len(columns))
+		results := make(ReadResults, remaining)
+
+		for key, values := range columns {
+			for i := 0; i < remaining; i++ {
+				if results[i] == nil {
+					results[i] = make(ReadResult, len(columns))
+				}
+
+				results[i][key] = values[i+offset]
 			}
+		}
 
-			results[i][key] = values[i]
+		if err := callback(results, offset+r.batchSize >= size); err != nil {
+			return 0, err
 		}
 	}
 
-	return results, nil
+	return fileSize, nil
 }
 
-func (r *s3Reader) listFilesFromDate(datetime time.Time) ([]string, error) {
+func (r *s3Reader) listFilesFromDate(datetime time.Time) ([]string, int64, error) {
 	prefix := r.prefixNamingStrategy(r.modelId, datetime)
-	files, err := r.listFiles(prefix)
+	files, totalSize, err := r.listFiles(prefix)
 
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	return files, err
+	return files, totalSize, err
 }
 
-func (r *s3Reader) listFiles(prefix string) ([]string, error) {
+func (r *s3Reader) listFiles(prefix string) ([]string, int64, error) {
 	bucket := r.getBucketName()
 
 	input := &s3.ListObjectsInput{
@@ -254,12 +521,13 @@ func (r *s3Reader) listFiles(prefix string) ([]string, error) {
 	}
 
 	files := make([]string, 0, 128)
+	var totalSize int64
 
 	for {
 		out, err := r.s3Client.ListObjects(input)
 
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 
 		if len(out.Contents) == 0 {
@@ -268,6 +536,7 @@ func (r *s3Reader) listFiles(prefix string) ([]string, error) {
 
 		for _, obj := range out.Contents {
 			files = append(files, *obj.Key)
+			totalSize += *obj.Size
 		}
 
 		if !*out.IsTruncated {
@@ -277,7 +546,7 @@ func (r *s3Reader) listFiles(prefix string) ([]string, error) {
 		input.Marker = out.Contents[len(out.Contents)-1].Key
 	}
 
-	return files, nil
+	return files, totalSize, nil
 }
 
 func (r *s3Reader) decode(input interface{}, output interface{}) error {


### PR DESCRIPTION
We often have a lot of small files as well as some big files for each
date of events in parquet files. Thus, after processing the small files,
there is only a single big file left to process and we can not take
advantage of multi core systems at all. Instead, we now process a date
set (what we would have done in the end in our applications) and already
start processing the next day while the current day is still not done.
We also split the operation into downloading and processing a file to
make sure we saturate an internet connection much better (if the file is
not already cached locally). When processing big files we however use
quite some memory at once, thus we introduced a new metric about how
many items we want to keep in memory at once (1 million items => 2gb).
This might limit concurrency again, but avoids running out of memory if
you have not too much of that to spare.