### PR TITLE
http: removed well-known http headers in favour of github.com/go-http…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/gin-contrib/cors v0.0.0-20190301062745-f9e10995c85a
 	github.com/gin-contrib/gzip v0.0.3
 	github.com/gin-gonic/gin v1.6.3
+	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a
 	github.com/go-playground/validator/v10 v10.2.0
 	github.com/go-redis/redis/v8 v8.8.0
 	github.com/go-resty/resty/v2 v2.6.0

--- a/go.sum
+++ b/go.sum
@@ -429,6 +429,8 @@ github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwv
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a h1:v6zMvHuY9yue4+QkG/HQ/W67wvtQmWJ4SDo9aK/GIno=
+github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a/go.mod h1:I79BieaU4fxrw4LMXby6q5OS9XnoR9UIKLOzDFjUmuw=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -8,6 +8,7 @@ import (
 	netUrl "net/url"
 	"time"
 
+	httpHeaders "github.com/go-http-utils/headers"
 	"github.com/go-resty/resty/v2"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/clock"
@@ -128,11 +129,11 @@ func (c *client) NewRequest() *Request {
 }
 
 func (c *client) NewJsonRequest() *Request {
-	return c.NewRequest().WithHeader(HdrAccept, ContentTypeApplicationJson)
+	return c.NewRequest().WithHeader(httpHeaders.Accept, MimeTypeApplicationJson)
 }
 
 func (c *client) NewXmlRequest() *Request {
-	return c.NewRequest().WithHeader(HdrAccept, ContentTypeApplicationXml)
+	return c.NewRequest().WithHeader(httpHeaders.Accept, MimeTypeApplicationXml)
 }
 
 func (c *client) SetCookie(hc *http.Cookie) {
@@ -148,7 +149,7 @@ func (c *client) SetTimeout(timeout time.Duration) {
 }
 
 func (c *client) SetUserAgent(ua string) {
-	c.defaultHeaders[HdrUserAgent] = ua
+	c.defaultHeaders[httpHeaders.UserAgent] = ua
 }
 
 func (c *client) SetProxyUrl(p string) {

--- a/pkg/http/header.go
+++ b/pkg/http/header.go
@@ -1,0 +1,16 @@
+package http
+
+const (
+	AcceptAll               = "*/*"
+	AuthorizationTypeBasic  = "Basic"
+	AuthorizationTypeBearer = "Bearer"
+	AuthorizationTypeDigest = "Digest"
+
+	ContentEncodingGzip = "gzip"
+
+	MimeTypeApplicationFormUrlencoded = "application/x-www-form-urlencoded"
+	MimeTypeApplicationJson           = "application/json"
+	MimeTypeApplicationXml            = "application/xml"
+	MimeTypeTextCsv                   = "text/csv"
+	MimeTypeTextPlain                 = "text/plain"
+)

--- a/pkg/http/request.go
+++ b/pkg/http/request.go
@@ -5,24 +5,11 @@ import (
 	"net/url"
 	"sync"
 
+	httpHeaders "github.com/go-http-utils/headers"
 	"github.com/go-resty/resty/v2"
 	"github.com/google/go-querystring/query"
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cast"
-)
-
-const (
-	HdrAccept          = "Accept"
-	HdrAcceptEncoding  = "Accept-Encoding"
-	HdrContentType     = "Content-Type"
-	HdrContentEncoding = "Content-Encoding"
-	HdrUserAgent       = "User-Agent"
-
-	ContentTypeApplicationJson           = "application/json"
-	ContentTypeApplicationXml            = "application/xml"
-	ContentTypeApplicationFormUrlencoded = "application/x-www-form-urlencoded"
-
-	ContentEncodingGzip = "gzip"
 )
 
 type Request struct {
@@ -38,7 +25,7 @@ var r struct {
 	lck      sync.Mutex
 }
 
-// use NewRequest(client) or client.NewRequest() to create a request, don't create the object inline!
+// NewRequest or client.NewRequest() creates a request, don't create the object inline!
 func NewRequest(client Client) *Request {
 	r.lck.Lock()
 	defer r.lck.Unlock()
@@ -58,16 +45,16 @@ func NewRequest(client Client) *Request {
 	return client.NewRequest()
 }
 
-// use NewJsonRequest to create a request that already contains the application/json content-type, don't create the object inline!
+// NewJsonRequest creates a request that already contains the application/json content-type, don't create the object inline!
 func NewJsonRequest(client Client) *Request {
 	return NewRequest(client).
-		WithHeader(HdrAccept, ContentTypeApplicationJson)
+		WithHeader(httpHeaders.Accept, MimeTypeApplicationJson)
 }
 
-// use NewXmlRequest to create a request that already contains the application/xml content-type, don't create the object inline!
+// NewXmlRequest creates a request that already contains the application/xml content-type, don't create the object inline!
 func NewXmlRequest(client Client) *Request {
 	return NewRequest(client).
-		WithHeader(HdrAccept, ContentTypeApplicationXml)
+		WithHeader(httpHeaders.Accept, MimeTypeApplicationXml)
 }
 
 func (r *Request) WithUrl(rawUrl string) *Request {

--- a/test/apiserver/compressed_test.go
+++ b/test/apiserver/compressed_test.go
@@ -10,6 +10,7 @@ import (
 	netHttp "net/http"
 	"testing"
 
+	httpHeaders "github.com/go-http-utils/headers"
 	"github.com/go-resty/resty/v2"
 	"github.com/justtrackio/gosoline/pkg/apiserver"
 	"github.com/justtrackio/gosoline/pkg/cfg"
@@ -66,21 +67,21 @@ func (s *CompressedTestSuite) TestCompressed() []*suite.ApiServerTestCase {
 			Method: netHttp.MethodPost,
 			Url:    route,
 			Headers: map[string]string{
-				http.HdrContentType:     http.ContentTypeApplicationJson,
-				http.HdrContentEncoding: http.ContentEncodingGzip,
-				http.HdrAcceptEncoding:  http.ContentEncodingGzip,
+				httpHeaders.ContentType:     http.MimeTypeApplicationJson,
+				httpHeaders.ContentEncoding: http.ContentEncodingGzip,
+				httpHeaders.AcceptEncoding:  http.ContentEncodingGzip,
 			},
 			Body:               buffer.Bytes(), // all routes should accept compressed requests
 			ExpectedStatusCode: netHttp.StatusOK,
 			Assert: func(res *resty.Response) error {
 				// only first route should be compressed
 				if i == 0 {
-					s.Equal([]string{http.ContentEncodingGzip}, res.Header()[http.HdrContentEncoding])
+					s.Equal([]string{http.ContentEncodingGzip}, res.Header()[httpHeaders.ContentEncoding])
 				} else {
-					s.Equal([]string(nil), res.Header()[http.HdrContentEncoding])
+					s.Equal([]string(nil), res.Header()[httpHeaders.ContentEncoding])
 				}
 
-				s.Equal([]string{apiserver.ContentTypeJson}, res.Header()[http.HdrContentType])
+				s.Equal([]string{apiserver.ContentTypeJson}, res.Header()[httpHeaders.ContentType])
 				s.Equal(expectedBody, string(res.Body()))
 
 				return nil

--- a/test/apiserver/eof_bind_test.go
+++ b/test/apiserver/eof_bind_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	httpHeaders "github.com/go-http-utils/headers"
 	"github.com/go-resty/resty/v2"
 	"github.com/justtrackio/gosoline/pkg/apiserver"
 	"github.com/justtrackio/gosoline/pkg/cfg"
@@ -80,7 +81,7 @@ func (s *EofBindTestSuite) TestEofBind() *suite.ApiServerTestCase {
 		Method: netHttp.MethodPost,
 		Url:    "/bind",
 		Headers: map[string]string{
-			http.HdrContentType: http.ContentTypeApplicationJson,
+			httpHeaders.ContentType: http.MimeTypeApplicationJson,
 		},
 		Body:               []byte{},
 		ExpectedStatusCode: netHttp.StatusBadRequest,
@@ -105,7 +106,7 @@ func (s *EofBindTestSuite) TestUnexpectedEofBind() *suite.ApiServerTestCase {
 		Method: netHttp.MethodPost,
 		Url:    "/bind",
 		Headers: map[string]string{
-			http.HdrContentType: http.ContentTypeApplicationJson,
+			httpHeaders.ContentType: http.MimeTypeApplicationJson,
 		},
 		Body:               []byte{'{'},
 		ExpectedStatusCode: netHttp.StatusBadRequest,


### PR DESCRIPTION
closes #466 