### PR TITLE
cloud/aws: replace aws default rate limiter with custom rate limiter;

### DIFF
--- a/pkg/cloud/aws/awsv2.go
+++ b/pkg/cloud/aws/awsv2.go
@@ -81,6 +81,7 @@ func DefaultClientOptions(config cfg.Config, logger log.Logger, settings ClientS
 			return retry.NewStandard(func(options *retry.StandardOptions) {
 				options.MaxAttempts = settings.Backoff.MaxAttempts
 				options.Backoff = NewBackoffDelayer(settings.Backoff.InitialInterval, settings.Backoff.MaxInterval)
+				options.RateLimiter = NewNopRateLimiter()
 			})
 		}),
 	}

--- a/pkg/cloud/aws/awsv2_rate_limiter.go
+++ b/pkg/cloud/aws/awsv2_rate_limiter.go
@@ -1,0 +1,21 @@
+package aws
+
+import "context"
+
+type NopRateLimiter struct{}
+
+func NewNopRateLimiter() NopRateLimiter {
+	return NopRateLimiter{}
+}
+
+func (n NopRateLimiter) GetToken(_ context.Context, _ uint) (releaseToken func() error, err error) {
+	return alwaysSucceed, nil
+}
+
+func (n NopRateLimiter) AddTokens(_ uint) error {
+	return nil
+}
+
+func alwaysSucceed() error {
+	return nil
+}


### PR DESCRIPTION
The AWSv2 SDK by default uses a rate limiter with capacity for 100
retries before it stops retrying. A retry needs to be paid for by 5
successful requests (so your backoff needs to be long enough and your
general traffic good enough). So if you are suddenly hitting onto a
ddb table with very limited capacity, almost all requests fail and you
exhaust the pool of retries. So requests will fail even with an infinite
retry policy. To fix this, we disable the rate limiter and only use our
backoff delayer to limit the number of requests we send to AWS.