### PR TITLE
stream, cloud: fixed some (potential) problems with overwriting a `sync.Once`;

### DIFF
--- a/pkg/cloud/aws/kinesis/reader.go
+++ b/pkg/cloud/aws/kinesis/reader.go
@@ -25,7 +25,7 @@ type reader struct {
 	settings KinsumerSettings
 	client   Kinsumer
 	handler  MessageHandler
-	doStop   sync.Once
+	doStop   *sync.Once
 	wg       sync.WaitGroup
 }
 
@@ -38,10 +38,11 @@ func NewReader(config cfg.Config, logger log.Logger, factory KinsumerFactory, ha
 	return &reader{
 		config:   config,
 		logger:   logger,
+		factory:  factory,
 		settings: settings,
 		client:   client,
 		handler:  handler,
-		factory:  factory,
+		doStop:   &sync.Once{},
 	}, nil
 }
 
@@ -120,7 +121,7 @@ func (r *reader) restartClient() error {
 	}
 
 	// allow us to stop the new client again
-	r.doStop = sync.Once{}
+	r.doStop = &sync.Once{}
 
 	if err := r.client.Run(); err != nil {
 		return fmt.Errorf("unable to restart kinesis stream input: %w", err)


### PR DESCRIPTION
How do you trigger a `fatal error: sync: unlock of unlocked mutex`? Just overwrite the mutex with a fresh one while it is locked! That is what the `InMemoryInput` was doing after all in its `Reset` call, so if something was still calling `Stop` on it and `Reset` was called at the same time, the mutex from the `sync.Once` would've been overwritten with a fresh, unlocked mutex. Thus we now changed the logic to make `Reset` thread-safe and also replaced another usage of `sync.Once` with a pointer to it (overwriting a pointer causes the thread using the old instance to unlock the old instance without being affected by the new
instance and thus avoids the problem).