### PR TITLE
stream: forward appctx container to consumer

### DIFF
--- a/pkg/appctx/container.go
+++ b/pkg/appctx/container.go
@@ -57,3 +57,13 @@ func Provide(ctx context.Context, key interface{}, factory func() (interface{}, 
 
 	return val, nil
 }
+
+func CopyContainer(from, to context.Context) (context.Context, error) {
+	var contI interface{}
+
+	if contI = from.Value(containerKey); contI == nil {
+		return nil, &ErrNoApplicationContainerFound{}
+	}
+
+	return context.WithValue(to, containerKey, contI), nil
+}

--- a/pkg/stream/consumer_batch_test.go
+++ b/pkg/stream/consumer_batch_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/justtrackio/gosoline/pkg/appctx"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/encoding/json"
 	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
@@ -113,7 +114,8 @@ func (s *BatchConsumerTestSuite) TestRun_ProcessOnStop() {
 	s.callback.On("Run", mock.AnythingOfType("*context.cancelCtx")).
 		Return(nil)
 
-	err := s.batchConsumer.Run(context.Background())
+	ctx := appctx.WithContainer(context.Background())
+	err := s.batchConsumer.Run(ctx)
 
 	s.NoError(err, "there should be no error during run")
 	s.Equal(3, processed)
@@ -166,7 +168,8 @@ func (s *BatchConsumerTestSuite) TestRun_BatchSizeReached() {
 	s.callback.On("Run", mock.AnythingOfType("*context.cancelCtx")).
 		Return(nil)
 
-	err := s.batchConsumer.Run(context.Background())
+	ctx := appctx.WithContainer(context.Background())
+	err := s.batchConsumer.Run(ctx)
 
 	s.NoError(err, "there should be no error during run")
 	s.Equal(5, processed)
@@ -177,7 +180,8 @@ func (s *BatchConsumerTestSuite) TestRun_BatchSizeReached() {
 }
 
 func (s *BatchConsumerTestSuite) TestRun_ContextCanceled() {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := appctx.WithContainer(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	stopped := make(chan struct{})
 	once := sync.Once{}
 
@@ -235,7 +239,8 @@ func (s *BatchConsumerTestSuite) TestRun_InputRunError() {
 			<-args[0].(context.Context).Done()
 		}).Return(nil)
 
-	err := s.batchConsumer.Run(context.Background())
+	ctx := appctx.WithContainer(context.Background())
+	err := s.batchConsumer.Run(ctx)
 
 	s.EqualError(err, "error while waiting for all routines to stop: panic during run of the consumer input: read error")
 
@@ -259,7 +264,8 @@ func (s *BatchConsumerTestSuite) TestRun_CallbackRunError() {
 	s.callback.On("Run", mock.AnythingOfType("*context.cancelCtx")).
 		Return(fmt.Errorf("consumerCallback run error"))
 
-	err := s.batchConsumer.Run(context.Background())
+	ctx := appctx.WithContainer(context.Background())
+	err := s.batchConsumer.Run(ctx)
 
 	s.EqualError(err, "error while waiting for all routines to stop: panic during run of the consumerCallback: consumerCallback run error")
 
@@ -318,7 +324,8 @@ func (s *BatchConsumerTestSuite) TestRun_AggregateMessage() {
 		Return(mdl.String("")).
 		Twice()
 
-	err = s.batchConsumer.Run(context.Background())
+	ctx := appctx.WithContainer(context.Background())
+	err = s.batchConsumer.Run(ctx)
 
 	s.Nil(err, "there should be no error returned on consume")
 	s.Equal(processed, 2)

--- a/pkg/stream/consumer_test.go
+++ b/pkg/stream/consumer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/justtrackio/gosoline/pkg/appctx"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/encoding/json"
 	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
@@ -74,7 +75,8 @@ func (s *ConsumerTestSuite) TestGetModelNil() {
 	})
 	s.callback.On("Run", mock.AnythingOfType("*context.cancelCtx")).Return(nil)
 
-	err := s.consumer.Run(context.Background())
+	ctx := appctx.WithContainer(context.Background())
+	err := s.consumer.Run(ctx)
 
 	s.NoError(err, "there should be no error during run")
 	s.input.AssertExpectations(s.T())
@@ -104,7 +106,8 @@ func (s *ConsumerTestSuite) TestRun() {
 
 	s.callback.On("Run", mock.AnythingOfType("*context.cancelCtx")).Return(nil)
 
-	err := s.consumer.Run(context.Background())
+	ctx := appctx.WithContainer(context.Background())
+	err := s.consumer.Run(ctx)
 
 	s.NoError(err, "there should be no error during run")
 	s.Len(consumed, 3)
@@ -114,7 +117,8 @@ func (s *ConsumerTestSuite) TestRun() {
 }
 
 func (s *ConsumerTestSuite) TestRun_ContextCancel() {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := appctx.WithContainer(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	stopped := make(chan struct{})
 	once := sync.Once{}
 
@@ -161,7 +165,8 @@ func (s *ConsumerTestSuite) TestRun_InputRunError() {
 			<-args[0].(context.Context).Done()
 		}).Return(nil)
 
-	err := s.consumer.Run(context.Background())
+	ctx := appctx.WithContainer(context.Background())
+	err := s.consumer.Run(ctx)
 
 	s.EqualError(err, "error while waiting for all routines to stop: panic during run of the consumer input: read error")
 
@@ -184,7 +189,8 @@ func (s *ConsumerTestSuite) TestRun_CallbackRunError() {
 	s.callback.On("Run", mock.AnythingOfType("*context.cancelCtx")).
 		Return(fmt.Errorf("consumerCallback run error"))
 
-	err := s.consumer.Run(context.Background())
+	ctx := appctx.WithContainer(context.Background())
+	err := s.consumer.Run(ctx)
 
 	s.EqualError(err, "error while waiting for all routines to stop: panic during run of the consumerCallback: consumerCallback run error")
 
@@ -229,7 +235,8 @@ func (s *ConsumerTestSuite) TestRun_CallbackRunPanic() {
 			return mdl.String("")
 		})
 
-	err := s.consumer.Run(context.Background())
+	ctx := appctx.WithContainer(context.Background())
+	err := s.consumer.Run(ctx)
 
 	s.Nil(err, "there should be no error returned on consume")
 	s.Len(consumed, 2)
@@ -291,7 +298,8 @@ func (s *ConsumerTestSuite) TestRun_AggregateMessage() {
 	s.callback.On("GetModel", expectedModelAttributes2).
 		Return(mdl.String(""))
 
-	err = s.consumer.Run(context.Background())
+	ctx := appctx.WithContainer(context.Background())
+	err = s.consumer.Run(ctx)
 
 	s.Nil(err, "there should be no error returned on consume")
 	s.Len(consumed, 2)


### PR DESCRIPTION
Add a copyContainer function to copy a container from one context to an other

fix the stream consumer to work with the appctx