### PR TITLE
config: check api_port only in config file

### DIFF
--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -47,10 +47,6 @@ type ApiServer struct {
 
 func New(definer Definer) kernel.ModuleFactory {
 	return func(ctx context.Context, config cfg.Config, logger log.Logger) (kernel.Module, error) {
-		if config.IsSet("api_port") || config.IsSet("api_mode") || config.IsSet("api_timeout_read") || config.IsSet("api_timeout_write") || config.IsSet("api_timeout_idle") {
-			return nil, fmt.Errorf("old config format detected. You have to change your config from api_port to api.port, api_mode to api.mode, and so on")
-		}
-
 		logger = logger.WithChannel("api")
 
 		settings := &Settings{}


### PR DESCRIPTION
We need this fix to override the api port with an env variable in a dockerfile