### PR TITLE
log: don't use the error message we constructed as a format string;

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -132,7 +132,7 @@ func (l *gosoLogger) Error(format string, args ...interface{}) {
 	err := fmt.Errorf(format, args...)
 	msg := err.Error()
 
-	l.log(PriorityError, msg, []interface{}{}, err)
+	l.log(PriorityError, "%s", []interface{}{msg}, err)
 }
 
 func (l *gosoLogger) WithChannel(channel string) Logger {


### PR DESCRIPTION
If you take some arbitrary message and use it as a format string, you destroy the parts which randomly contain percent signs (url encoded data for example). Thus, we need to supply a format string (just %s) on our own to avoid this problem and get the message as we pass it in.