### PR TITLE
kernel: return an appropriate exit code on leaving the kernel;

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+embedmd: #go install github.com/campoy/embedmd@latest
+	embedmd -w $$(find . | grep "\.md")

--- a/docs/getting_started/kernel.md
+++ b/docs/getting_started/kernel.md
@@ -181,16 +181,16 @@ type Option func(k *kernel) error
 
 Two useful predefined options are:
 
-[embedmd]:# (../../pkg/kernel/kernel_options.go /func KillTimeout/ /{/)
+[embedmd]:# (../../pkg/kernel/kernel_options.go /func WithKillTimeout/ /{/)
 ```go
-func KillTimeout(killTimeout time.Duration) Option {
+func WithKillTimeout(killTimeout time.Duration) Option {
 ```
 
 - configures how long a kernel will continue to run, after it has decided to stop (because it has received an interrupt signal, or all its foreground modules have finished, etc.).
 
-[embedmd]:# (../../pkg/kernel/kernel_options.go /func ForceExit/ /{/)
+[embedmd]:# (../../pkg/kernel/kernel_options.go /func WithExitHandler/ /{/)
 ```go
-func ForceExit(forceExit func(code int)) Option {
+func WithExitHandler(handler func(code int)) Option {
 ```
 
 - meant to be used in tests, it configures extra functionality to be run in case the kernel has a forced exit.

--- a/pkg/application/app_test.go
+++ b/pkg/application/app_test.go
@@ -39,7 +39,9 @@ func TestDefaultConfigParser(t *testing.T) {
 	assert.NoError(t, err)
 
 	runTestApp(t, func() {
-		app := application.Default()
+		exitCodeHandler := application.WithKernelExitHandler(func(code int) {})
+
+		app := application.Default(exitCodeHandler)
 		app.Add("test", func(ctx context.Context, config cfg.Config, logger log.Logger) (kernel.Module, error) {
 			return testModule{
 				t: t,

--- a/pkg/application/options.go
+++ b/pkg/application/options.go
@@ -157,12 +157,20 @@ func WithFixtures(fixtureSets []*fixtures.FixtureSet) Option {
 	}
 }
 
+func WithKernelExitHandler(handler kernelPkg.ExitHandler) Option {
+	return func(app *App) {
+		app.addKernelOption(func(config cfg.GosoConf, kernel kernelPkg.GosoKernel) error {
+			return kernel.Option(kernelPkg.WithExitHandler(handler))
+		})
+	}
+}
+
 func WithKernelSettingsFromConfig(app *App) {
 	app.addKernelOption(func(config cfg.GosoConf, k kernelPkg.GosoKernel) error {
 		settings := &kernelSettings{}
 		config.UnmarshalKey("kernel", settings)
 
-		return k.Option(kernelPkg.KillTimeout(settings.KillTimeout))
+		return k.Option(kernelPkg.WithKillTimeout(settings.KillTimeout))
 	})
 }
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -35,7 +35,7 @@ func Run(module kernel.ModuleFactory, otherModuleMaps ...map[string]kernel.Modul
 
 	ctx := appctx.WithContainer(context.Background())
 
-	k, err := kernel.New(ctx, config, logger, kernel.KillTimeout(settings.KillTimeout))
+	k, err := kernel.New(ctx, config, logger, kernel.WithKillTimeout(settings.KillTimeout))
 	if err != nil {
 		defaultErrorHandler("can not initialize the kernel: %w", err)
 	}

--- a/pkg/kernel/kernel_options.go
+++ b/pkg/kernel/kernel_options.go
@@ -2,7 +2,7 @@ package kernel
 
 import "time"
 
-func KillTimeout(killTimeout time.Duration) Option {
+func WithKillTimeout(killTimeout time.Duration) Option {
 	return func(k *kernel) error {
 		k.killTimeout = killTimeout
 
@@ -10,9 +10,9 @@ func KillTimeout(killTimeout time.Duration) Option {
 	}
 }
 
-func ForceExit(forceExit func(code int)) Option {
+func WithExitHandler(handler func(code int)) Option {
 	return func(k *kernel) error {
-		k.forceExit = forceExit
+		k.exitHandler = handler
 
 		return nil
 	}

--- a/pkg/kernel/middleware_test.go
+++ b/pkg/kernel/middleware_test.go
@@ -15,7 +15,7 @@ import (
 func TestMiddleware(t *testing.T) {
 	config, logger, module := createMocks()
 
-	k, err := kernel.New(context.Background(), config, logger, kernel.KillTimeout(time.Second))
+	k, err := kernel.New(context.Background(), config, logger, kernel.WithKillTimeout(time.Second), mockExitHandler(t, kernel.ExitCodeOk))
 	assert.NoError(t, err)
 
 	callstack := make([]string, 0)

--- a/pkg/kernel/stage.go
+++ b/pkg/kernel/stage.go
@@ -14,6 +14,7 @@ var ErrKernelStopping = fmt.Errorf("stopping kernel")
 type stage struct {
 	cfn coffin.Coffin
 	ctx context.Context
+	err error
 
 	running    conc.SignalOnce
 	terminated conc.SignalOnce
@@ -68,10 +69,10 @@ func (s *stage) run(k *kernel) {
 
 func (s *stage) stopWait(stageIndex int, logger log.Logger) {
 	s.cfn.Kill(ErrKernelStopping)
-	err := s.cfn.Wait()
+	s.err = s.cfn.Wait()
 
-	if err != nil && err != ErrKernelStopping {
-		logger.Error("error during the execution of stage %d: %w", stageIndex, err)
+	if s.err != nil && s.err != ErrKernelStopping {
+		logger.Error("error during the execution of stage %d: %w", stageIndex, s.err)
 	}
 
 	s.terminated.Signal()

--- a/pkg/log/status/module_test.go
+++ b/pkg/log/status/module_test.go
@@ -115,7 +115,9 @@ func (m *testModule) WorkWithContext(ctx context.Context) error {
 }
 
 func TestModuleExample(t *testing.T) {
-	app := application.New()
+	exitCodeHandler := application.WithKernelExitHandler(func(code int) {})
+
+	app := application.New(exitCodeHandler)
 	app.Add("status", status.NewModule(status.ProvideManager()))
 	app.Add("main", NewTestModule)
 	app.Run()

--- a/pkg/test/application.go
+++ b/pkg/test/application.go
@@ -8,6 +8,7 @@ import (
 func Application() kernel.Kernel {
 	options := []application.Option{
 		application.WithConfigFile("./config.dist.yml", "yml"),
+		application.WithKernelExitHandler(func(code int) {}),
 	}
 
 	return application.New(options...)

--- a/pkg/test/suite/testcase_application.go
+++ b/pkg/test/suite/testcase_application.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/justtrackio/gosoline/pkg/application"
+	"github.com/justtrackio/gosoline/pkg/kernel"
 	"github.com/justtrackio/gosoline/pkg/test/env"
 	"github.com/stretchr/testify/assert"
 )
@@ -43,9 +44,12 @@ func buildTestCaseApplication(suite TestingSuite, method reflect.Method) (testCa
 
 func runTestCaseApplication(t *testing.T, suite TestingSuite, suiteOptions *suiteOptions, environment *env.Environment, testcase func(aut *appUnderTest)) {
 	appOptions := append(suiteOptions.appOptions, []application.Option{
-		application.WithProducerDaemon,
 		application.WithConfigMap(map[string]interface{}{
 			"env": "test",
+		}),
+		application.WithProducerDaemon,
+		application.WithKernelExitHandler(func(code int) {
+			assert.Equal(t, kernel.ExitCodeOk, code, "exit code should be %d", kernel.ExitCodeOk)
 		}),
 	}...)
 

--- a/test/guard/guard_test.go
+++ b/test/guard/guard_test.go
@@ -38,7 +38,7 @@ func (s *GuardTestSuite) SetupTest() error {
 	return nil
 }
 
-func (s *GuardTestSuite) TestCrud(app suite.AppUnderTest) {
+func (s *GuardTestSuite) TestCrud() {
 	pol := ladon.DefaultPolicy{
 		ID:          "1",
 		Description: "allow all",
@@ -64,7 +64,7 @@ func (s *GuardTestSuite) TestCrud(app suite.AppUnderTest) {
 	s.NoError(err)
 }
 
-func (s *GuardTestSuite) TestGetPolicies(app suite.AppUnderTest) {
+func (s *GuardTestSuite) TestGetPolicies() {
 	policies, err := s.guard.GetPolicies()
 	if !s.NoError(err) {
 		return
@@ -80,7 +80,7 @@ func (s *GuardTestSuite) TestGetPolicies(app suite.AppUnderTest) {
 	s.Len(policies, 1)
 }
 
-func (s *GuardTestSuite) TestIsAllowed(app suite.AppUnderTest) {
+func (s *GuardTestSuite) TestIsAllowed() {
 	req := ladon.Request{
 		Resource: "gsl:e1",
 		Action:   "read",

--- a/test/stream/producer_daemon_test.go
+++ b/test/stream/producer_daemon_test.go
@@ -120,7 +120,9 @@ func (s *ProducerDaemonTestSuite) TestWriteData() {
 		t: s.T(),
 	}
 
-	app := application.Default(application.WithLoggerHandlers(handler))
+	app := application.Default(application.WithLoggerHandlers(handler), application.WithKernelExitHandler(func(code int) {
+		assert.Equal(s.T(), kernel.ExitCodeOk, code, "exit code should be %d", kernel.ExitCodeOk)
+	}))
 	app.Add("testModule", newTestModule)
 	app.Add("testCompressionModule", newTestCompressionModule)
 	app.Add("testFifoModule", newTestFifoModule(s.T()))


### PR DESCRIPTION
Before this release, the kernel run function was just returning to the golang main function, which resulted in an exit code of 0 in normal cases. An exception was the forced stop which exited with code 1.

With this release, the kernel always exits with an appropriate exit code:  
- Code 0 on successful runs  
- Code 1 on errors during module boot or run
- Code 10 if there are no modules to run
- Code 11 if there are no foreground modules
- Code 12 if the kernel is forced to stop due to the kill timeout
