### PR TITLE
fixed blob store double slash bug

### DIFF
--- a/pkg/blob/store.go
+++ b/pkg/blob/store.go
@@ -307,8 +307,14 @@ func (o *CopyObject) GetFullKey() string {
 	return getFullKey(o.prefix, o.Key)
 }
 
-func getFullKey(prefix, key *string) string {
-	fullKey := fmt.Sprintf("%s/%s", mdl.EmptyStringIfNil(prefix), mdl.EmptyStringIfNil(key))
+func getFullKey(prefixPtr, keyPtr *string) string {
+	key := mdl.EmptyStringIfNil(keyPtr)
+	key = strings.TrimLeft(key, "/")
+
+	prefix := mdl.EmptyStringIfNil(prefixPtr)
+	prefix = strings.TrimRight(prefix, "/")
+
+	fullKey := fmt.Sprintf("%s/%s", prefix, key)
 	fullKey = strings.TrimLeft(fullKey, "/")
 	return fullKey
 }


### PR DESCRIPTION
This aims to solve a problem I encountered when using the BlobStoreFixtureWriter. It works along the lines of:

the `BlobFixtureWriter` calles `filepath.Abs` on the given filepath. This always returns something like `/path/to/file` which is written into `basePath`. The writer then builds the object key of the S3 fixture using `strings.Replace(file, s.basePath, "", 1)`, which returns a key that looks like `/file`. When it is then tried to build the final S3 path this code is used: `fmt.Sprintf("%s/%s", mdl.EmptyStringIfNil(prefix), mdl.EmptyStringIfNil(key))`, which returns a invalid S3 path the likes of `s3prefix//file`.
