### PR TITLE
cloud/aws/kinesis: do not consider finished shards or shards with an unfinished parent shard for reading;

### DIFF
--- a/pkg/cloud/aws/kinesis/mocks/MetadataRepository.go
+++ b/pkg/cloud/aws/kinesis/mocks/MetadataRepository.go
@@ -51,6 +51,27 @@ func (_m *MetadataRepository) DeregisterClient(ctx context.Context) error {
 	return r0
 }
 
+// IsShardFinished provides a mock function with given fields: ctx, shardId
+func (_m *MetadataRepository) IsShardFinished(ctx context.Context, shardId kinesis.ShardId) (bool, error) {
+	ret := _m.Called(ctx, shardId)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, kinesis.ShardId) bool); ok {
+		r0 = rf(ctx, shardId)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, kinesis.ShardId) error); ok {
+		r1 = rf(ctx, shardId)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // RegisterClient provides a mock function with given fields: ctx
 func (_m *MetadataRepository) RegisterClient(ctx context.Context) (int, int, error) {
 	ret := _m.Called(ctx)


### PR DESCRIPTION
If you change the number of shards in kinesis, you either split or combine shards. Thus, for a limited amount of time, you might have a different number of shards than you expect (e.g., when changing from 4 to 8 shards, there are 12 shards for some time, the old 4 shards and the new 8 shards). We will now ignore the 4 shards you already finished (if you are not behind on the stream) or any of the 8 new shards which have still unfinished parent shards in the set of the old 4 shards when assigning shards to clients. This also ensures you don't read data from a child shard before completing the parent shard (which would violate processing data with the same partition key in-order).