### PR TITLE
mdlsub: added kinesis handler for publisher

### DIFF
--- a/pkg/db-repo/notification_sns.go
+++ b/pkg/db-repo/notification_sns.go
@@ -11,14 +11,17 @@ import (
 )
 
 func NewSnsNotifier(ctx context.Context, config cfg.Config, logger log.Logger, modelId mdl.ModelId, version int, transformer mdl.TransformerResolver) (*baseNotifier, error) {
+	appId := cfg.AppId{
+		Project:     modelId.Project,
+		Environment: modelId.Environment,
+		Family:      modelId.Family,
+		Application: modelId.Application,
+	}
+	appId.PadFromConfig(config)
+
 	output, err := stream.NewSnsOutput(ctx, config, logger, &stream.SnsOutputSettings{
 		TopicId: modelId.Name,
-		AppId: cfg.AppId{
-			Project:     modelId.Project,
-			Environment: modelId.Environment,
-			Family:      modelId.Family,
-			Application: modelId.Application,
-		},
+		AppId:   appId,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("can not create sns output: %w", err)

--- a/pkg/stream/output_configurable.go
+++ b/pkg/stream/output_configurable.go
@@ -65,17 +65,22 @@ func newFileOutputFromConfig(_ context.Context, config cfg.Config, logger log.Lo
 	return NewFileOutput(config, logger, settings), nil
 }
 
+type InMemoryOutputConfiguration struct {
+	Type string `cfg:"type" default:"inMemory"`
+}
+
 func newInMemoryOutputFromConfig(_ context.Context, _ cfg.Config, _ log.Logger, name string) (Output, error) {
 	return ProvideInMemoryOutput(name), nil
 }
 
-type kinesisOutputConfiguration struct {
+type KinesisOutputConfiguration struct {
+	Type       string `cfg:"type" default:"kinesis"`
 	StreamName string `cfg:"stream_name"`
 }
 
 func newKinesisOutputFromConfig(ctx context.Context, config cfg.Config, logger log.Logger, name string) (Output, error) {
 	key := ConfigurableOutputKey(name)
-	settings := &kinesisOutputConfiguration{}
+	settings := &KinesisOutputConfiguration{}
 	config.UnmarshalKey(key, settings)
 
 	return NewKinesisOutput(ctx, config, logger, &KinesisOutputSettings{
@@ -112,7 +117,7 @@ func newRedisListOutputFromConfig(_ context.Context, config cfg.Config, logger l
 
 type SnsOutputConfiguration struct {
 	BaseOutputSettings
-	Type        string `cfg:"type"`
+	Type        string `cfg:"type" default:"sns"`
 	Project     string `cfg:"project"`
 	Family      string `cfg:"family"`
 	Application string `cfg:"application"`
@@ -141,8 +146,9 @@ func newSnsOutputFromConfig(ctx context.Context, config cfg.Config, logger log.L
 	})
 }
 
-type sqsOutputConfiguration struct {
+type SqsOutputConfiguration struct {
 	BaseOutputSettings
+	Type              string            `cfg:"type" default:"sqs"`
 	Project           string            `cfg:"project"`
 	Family            string            `cfg:"family"`
 	Application       string            `cfg:"application"`
@@ -155,7 +161,7 @@ type sqsOutputConfiguration struct {
 
 func newSqsOutputFromConfig(ctx context.Context, config cfg.Config, logger log.Logger, name string) (Output, error) {
 	key := ConfigurableOutputKey(name)
-	configuration := sqsOutputConfiguration{}
+	configuration := SqsOutputConfiguration{}
 	config.UnmarshalKey(key, &configuration)
 
 	clientName := configuration.ClientName

--- a/pkg/stream/producer.go
+++ b/pkg/stream/producer.go
@@ -4,10 +4,18 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/justtrackio/gosoline/pkg/appctx"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/justtrackio/gosoline/pkg/refl"
 )
+
+const MetadataKeyProducers = "stream.producers"
+
+type ProducerMetadata struct {
+	Name          string `json:"name"`
+	DaemonEnabled bool   `json:"daemon_enabled"`
+}
 
 type ProducerSettings struct {
 	Output      string                 `cfg:"output"`
@@ -53,6 +61,14 @@ func NewProducer(ctx context.Context, config cfg.Config, logger log.Logger, name
 		Compression:    settings.Compression,
 		EncodeHandlers: encodeHandlers,
 	})
+
+	metadata := ProducerMetadata{
+		Name:          name,
+		DaemonEnabled: settings.Daemon.Enabled,
+	}
+	if err = appctx.MetadataAppend(ctx, MetadataKeyProducers, metadata); err != nil {
+		return nil, fmt.Errorf("can not access the appctx metadata: %w", err)
+	}
 
 	return NewProducerWithInterfaces(encoder, output), nil
 }


### PR DESCRIPTION
The publisher is able to handle the kinesis output now.
You can configure a kinesis publisher like this:  
```yaml
mdlsub:
  publishers:    
    todoItem: { output_type: kinesis, application: my-todo-app }
```
which will result in the following producer and output configuration:
```json
{
  "stream": {
    "producer": {
      "publisher-todoItem": {
        "compression": "none",
        "daemon": {
          "aggregation_max_size": 950000,
          "aggregation_size": 1,
          "batch_max_size": 4500000,
          "batch_size": 500,
          "buffer_size": 10,
          "enabled": true,
          "interval": 1000000000,
          "message_attributes": {
            "modelId": "project.family.my-todo-app.todoItem"
          },
          "runner_count": 10
        },
        "encoding": "",
        "output": "publisher-todoItem"
      }
    },
    "output": {
      "publisher-todoItem": {
        "stream_name": "project-env-family-my-todo-app-todoItem",
        "type": "kinesis"
      }
    }
  }
}
```