### PR TITLE
ddb: fix transaction repo not returning old value if return all old is specified 

### DIFF
--- a/pkg/cloud/aws/dynamodb/error_test.go
+++ b/pkg/cloud/aws/dynamodb/error_test.go
@@ -34,7 +34,7 @@ func TestTransformTransactionError(t *testing.T) {
 
 	transformed := dynamodb.TransformTransactionError(err)
 
-	assert.True(t, errors.Is(transformed, dynamodb.ConditionalCheckFailedError))
+	assert.True(t, errors.As(transformed, &dynamodb.ConditionalCheckFailedError{}))
 	assert.True(t, errors.Is(transformed, dynamodb.TransactionConflictError))
 }
 


### PR DESCRIPTION
The current implementation of the ddb transaction repository can be given an item builder which specifies the `ReturnAllOld` builder option, which should lead to the repo returning the old value if an operation fails (i.e. if some condition check failed for a PutItem). The current implementation swallows this old value while converting the returned error to the hashicorp.Multierror.