### PR TITLE
cloud/aws/kinesis: use the application id from the app itself, not the stream we are reading

### DIFF
--- a/pkg/cloud/aws/kinesis/metadata_repository.go
+++ b/pkg/cloud/aws/kinesis/metadata_repository.go
@@ -139,10 +139,15 @@ func NewMetadataRepository(ctx context.Context, config cfg.Config, logger log.Lo
 		return nil, fmt.Errorf("can not create ddb repository: %w", err)
 	}
 
-	return NewMetadataRepositoryWithInterfaces(logger, stream, clientId, repo, settings, clock.Provider), nil
+	// we need the app id from the application we are running at, not the app id from the settings as this is the same
+	// for different kinsumers of the same stream!
+	appId := cfg.AppId{}
+	appId.PadFromConfig(config)
+
+	return NewMetadataRepositoryWithInterfaces(logger, stream, clientId, repo, settings, appId, clock.Provider), nil
 }
 
-func NewMetadataRepositoryWithInterfaces(logger log.Logger, stream Stream, clientId ClientId, repo ddb.Repository, settings Settings, clock clock.Clock) MetadataRepository {
+func NewMetadataRepositoryWithInterfaces(logger log.Logger, stream Stream, clientId ClientId, repo ddb.Repository, settings Settings, appId cfg.AppId, clock clock.Clock) MetadataRepository {
 	clientTimeout := settings.DiscoverFrequency * 5
 	if clientTimeout < time.Minute {
 		clientTimeout = time.Minute
@@ -158,7 +163,7 @@ func NewMetadataRepositoryWithInterfaces(logger log.Logger, stream Stream, clien
 		stream:            stream,
 		clientId:          clientId,
 		repo:              repo,
-		appId:             settings.AppId,
+		appId:             appId,
 		clientTimeout:     clientTimeout,
 		checkpointTimeout: checkpointTimeout,
 		clock:             clock,

--- a/pkg/cloud/aws/kinesis/metadata_repository_test.go
+++ b/pkg/cloud/aws/kinesis/metadata_repository_test.go
@@ -31,6 +31,7 @@ type metadataRepositoryTestSuite struct {
 	checkpointNamespace string
 	repo                *ddbMocks.Repository
 	settings            kinesis.Settings
+	appId               cfg.AppId
 	clock               clock.FakeClock
 	metadataRepository  kinesis.MetadataRepository
 }
@@ -49,18 +50,18 @@ func (s *metadataRepositoryTestSuite) SetupTest() {
 	s.checkpointNamespace = string("checkpoint:gosoline-test-metadata-repository-test-suite:" + s.stream)
 	s.repo = new(ddbMocks.Repository)
 	s.settings = kinesis.Settings{
-		AppId: cfg.AppId{
-			Project:     "gosoline",
-			Environment: "test",
-			Family:      "metadata-repository",
-			Application: "test-suite",
-		},
 		DiscoverFrequency: time.Minute * 10,
 		PersistFrequency:  time.Second * 10,
 	}
+	s.appId = cfg.AppId{
+		Project:     "gosoline",
+		Environment: "test",
+		Family:      "metadata-repository",
+		Application: "test-suite",
+	}
 	s.clock = clock.NewFakeClock()
 
-	s.metadataRepository = kinesis.NewMetadataRepositoryWithInterfaces(s.logger, s.stream, s.clientId, s.repo, s.settings, s.clock)
+	s.metadataRepository = kinesis.NewMetadataRepositoryWithInterfaces(s.logger, s.stream, s.clientId, s.repo, s.settings, s.appId, s.clock)
 }
 
 func (s *metadataRepositoryTestSuite) TearDownTest() {


### PR DESCRIPTION
When we create the namespace for the kinsumer state, we used the application name of the stream instead of the consuming application. This caused different consumers of the same stream to share a state and only consume a portion of the events (if at all). Instead, we are now using the application id of the consumer, ensuring the states are kept separate.