### PR TITLE
cloud/aws: fix context.Canceled error for larger S3 downloads;

### DIFF
--- a/pkg/cloud/aws/kinesis/kinsumer.go
+++ b/pkg/cloud/aws/kinesis/kinsumer.go
@@ -158,8 +158,8 @@ func NewKinsumerWithInterfaces(logger log.Logger, settings Settings, stream Stre
 }
 
 func (k *kinsumer) Run(ctx context.Context, handler MessageHandler) (finalErr error) {
-	deregisterCtx := exec.WithDelayedCancelContext(ctx, k.settings.ReleaseDelay)
-	defer deregisterCtx.Stop()
+	deregisterCtx, stop := exec.WithDelayedCancelContext(ctx, k.settings.ReleaseDelay)
+	defer stop()
 
 	logger := k.logger.WithContext(ctx)
 

--- a/pkg/cloud/aws/kinesis/kinsumer_test.go
+++ b/pkg/cloud/aws/kinesis/kinsumer_test.go
@@ -145,7 +145,7 @@ func (s *kinsumerTestSuite) TearDownTest() {
 
 func (s *kinsumerTestSuite) TestRegisterClientFail() {
 	s.metadataRepository.On("RegisterClient", s.ctx).Return(0, 0, fmt.Errorf("fail")).Once()
-	s.metadataRepository.On("DeregisterClient", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(nil).Once()
+	s.metadataRepository.On("DeregisterClient", mock.AnythingOfType("*exec.stoppableContext")).Return(nil).Once()
 
 	err := s.kinsumer.Run(s.ctx, s.handler)
 	s.EqualError(err, "failed to load first list of shard ids and register as client: failed to register as client: fail")
@@ -153,7 +153,7 @@ func (s *kinsumerTestSuite) TestRegisterClientFail() {
 
 func (s *kinsumerTestSuite) TestRegisterClientDeregisterFailToo() {
 	s.metadataRepository.On("RegisterClient", s.ctx).Return(0, 0, fmt.Errorf("fail")).Once()
-	s.metadataRepository.On("DeregisterClient", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(fmt.Errorf("also fail")).Once()
+	s.metadataRepository.On("DeregisterClient", mock.AnythingOfType("*exec.stoppableContext")).Return(fmt.Errorf("also fail")).Once()
 
 	err := s.kinsumer.Run(s.ctx, s.handler)
 	s.EqualError(err, multierror.Append(
@@ -164,7 +164,7 @@ func (s *kinsumerTestSuite) TestRegisterClientDeregisterFailToo() {
 
 func (s *kinsumerTestSuite) TestInitialListShardsFail() {
 	s.metadataRepository.On("RegisterClient", s.ctx).Return(0, 1, nil).Once()
-	s.metadataRepository.On("DeregisterClient", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(nil).Once()
+	s.metadataRepository.On("DeregisterClient", mock.AnythingOfType("*exec.stoppableContext")).Return(nil).Once()
 
 	s.logger.On("Info", "we are client %d / %d, refreshing %d shards", 1, 1, 0).Once()
 
@@ -178,7 +178,7 @@ func (s *kinsumerTestSuite) TestInitialListShardsFail() {
 
 func (s *kinsumerTestSuite) TestInitialListShardsNoSuchStream() {
 	s.metadataRepository.On("RegisterClient", s.ctx).Return(0, 1, nil).Once()
-	s.metadataRepository.On("DeregisterClient", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(nil).Once()
+	s.metadataRepository.On("DeregisterClient", mock.AnythingOfType("*exec.stoppableContext")).Return(nil).Once()
 
 	s.logger.On("Info", "we are client %d / %d, refreshing %d shards", 1, 1, 0).Once()
 
@@ -196,7 +196,7 @@ func (s *kinsumerTestSuite) TestInitialListShardsNoSuchStream() {
 
 func (s *kinsumerTestSuite) TestInitialListShardsResourceInUse() {
 	s.metadataRepository.On("RegisterClient", s.ctx).Return(0, 1, nil).Once()
-	s.metadataRepository.On("DeregisterClient", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(nil).Once()
+	s.metadataRepository.On("DeregisterClient", mock.AnythingOfType("*exec.stoppableContext")).Return(nil).Once()
 
 	s.logger.On("Info", "we are client %d / %d, refreshing %d shards", 1, 1, 0).Once()
 
@@ -214,7 +214,7 @@ func (s *kinsumerTestSuite) TestInitialListShardsResourceInUse() {
 
 func (s *kinsumerTestSuite) TestInitialListShardsIterate() {
 	s.metadataRepository.On("RegisterClient", s.ctx).Return(0, 1, nil).Once()
-	s.metadataRepository.On("DeregisterClient", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(nil).Once()
+	s.metadataRepository.On("DeregisterClient", mock.AnythingOfType("*exec.stoppableContext")).Return(nil).Once()
 
 	s.logger.On("Info", "we are client %d / %d, refreshing %d shards", 1, 1, 0).Once()
 
@@ -303,7 +303,7 @@ func (s *kinsumerTestSuite) TestListShardsChangedShardIds() {
 
 func (s *kinsumerTestSuite) TestShardListFinishedShardHandling() {
 	s.metadataRepository.On("RegisterClient", s.ctx).Return(0, 1, nil).Once()
-	s.metadataRepository.On("DeregisterClient", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(nil).Once()
+	s.metadataRepository.On("DeregisterClient", mock.AnythingOfType("*exec.stoppableContext")).Return(nil).Once()
 
 	s.logger.On("Info", "we are client %d / %d, refreshing %d shards", 1, 1, 0).Once()
 
@@ -463,7 +463,7 @@ func (s *kinsumerTestSuite) TestConsumeMessagesFails() {
 
 func (s *kinsumerTestSuite) mockBaseSuccess(shards ...string) {
 	s.metadataRepository.On("RegisterClient", s.ctx).Return(0, 1, nil).Once()
-	s.metadataRepository.On("DeregisterClient", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(nil).Once()
+	s.metadataRepository.On("DeregisterClient", mock.AnythingOfType("*exec.stoppableContext")).Return(nil).Once()
 
 	s.logger.On("Info", "we are client %d / %d, refreshing %d shards", 1, 1, 0).Once()
 

--- a/pkg/cloud/aws/kinesis/shard_reader.go
+++ b/pkg/cloud/aws/kinesis/shard_reader.go
@@ -81,8 +81,8 @@ func (s *shardReader) Run(ctx context.Context, handler func(record []byte) error
 	s.logger.Info("acquired shard")
 	defer s.logger.Info("releasing shard")
 
-	releaseCtx := exec.WithDelayedCancelContext(ctx, s.settings.ReleaseDelay)
-	defer releaseCtx.Stop()
+	releaseCtx, stop := exec.WithDelayedCancelContext(ctx, s.settings.ReleaseDelay)
+	defer stop()
 
 	defer func() {
 		if err := s.releaseCheckpoint(releaseCtx); err != nil {

--- a/pkg/cloud/aws/kinesis/shard_reader_test.go
+++ b/pkg/cloud/aws/kinesis/shard_reader_test.go
@@ -102,8 +102,8 @@ func (s *shardReaderTestSuite) TestGetShardIteratorFails() {
 	s.setupReader()
 
 	checkpoint := new(mocks.Checkpoint)
-	checkpoint.On("Persist", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(true, nil).Once()
-	checkpoint.On("Release", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(nil).Once()
+	checkpoint.On("Persist", mock.AnythingOfType("*exec.stoppableContext")).Return(true, nil).Once()
+	checkpoint.On("Release", mock.AnythingOfType("*exec.stoppableContext")).Return(nil).Once()
 	checkpoint.On("GetSequenceNumber").Return(gosoKinesis.SequenceNumber("sequence number")).Once()
 	defer checkpoint.AssertExpectations(s.T())
 
@@ -125,8 +125,8 @@ func (s *shardReaderTestSuite) TestGetShardIteratorReturnsEmpty() {
 	s.setupReader()
 
 	checkpoint := new(mocks.Checkpoint)
-	checkpoint.On("Persist", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(true, nil).Once()
-	checkpoint.On("Release", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(nil).Once()
+	checkpoint.On("Persist", mock.AnythingOfType("*exec.stoppableContext")).Return(true, nil).Once()
+	checkpoint.On("Release", mock.AnythingOfType("*exec.stoppableContext")).Return(nil).Once()
 	checkpoint.On("GetSequenceNumber").Return(gosoKinesis.SequenceNumber("")).Once()
 	checkpoint.On("Done", gosoKinesis.SequenceNumber("")).Return(nil).Once()
 	defer checkpoint.AssertExpectations(s.T())
@@ -152,8 +152,8 @@ func (s *shardReaderTestSuite) TestGetRecordsAndReleaseFails() {
 	s.setupReader()
 
 	checkpoint := new(mocks.Checkpoint)
-	checkpoint.On("Persist", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(true, nil).Once()
-	checkpoint.On("Release", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(fmt.Errorf("fail again")).Once()
+	checkpoint.On("Persist", mock.AnythingOfType("*exec.stoppableContext")).Return(true, nil).Once()
+	checkpoint.On("Release", mock.AnythingOfType("*exec.stoppableContext")).Return(fmt.Errorf("fail again")).Once()
 	checkpoint.On("GetSequenceNumber").Return(gosoKinesis.SequenceNumber("")).Once()
 	defer checkpoint.AssertExpectations(s.T())
 
@@ -185,8 +185,8 @@ func (s *shardReaderTestSuite) TestReleaseFailsAfterShardIteratorFailed() {
 	s.setupReader()
 
 	checkpoint := new(mocks.Checkpoint)
-	checkpoint.On("Persist", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(true, nil).Once()
-	checkpoint.On("Release", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(fmt.Errorf("fail again")).Once()
+	checkpoint.On("Persist", mock.AnythingOfType("*exec.stoppableContext")).Return(true, nil).Once()
+	checkpoint.On("Release", mock.AnythingOfType("*exec.stoppableContext")).Return(fmt.Errorf("fail again")).Once()
 	checkpoint.On("GetSequenceNumber").Return(gosoKinesis.SequenceNumber("sequence number")).Once()
 	defer checkpoint.AssertExpectations(s.T())
 
@@ -211,8 +211,8 @@ func (s *shardReaderTestSuite) TestConsumeTwoBatches() {
 	s.setupReader()
 
 	checkpoint := new(mocks.Checkpoint)
-	checkpoint.On("Persist", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(true, nil).Once()
-	checkpoint.On("Release", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(nil).Once()
+	checkpoint.On("Persist", mock.AnythingOfType("*exec.stoppableContext")).Return(true, nil).Once()
+	checkpoint.On("Release", mock.AnythingOfType("*exec.stoppableContext")).Return(nil).Once()
 	checkpoint.On("GetSequenceNumber").Return(gosoKinesis.SequenceNumber("sequence number")).Once()
 	checkpoint.On("Advance", gosoKinesis.SequenceNumber("seq 1")).Return(nil).Once()
 	checkpoint.On("Advance", gosoKinesis.SequenceNumber("seq 2")).Return(nil).Once()
@@ -285,8 +285,8 @@ func (s *shardReaderTestSuite) TestExpiredIteratorExceptionThenDelayedBadData() 
 	s.setupReader()
 
 	checkpoint := new(mocks.Checkpoint)
-	checkpoint.On("Persist", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(true, nil).Once()
-	checkpoint.On("Release", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(nil).Once()
+	checkpoint.On("Persist", mock.AnythingOfType("*exec.stoppableContext")).Return(true, nil).Once()
+	checkpoint.On("Release", mock.AnythingOfType("*exec.stoppableContext")).Return(nil).Once()
 	checkpoint.On("GetSequenceNumber").Return(gosoKinesis.SequenceNumber("sequence number")).Twice()
 	checkpoint.On("Advance", gosoKinesis.SequenceNumber("seq 1")).Return(nil).Once()
 	defer checkpoint.AssertExpectations(s.T())
@@ -383,8 +383,8 @@ func (s *shardReaderTestSuite) TestPersisterPersistCanceled() {
 
 	checkpoint := new(mocks.Checkpoint)
 	checkpoint.On("Persist", mock.AnythingOfType("*exec.manualCancelContext")).Return(false, context.Canceled).Maybe()
-	checkpoint.On("Persist", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(true, nil).Once()
-	checkpoint.On("Release", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(nil).Once()
+	checkpoint.On("Persist", mock.AnythingOfType("*exec.stoppableContext")).Return(true, nil).Once()
+	checkpoint.On("Release", mock.AnythingOfType("*exec.stoppableContext")).Return(nil).Once()
 	checkpoint.On("GetSequenceNumber").Return(gosoKinesis.SequenceNumber("sequence number")).Once()
 	defer checkpoint.AssertExpectations(s.T())
 
@@ -437,8 +437,8 @@ func (s *shardReaderTestSuite) TestConsumeDelayWithWait() {
 	s.setupReader()
 
 	checkpoint := new(mocks.Checkpoint)
-	checkpoint.On("Persist", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(true, nil).Once()
-	checkpoint.On("Release", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(nil).Once()
+	checkpoint.On("Persist", mock.AnythingOfType("*exec.stoppableContext")).Return(true, nil).Once()
+	checkpoint.On("Release", mock.AnythingOfType("*exec.stoppableContext")).Return(nil).Once()
 	checkpoint.On("GetSequenceNumber").Return(gosoKinesis.SequenceNumber("sequence number")).Once()
 	checkpoint.On("Advance", gosoKinesis.SequenceNumber("seq 1")).Return(nil).Once()
 	checkpoint.On("Done", gosoKinesis.SequenceNumber("seq 1")).Return(nil).Once()
@@ -502,8 +502,8 @@ func (s *shardReaderTestSuite) TestConsumeDelayWithOldRecord() {
 	s.clock.Advance(time.Minute)
 
 	checkpoint := new(mocks.Checkpoint)
-	checkpoint.On("Persist", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(true, nil).Once()
-	checkpoint.On("Release", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(nil).Once()
+	checkpoint.On("Persist", mock.AnythingOfType("*exec.stoppableContext")).Return(true, nil).Once()
+	checkpoint.On("Release", mock.AnythingOfType("*exec.stoppableContext")).Return(nil).Once()
 	checkpoint.On("GetSequenceNumber").Return(gosoKinesis.SequenceNumber("sequence number")).Once()
 	checkpoint.On("Advance", gosoKinesis.SequenceNumber("seq 1")).Return(nil).Once()
 	checkpoint.On("Done", gosoKinesis.SequenceNumber("seq 1")).Return(nil).Once()
@@ -561,8 +561,8 @@ func (s *shardReaderTestSuite) TestConsumeDelayWithCancelDuringWait() {
 	ctx, cancel := context.WithCancel(s.ctx)
 
 	checkpoint := new(mocks.Checkpoint)
-	checkpoint.On("Persist", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(true, nil).Once()
-	checkpoint.On("Release", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(nil).Once()
+	checkpoint.On("Persist", mock.AnythingOfType("*exec.stoppableContext")).Return(true, nil).Once()
+	checkpoint.On("Release", mock.AnythingOfType("*exec.stoppableContext")).Return(nil).Once()
 	checkpoint.On("GetSequenceNumber").Return(gosoKinesis.SequenceNumber("sequence number")).Once()
 	defer checkpoint.AssertExpectations(s.T())
 
@@ -625,8 +625,8 @@ func (s *shardReaderTestSuite) TestConsumeDelayWithCancelDuringWaitNoRecords() {
 	ctx, cancel := context.WithCancel(s.ctx)
 
 	checkpoint := new(mocks.Checkpoint)
-	checkpoint.On("Persist", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(true, nil).Once()
-	checkpoint.On("Release", mock.AnythingOfType("*exec.DelayedCancelContext")).Return(nil).Once()
+	checkpoint.On("Persist", mock.AnythingOfType("*exec.stoppableContext")).Return(true, nil).Once()
+	checkpoint.On("Release", mock.AnythingOfType("*exec.stoppableContext")).Return(nil).Once()
 	checkpoint.On("GetSequenceNumber").Return(gosoKinesis.SequenceNumber("sequence number")).Once()
 	checkpoint.On("Done", gosoKinesis.SequenceNumber("")).Return(nil).Once()
 	defer checkpoint.AssertExpectations(s.T())

--- a/pkg/conc/ddb_lock.go
+++ b/pkg/conc/ddb_lock.go
@@ -51,10 +51,10 @@ func (l *ddbLock) Release() error {
 	// stop the debug thread if needed
 	l.released.Signal()
 
-	ctx := exec.WithDelayedCancelContext(l.ctx, time.Second*3)
+	ctx, stop := exec.WithDelayedCancelContext(l.ctx, time.Second*3)
 	// stop the cancel context eventually to make sure we are not leaking
 	// a lot of go routines should our parent context get reused over and over
-	defer ctx.Stop()
+	defer stop()
 
 	return l.manager.release(ctx, l.resource, l.token)
 }

--- a/pkg/conc/ddb_lock_provider_test.go
+++ b/pkg/conc/ddb_lock_provider_test.go
@@ -104,7 +104,7 @@ func (s *ddbLockProviderTestSuite) getReleaseQueryBuilder(result *ddb.DeleteItem
 	qb.On("WithCondition", ddb.AttributeExists("resource").And(ddb.Eq("token", s.token))).Return(qb).Once()
 
 	s.repo.On("DeleteItemBuilder").Return(qb).Once()
-	s.repo.On("DeleteItem", mock.AnythingOfType("*exec.DelayedCancelContext"), qb, &conc.DdbLockItem{
+	s.repo.On("DeleteItem", mock.AnythingOfType("*exec.stoppableContext"), qb, &conc.DdbLockItem{
 		Resource: s.resource,
 		Token:    s.token,
 	}).Return(result, err)

--- a/pkg/exec/context.go
+++ b/pkg/exec/context.go
@@ -3,84 +3,168 @@ package exec
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/justtrackio/gosoline/pkg/clock"
 )
 
-type DelayedCancelContext struct {
-	context.Context
-	done     chan struct{}
-	stopWg   *sync.WaitGroup
-	stopOnce sync.Once
-	stop     chan struct{}
+type StopFunc func()
+
+type stoppableContext struct {
+	parentCtx context.Context
+	done      chan struct{}
+	err       atomic.Value
+	stopWg    *sync.WaitGroup
+	stopOnce  sync.Once
+	stopped   chan struct{}
+	deadline  *time.Time
 }
 
-func (c *DelayedCancelContext) Done() <-chan struct{} {
+func newStoppableContext(parentCtx context.Context, deadline *time.Time, handler func(ctx *stoppableContext) (bool, error)) (context.Context, StopFunc) {
+	if parentCtx == nil {
+		panic("cannot create context from nil parent")
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	ctx := &stoppableContext{
+		parentCtx: parentCtx,
+		err:       atomic.Value{},
+		done:      make(chan struct{}),
+		stopWg:    wg,
+		stopped:   make(chan struct{}),
+		deadline:  deadline,
+	}
+	if parentDeadline, ok := parentCtx.Deadline(); ok {
+		if ctx.deadline == nil || ctx.deadline.After(parentDeadline) {
+			ctx.deadline = &parentDeadline
+		}
+	}
+
+	go func() {
+		defer ctx.stopWg.Done()
+
+		shouldClose, err := handler(ctx)
+		if err != nil {
+			ctx.err.Store(err)
+		}
+		if shouldClose {
+			close(ctx.done)
+		}
+	}()
+
+	return ctx, ctx.stop
+}
+
+func (c *stoppableContext) Done() <-chan struct{} {
 	return c.done
 }
 
-// Stop releases the resources from a delayed cancel context. This causes the delayed context to never be canceled (if it
+func (c *stoppableContext) Err() error {
+	err := c.err.Load()
+	if err == nil {
+		return nil
+	}
+
+	return err.(error)
+}
+
+func (c *stoppableContext) Deadline() (time.Time, bool) {
+	if c.deadline != nil {
+		return *c.deadline, true
+	}
+
+	return time.Time{}, false
+}
+
+func (c *stoppableContext) Value(key interface{}) interface{} {
+	return c.parentCtx.Value(key)
+}
+
+// stop releases the resources from a delayed cancel context. This causes the delayed context to never be canceled (if it
 // wasn't canceled already). Calling stop never returns before all resources have been released, so after Stop returns,
 // the context will not experience a delayed cancel anymore.
-func (c *DelayedCancelContext) Stop() {
+func (c *stoppableContext) stop() {
 	c.stopOnce.Do(func() {
-		close(c.stop)
+		close(c.stopped)
 	})
 
 	c.stopWg.Wait()
 }
 
 // WithDelayedCancelContext creates a context which propagates the cancellation of the parent context after a fixed delay
-// to the returned context. Call DelayedCancelContext.Stop to release resources associated with the returned context once
-// you no longer need it.
-func WithDelayedCancelContext(parentCtx context.Context, delay time.Duration) *DelayedCancelContext {
-	done := make(chan struct{})
-	stop := make(chan struct{})
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-
+// to the returned context. Call the returned StopFunc function to release resources associated with the returned context once
+// you no longer need it. Calling stop never returns before all resources have been released, so after Stop returns,
+// the context will not experience a delayed cancel anymore.
+func WithDelayedCancelContext(parentCtx context.Context, delay time.Duration) (context.Context, StopFunc) {
+	return newStoppableContext(parentCtx, nil, func(ctx *stoppableContext) (bool, error) {
 		select {
-		case <-stop:
+		case <-ctx.stopped:
+			return false, nil
 		case <-parentCtx.Done():
 			clock.Provider.Sleep(delay)
-			close(done)
+			return true, parentCtx.Err()
 		}
-	}()
+	})
+}
 
-	return &DelayedCancelContext{
-		Context: parentCtx,
-		done:    done,
-		stopWg:  wg,
-		stop:    stop,
-	}
+// WithStoppableDeadlineContext is similar to context.WithDeadline. However, while context.WithDeadline cancels the context when
+// you call the returned context.CancelFunc, WithStoppableDeadlineContext does not cancel the context if it is not yet canceled
+// once you stop it.
+func WithStoppableDeadlineContext(parentCtx context.Context, deadline time.Time) (context.Context, StopFunc) {
+	return newStoppableContext(parentCtx, &deadline, func(ctx *stoppableContext) (bool, error) {
+		c := clock.Provider
+		waitTime := -c.Since(deadline)
+		timer := c.NewTimer(waitTime)
+		defer timer.Stop()
+
+		select {
+		case <-ctx.stopped:
+			return false, nil
+		case <-parentCtx.Done():
+			return true, parentCtx.Err()
+		case <-timer.Chan():
+			return true, context.DeadlineExceeded
+		}
+	})
 }
 
 type manualCancelContext struct {
 	context.Context
 	done chan struct{}
+	err  atomic.Value
 }
 
 func (c *manualCancelContext) Done() <-chan struct{} {
 	return c.done
 }
 
+func (c *manualCancelContext) Err() error {
+	err := c.err.Load()
+	if err == nil {
+		return nil
+	}
+
+	return err.(error)
+}
+
 // WithManualCancelContext is similar to context.WithCancel, but it only cancels the returned context once the cancel
 // function has been called. Cancellation of the parent context is not automatically propagated to the child context.
 func WithManualCancelContext(parentCtx context.Context) (context.Context, context.CancelFunc) {
-	done := make(chan struct{})
+	ctx := &manualCancelContext{
+		Context: parentCtx,
+		done:    make(chan struct{}),
+		err:     atomic.Value{},
+	}
 	once := &sync.Once{}
 	cancel := func() {
 		once.Do(func() {
-			close(done)
+			ctx.err.Store(context.Canceled)
+			close(ctx.done)
 		})
 	}
 
-	return &manualCancelContext{
-		Context: parentCtx,
-		done:    done,
-	}, cancel
+	return ctx, cancel
 }

--- a/pkg/exec/context_test.go
+++ b/pkg/exec/context_test.go
@@ -7,95 +7,148 @@ import (
 
 	"github.com/justtrackio/gosoline/pkg/clock"
 	"github.com/justtrackio/gosoline/pkg/exec"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestWithDelayedCancelContext(t *testing.T) {
-	oldProvider := clock.Provider
-	defer func() {
-		clock.Provider = oldProvider
-	}()
-	fakeClock := clock.NewFakeClock()
-	clock.Provider = fakeClock
+type contextTestSuite struct {
+	suite.Suite
+	fakeClock   clock.FakeClock
+	oldProvider clock.Clock
+}
 
+func (s *contextTestSuite) SetupSuite() {
+	s.oldProvider = clock.Provider
+	s.fakeClock = clock.NewFakeClock()
+	clock.Provider = s.fakeClock
+}
+
+func (s *contextTestSuite) TearDownSuite() {
+	clock.Provider = s.oldProvider
+}
+
+func (s *contextTestSuite) TestWithDelayedCancelContext() {
 	parentCtx, cancel := context.WithCancel(context.Background())
-
-	ctx := exec.WithDelayedCancelContext(parentCtx, time.Minute)
+	ctx, stop := exec.WithDelayedCancelContext(parentCtx, time.Minute)
 
 	// initially the context is not canceled
-	assertNotCanceled(t, ctx)
+	s.assertNotCanceled(ctx)
 
 	// once we cancel it, the parent context is canceled, but not the child
 	cancel()
-	assertCanceled(t, parentCtx)
-	assertNotCanceled(t, ctx)
+	s.assertCanceled(parentCtx, context.Canceled)
+	s.assertNotCanceled(ctx)
 
 	// only after some time passes, the context is canceled
-	fakeClock.BlockUntil(1)
-	fakeClock.Advance(time.Minute)
-	ctx.Stop() // Stop returns only after the go routine is gone
-	assertCanceled(t, ctx)
+	s.fakeClock.BlockUntil(1)
+	s.fakeClock.Advance(time.Minute)
+	stop() // Stop returns only after the go routine is gone
+	s.assertCanceled(ctx, context.Canceled)
 }
 
-func TestWithDelayedCancelContext_Stop(t *testing.T) {
-	oldProvider := clock.Provider
-	defer func() {
-		clock.Provider = oldProvider
-	}()
-	fakeClock := clock.NewFakeClock()
-	clock.Provider = fakeClock
-
+func (s *contextTestSuite) TestWithDelayedCancelContext_Stop() {
 	parentCtx, cancel := context.WithCancel(context.Background())
-
-	ctx := exec.WithDelayedCancelContext(parentCtx, time.Minute)
+	ctx, stop := exec.WithDelayedCancelContext(parentCtx, time.Minute)
 
 	// initially the context is not canceled
-	assertNotCanceled(t, ctx)
+	s.assertNotCanceled(ctx)
 
 	// we stop the delayed context, so it will never propagate the cancel
-	ctx.Stop()
-	assertNotCanceled(t, ctx)
+	stop()
+	s.assertNotCanceled(ctx)
 
 	// once we cancel it, the parent context is canceled, but not the child
 	cancel()
-	assertCanceled(t, parentCtx)
+	s.assertCanceled(parentCtx, context.Canceled)
 	// even give it some time to wrongly propagate a cancel - as this should not happen, this should not change it
 	time.Sleep(time.Millisecond)
-	assertNotCanceled(t, ctx)
+	s.assertNotCanceled(ctx)
 }
 
-func TestWithManualCancelContext(t *testing.T) {
-	parentCtx, cancelParent := context.WithCancel(context.Background())
+func (s *contextTestSuite) TestWithStoppableDeadlineContext() {
+	parentCtx := context.Background()
+	ctx, stop := exec.WithStoppableDeadlineContext(parentCtx, s.fakeClock.Now().Add(time.Minute))
+	defer stop()
 
+	// initially the context is not canceled
+	s.assertNotCanceled(ctx)
+
+	// after some time passes, the context is canceled
+	s.fakeClock.BlockUntilTimers(1)
+	s.fakeClock.Advance(time.Minute)
+	// the context is now canceled
+	<-ctx.Done()
+	s.assertCanceled(ctx, context.DeadlineExceeded)
+}
+
+func (s *contextTestSuite) TestWithStoppableDeadlineContext_CancelParent() {
+	parentCtx, cancel := context.WithCancel(context.Background())
+	ctx, stop := exec.WithStoppableDeadlineContext(parentCtx, s.fakeClock.Now().Add(time.Minute))
+	defer stop()
+
+	// initially the context is not canceled
+	s.assertNotCanceled(ctx)
+
+	// once we cancel it, the parent context is canceled, the child is also canceled
+	cancel()
+	// the context is now canceled
+	<-ctx.Done()
+	s.assertCanceled(ctx, context.Canceled)
+}
+
+func (s *contextTestSuite) TestWithStoppableDeadlineContext_Stop() {
+	parentCtx, cancel := context.WithCancel(context.Background())
+	ctx, stop := exec.WithStoppableDeadlineContext(parentCtx, s.fakeClock.Now().Add(time.Minute))
+
+	// initially the context is not canceled
+	s.assertNotCanceled(ctx)
+
+	// we stop the delayed context, so it will never propagate the cancel
+	stop()
+	s.assertNotCanceled(ctx)
+
+	// once we cancel it, the parent context is canceled, but not the child
+	cancel()
+	s.assertCanceled(parentCtx, context.Canceled)
+	// even give it some time to wrongly propagate a cancel - as this should not happen, this should not change it
+	time.Sleep(time.Millisecond)
+	s.assertNotCanceled(ctx)
+}
+
+func (s *contextTestSuite) TestWithManualCancelContext() {
+	parentCtx, cancelParent := context.WithCancel(context.Background())
 	ctx, cancelChild := exec.WithManualCancelContext(parentCtx)
 
 	// initially the context is not canceled
-	assertNotCanceled(t, ctx)
+	s.assertNotCanceled(ctx)
 
 	// we stop the parent context, this should not be propagated to the child
 	cancelParent()
-	assertCanceled(t, parentCtx)
-	assertNotCanceled(t, ctx)
+	s.assertCanceled(parentCtx, context.Canceled)
+	s.assertNotCanceled(ctx)
 
 	// once we cancel the child, it should be canceled
 	cancelChild()
-	assertCanceled(t, ctx)
+	s.assertCanceled(ctx, context.Canceled)
 }
 
-func assertCanceled(t *testing.T, ctx context.Context) {
+func (s *contextTestSuite) assertCanceled(ctx context.Context, expectedErr error) {
 	select {
 	case <-ctx.Done():
-		return
+		s.Equal(expectedErr, ctx.Err())
 	default:
-		assert.Fail(t, "context was not canceled")
+		s.Fail("context was not canceled")
 	}
 }
 
-func assertNotCanceled(t *testing.T, ctx context.Context) {
+func (s *contextTestSuite) assertNotCanceled(ctx context.Context) {
 	select {
 	case <-ctx.Done():
-		assert.Fail(t, "context was canceled")
+		s.Fail("context was canceled")
 	default:
-		return
+		s.NoError(ctx.Err())
 	}
+}
+
+func TestContextTestSuite(t *testing.T) {
+	suite.Run(t, new(contextTestSuite))
 }

--- a/pkg/exec/executor_backoff.go
+++ b/pkg/exec/executor_backoff.go
@@ -34,8 +34,8 @@ func (e *BackoffExecutor) Execute(ctx context.Context, f Executable) (interface{
 		"exec_resource_name": e.resource.Name,
 	})
 
-	delayedCtx := WithDelayedCancelContext(ctx, e.settings.CancelDelay)
-	defer delayedCtx.Stop()
+	delayedCtx, stop := WithDelayedCancelContext(ctx, e.settings.CancelDelay)
+	defer stop()
 
 	var res interface{}
 	var err error

--- a/test/cloud/aws/dynamodb/client_test.go
+++ b/test/cloud/aws/dynamodb/client_test.go
@@ -88,9 +88,10 @@ func (s *ClientTestSuite) TestSuccess() {
 
 func (s *ClientTestSuite) TestHttpTimeout() {
 	proxy := s.Env().DynamoDb("default").Toxiproxy()
-	proxy.AddToxic("latency_down", "latency", "downstream", 1.0, toxiproxy.Attributes{
+	_, err := proxy.AddToxic("latency_down", "latency", "downstream", 1.0, toxiproxy.Attributes{
 		"latency": 200,
 	})
+	s.NoError(err)
 
 	ctx := context.Background()
 	resource := &exec.ExecutableResource{
@@ -121,7 +122,8 @@ func (s *ClientTestSuite) TestHttpTimeout() {
 			return stack.Finalize.Add(middleware.FinalizeMiddlewareFunc("bla", func(ctx context.Context, input middleware.FinalizeInput, handler middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
 				i++
 				if i == 3 {
-					proxy.RemoveToxic("latency_down")
+					err := proxy.RemoveToxic("latency_down")
+					s.NoError(err)
 				}
 
 				return handler.HandleFinalize(ctx, input)
@@ -135,9 +137,10 @@ func (s *ClientTestSuite) TestHttpTimeout() {
 
 func (s *ClientTestSuite) TestMaxElapsedTimeExceeded() {
 	proxy := s.Env().DynamoDb("default").Toxiproxy()
-	proxy.AddToxic("latency_down", "latency", "downstream", 1.0, toxiproxy.Attributes{
+	_, err := proxy.AddToxic("latency_down", "latency", "downstream", 1.0, toxiproxy.Attributes{
 		"latency": 200,
 	})
+	s.NoError(err)
 
 	ctx := context.Background()
 	loggerMock := new(logMocks.Logger)

--- a/test/fixtures/dynamodb/dynamodb_test.go
+++ b/test/fixtures/dynamodb/dynamodb_test.go
@@ -1,5 +1,5 @@
-//go:build integration || fixtures
-// +build integration fixtures
+//go:build integration && fixtures
+// +build integration,fixtures
 
 package dynamodb_test
 

--- a/test/fixtures/mysql/mysql_test.go
+++ b/test/fixtures/mysql/mysql_test.go
@@ -1,5 +1,5 @@
-//go:build integration || fixtures
-// +build integration fixtures
+//go:build integration && fixtures
+// +build integration,fixtures
 
 package mysql_test
 

--- a/test/fixtures/redis/redis_test.go
+++ b/test/fixtures/redis/redis_test.go
@@ -1,5 +1,5 @@
-//go:build integration || fixtures
-// +build integration fixtures
+//go:build integration && fixtures
+// +build integration,fixtures
 
 package redis_test
 


### PR DESCRIPTION
exec: added WithStoppableDeadlineContext;

When we request a file from S3, we do the initial request with a deadline and, if successful, cancel the deadline. However, this then cancels the context we need to download the body of that response - causing spurious canceled errors when downloading larger files (smaller files sometimes manage to slip through the window until the cancel is detected). To fix this, we introduce a new context type which is stopped but not canceled, so we can free the associated resources without causing this problem.