### PR TITLE
test/suite: added two options to make debugging tests easier;

### DIFF
--- a/test/cloud/aws/dynamodb/client_test.go
+++ b/test/cloud/aws/dynamodb/client_test.go
@@ -141,6 +141,10 @@ func (s *ClientTestSuite) TestMaxElapsedTimeExceeded() {
 		"latency": 200,
 	})
 	s.NoError(err)
+	defer func() {
+		err := proxy.RemoveToxic("latency_down")
+		s.NoError(err)
+	}()
 
 	ctx := context.Background()
 	loggerMock := new(logMocks.Logger)

--- a/test/suite/suite_test.go
+++ b/test/suite/suite_test.go
@@ -1,0 +1,38 @@
+//go:build integration
+// +build integration
+
+package suite_test
+
+import (
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/test/suite"
+	"github.com/stretchr/testify/assert"
+)
+
+type SuiteTestSuite struct {
+	suite.Suite
+	testCount int
+}
+
+func (s *SuiteTestSuite) SetupSuite() []suite.Option {
+	return []suite.Option{
+		suite.WithSharedEnvironment(),
+		suite.WithTestCaseWhitelist("TestExpectedToRun"),
+		suite.WithTestCaseRepeatCount(2),
+	}
+}
+
+func (s *SuiteTestSuite) TestExpectedToRun() {
+	s.testCount++
+}
+
+func (s *SuiteTestSuite) TestExpectedToSkip() {
+	s.FailNow("should've been skipped")
+}
+
+func TestSuiteTestSuite(t *testing.T) {
+	s := &SuiteTestSuite{}
+	suite.Run(t, s)
+	assert.Equal(t, 2, s.testCount)
+}


### PR DESCRIPTION
- `WithTestCaseWhitelist` allows you to specify which tests to run from a larger set, so you can easily add `WithTestCaseWhitelist("TestYourMethod")` to debug the `TestYourMethod` test.
- `WithTestCaseRepeatCount` allows you to repeat a whole test suite without wrapping the `suite.Run` call in a for loop or similar. If a problem you are debugging doesn't happen every time this option helps you debug this problem.