### PR TITLE
stream: smaller bugfixes and improvements

### DIFF
--- a/pkg/stream/consumer.go
+++ b/pkg/stream/consumer.go
@@ -123,7 +123,7 @@ func (c *Consumer) processSingleMessage(ctx context.Context, cdata *consumerData
 }
 
 func (c *Consumer) process(ctx context.Context, msg *Message) bool {
-	defer c.recover()
+	defer c.recover(ctx, msg)
 
 	var err error
 	var ack bool

--- a/pkg/stream/consumer_batch.go
+++ b/pkg/stream/consumer_batch.go
@@ -151,7 +151,7 @@ func (c *BatchConsumer) processBatch(ctx context.Context) {
 }
 
 func (c *BatchConsumer) consumeBatch(ctx context.Context, batch []*consumerData) {
-	defer c.recover()
+	defer c.recover(ctx, nil)
 
 	start := c.clock.Now()
 

--- a/pkg/stream/producer_daemon_test.go
+++ b/pkg/stream/producer_daemon_test.go
@@ -268,11 +268,10 @@ func (s *ProducerDaemonTestSuite) TestWriteAfterClose() {
 	}
 
 	err := s.stop()
-
 	s.NoError(err)
 
 	err = s.daemon.Write(context.Background(), messages)
-	s.NoError(err, "there should be no error on write")
+	s.EqualError(err, "can't write messages as the producer daemon testDaemon is not running")
 
 	s.output.AssertExpectations(s.T())
 }


### PR DESCRIPTION
- the consumer now retries messages on panic with a custom retry handler
- the producer will produce an error now if one tries to write a message with a not running daemon