### PR TITLE
investigate producer daemon test

### DIFF
--- a/test/stream/producer_daemon/module.go
+++ b/test/stream/producer_daemon/module.go
@@ -40,7 +40,7 @@ func (p producingModule) Run(ctx context.Context) error {
 		}
 
 		if err := p.producer.WriteOne(ctx, event); err != nil {
-			return nil
+			return err
 		}
 	}
 


### PR DESCRIPTION
```
=== CONT  TestProducerDaemonTestSuite
    components.go:92: 
        	Error Trace:	components.go:92
        	            				component_stream_output.go:54
        	            				suite_test.go:30
        	Error:      	message not available
        	Test:       	TestProducerDaemonTestSuite
        	Messages:   	there is no message with index 0
--- FAIL: TestProducerDaemonTestSuite (8.91s)
```