### PR TITLE
fixed data race in clock package

### DIFF
--- a/pkg/clock/fake_ticker.go
+++ b/pkg/clock/fake_ticker.go
@@ -50,11 +50,11 @@ func (f *fakeTicker) Reset(d time.Duration) {
 		panic(errors.New("non-positive interval for Reset"))
 	}
 
-	f.remaining = d
-	f.duration = d
-
 	f.clock.lck.Lock()
 	defer f.clock.lck.Unlock()
+
+	f.remaining = d
+	f.duration = d
 
 	f.clock.blockOnTickers = f.clock.notifyBlockers(f.clock.blockOnTickers, f.clock.waitingTickers())
 }

--- a/pkg/clock/fake_timer.go
+++ b/pkg/clock/fake_timer.go
@@ -44,10 +44,10 @@ func (f *fakeTimer) Stop() bool {
 }
 
 func (f *fakeTimer) Reset(d time.Duration) {
-	f.remaining = d
-
 	f.clock.lck.Lock()
 	defer f.clock.lck.Unlock()
+
+	f.remaining = d
 
 	// if we are reset to <= 0, we have to trigger a tick immediately
 	if d <= 0 {


### PR DESCRIPTION
You had a data race in your clock package.

`go test -race -v .\pkg\clock\`

![image](https://user-images.githubusercontent.com/14594374/163100395-da647073-d0fe-46f0-876c-ea45d79d8c2f.png)
![image](https://user-images.githubusercontent.com/14594374/163100426-06d7eb70-58dd-4570-a1a9-54eee8ca0f48.png)