### PR TITLE
Entity sharing package

### DIFF
--- a/pkg/apiserver/crud/handler.go
+++ b/pkg/apiserver/crud/handler.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/jinzhu/inflection"
 	"github.com/justtrackio/gosoline/pkg/apiserver"
-	db_repo "github.com/justtrackio/gosoline/pkg/db-repo"
+	"github.com/justtrackio/gosoline/pkg/db-repo"
 	"github.com/justtrackio/gosoline/pkg/log"
 )
 

--- a/pkg/apiserver/crud/update.go
+++ b/pkg/apiserver/crud/update.go
@@ -44,7 +44,7 @@ func (uh updateHandler) Handle(ctx context.Context, request *apiserver.Request) 
 
 	var notFound db_repo.RecordNotFoundError
 	if errors.As(err, &notFound) {
-		uh.logger.WithContext(ctx).Warn("failed to update model: %s", err)
+		uh.logger.WithContext(ctx).Warn("failed to update model: %s", err.Error())
 
 		return apiserver.NewStatusResponse(http.StatusNotFound), nil
 	}

--- a/pkg/application/options.go
+++ b/pkg/application/options.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/justtrackio/gosoline/pkg/share"
+
 	"github.com/justtrackio/gosoline/pkg/apiserver"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/clock"
@@ -142,6 +144,12 @@ func WithExecBackoffSettings(settings *exec.BackoffSettings) Option {
 func WithDbRepoChangeHistory(app *App) {
 	app.addKernelOption(func(config cfg.GosoConf) kernelPkg.Option {
 		return kernelPkg.WithMiddlewareFactory(db_repo.KernelMiddlewareChangeHistory, kernelPkg.PositionEnd)
+	})
+}
+
+func WithApiServerShares(app *App) {
+	app.addKernelOption(func(config cfg.GosoConf) kernelPkg.Option {
+		return kernelPkg.WithMiddlewareFactory(share.KernelMiddlewareShares, kernelPkg.PositionEnd)
 	})
 }
 

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -27,13 +27,13 @@ type dispatcher struct {
 	listeners map[string][]Callback
 }
 
-func ProvideDispatcher(ctx context.Context, config cfg.Config, logger log.Logger) (Dispatcher, error) {
+func ProvideDispatcher(ctx context.Context, _ cfg.Config, logger log.Logger) (Dispatcher, error) {
 	return appctx.Provide(ctx, dispatcherCtxKey("Dispatcher"), func() (Dispatcher, error) {
-		return newDispatcher(ctx, config, logger)
+		return newDispatcher(logger)
 	})
 }
 
-func newDispatcher(_ context.Context, _ cfg.Config, logger log.Logger) (Dispatcher, error) {
+func newDispatcher(logger log.Logger) (Dispatcher, error) {
 	return &dispatcher{
 		logger:    logger.WithChannel("dispatcher"),
 		mx:        sync.RWMutex{},

--- a/pkg/share/create.go
+++ b/pkg/share/create.go
@@ -1,0 +1,115 @@
+package share
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/justtrackio/gosoline/pkg/apiserver"
+	"github.com/justtrackio/gosoline/pkg/apiserver/crud"
+	"github.com/justtrackio/gosoline/pkg/db"
+	"github.com/justtrackio/gosoline/pkg/db-repo"
+	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/justtrackio/gosoline/pkg/uuid"
+	"github.com/justtrackio/gosoline/pkg/validation"
+)
+
+type shareCreateHandler struct {
+	logger       log.Logger
+	transformer  ShareCreateHandler
+	uuidProvider uuid.Uuid
+}
+
+func NewShareCreateHandler(logger log.Logger, transformer ShareCreateHandler) gin.HandlerFunc {
+	sh := shareCreateHandler{
+		logger:       logger,
+		transformer:  transformer,
+		uuidProvider: uuid.New(),
+	}
+
+	return apiserver.CreateJsonHandler(sh)
+}
+
+func (s shareCreateHandler) GetInput() interface{} {
+	return s.transformer.GetCreateInput()
+}
+
+func (s shareCreateHandler) Handle(ctx context.Context, req *apiserver.Request) (*apiserver.Response, error) {
+	logger := s.logger.WithContext(ctx)
+
+	id, valid := apiserver.GetUintFromRequest(req, "id")
+	if !valid {
+		return nil, errors.New("no valid id provided")
+	}
+
+	entity, err := s.getEntity(ctx, id)
+	var notFound db_repo.RecordNotFoundError
+	if errors.As(err, &notFound) {
+		logger.Warn("failed to read entity: %s", err.Error())
+
+		return apiserver.NewStatusResponse(http.StatusNotFound), nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	model := s.transformer.GetModel()
+	// we assert cast safely here as the req.Body will get parsed in something that implements Metadata
+	shareInput := req.Body.(Metadata)
+	policy := BuildSharePolicy(s.uuidProvider.NewV4(), entity, shareInput.GetOwnerId(), shareInput.GetActions())
+
+	guard := s.transformer.GetGuard()
+	err = guard.CreatePolicy(policy)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.transformer.TransformCreate(ctx, req.Body, entity, policy, model)
+	if err != nil {
+		return nil, err
+	}
+
+	shareRepo := s.transformer.GetRepository()
+	err = shareRepo.Create(ctx, model)
+
+	if db.IsDuplicateEntryError(err) {
+		return apiserver.NewStatusResponse(http.StatusConflict), nil
+	}
+
+	if errors.Is(err, &validation.Error{}) {
+		return apiserver.GetErrorHandler()(http.StatusBadRequest, err), nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	reload := s.transformer.GetModel()
+	err = shareRepo.Read(ctx, model.GetId(), reload)
+
+	if err != nil {
+		return nil, err
+	}
+
+	apiView := crud.GetApiViewFromHeader(req.Header)
+	out, err := s.transformer.TransformOutput(ctx, reload, apiView)
+	if err != nil {
+		return nil, err
+	}
+
+	return apiserver.NewJsonResponse(out), nil
+}
+
+func (s shareCreateHandler) getEntity(ctx context.Context, id *uint) (Shareable, error) {
+	entity := s.transformer.GetEntityModel()
+	entityRepo := s.transformer.GetEntityRepository()
+
+	err := entityRepo.Read(ctx, id, entity)
+	if err != nil {
+		return nil, err
+	}
+
+	return entity, nil
+}

--- a/pkg/share/handler.go
+++ b/pkg/share/handler.go
@@ -1,0 +1,58 @@
+package share
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/justtrackio/gosoline/pkg/apiserver"
+	"github.com/justtrackio/gosoline/pkg/apiserver/crud"
+	"github.com/justtrackio/gosoline/pkg/db-repo"
+	"github.com/justtrackio/gosoline/pkg/guard"
+	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/ory/ladon"
+)
+
+type Shareable interface {
+	db_repo.ModelBased
+	GetResources() []string
+	GetEntityType() string
+}
+
+type Metadata interface {
+	GetOwnerId() uint
+	GetActions() []string
+}
+
+type ModelBased interface {
+	db_repo.ModelBased
+	GetPolicyId() string
+}
+
+type BaseShareHandler interface {
+	GetEntityModel() Shareable
+	GetEntityRepository() db_repo.Repository
+	GetGuard() guard.Guard
+	GetModel() ModelBased
+	GetRepository() db_repo.Repository
+	TransformOutput(ctx context.Context, model db_repo.ModelBased, apiView string) (output interface{}, err error)
+}
+
+type EntityUpdateHandler interface {
+	BaseShareHandler
+	crud.BaseUpdateHandler
+}
+
+type EntityDeleteHandler interface {
+	BaseShareHandler
+}
+
+type ShareCreateHandler interface {
+	BaseShareHandler
+	GetCreateInput() Metadata
+	TransformCreate(ctx context.Context, input interface{}, entity Shareable, policy ladon.Policy, model db_repo.ModelBased) (err error)
+}
+
+func AddShareCreateHandler(logger log.Logger, d *apiserver.Definitions, version int, basePath string, handler ShareCreateHandler) {
+	path := fmt.Sprintf("/v%d/%s/:id/share", version, basePath)
+	d.POST(path, NewShareCreateHandler(logger, handler))
+}

--- a/pkg/share/manager.go
+++ b/pkg/share/manager.go
@@ -1,0 +1,92 @@
+package share
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jinzhu/gorm"
+	"github.com/justtrackio/gosoline/pkg/appctx"
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/db-repo"
+	"github.com/justtrackio/gosoline/pkg/log"
+)
+
+type Settings struct {
+	TableName struct {
+		Owner  string `cfg:"owner" default:"owners"`
+		Policy string `cfg:"policy" default:"policies"`
+		Share  string `cfg:"share" default:"shares"`
+	} `cfg:"table_name"`
+}
+
+type shareManagerAppctxKey string
+
+type Share struct {
+	db_repo.Model
+	EntityId   uint
+	EntityType string
+	OwnerId    uint
+	PolicyId   string
+}
+
+func (s *Share) GetPolicyId() string {
+	return s.PolicyId
+}
+
+type shareManager struct {
+	orm      *gorm.DB
+	logger   log.Logger
+	settings Settings
+}
+
+func ProvideShareManager(ctx context.Context, config cfg.Config, logger log.Logger) (*shareManager, error) {
+	return appctx.Provide(ctx, shareManagerAppctxKey("shareManager"), func() (*shareManager, error) {
+		return NewShareManager(config, logger)
+	})
+}
+
+func NewShareManager(config cfg.Config, logger log.Logger) (*shareManager, error) {
+	orm, err := db_repo.NewOrm(config, logger)
+	if err != nil {
+		return nil, fmt.Errorf("can not create orm: %w", err)
+	}
+
+	settings := Settings{}
+	config.UnmarshalKey("share", &settings)
+
+	return &shareManager{
+		logger:   logger.WithChannel("share_manager"),
+		orm:      orm,
+		settings: settings,
+	}, nil
+}
+
+func (m *shareManager) SetupShareTable() error {
+	tn := m.settings.TableName
+
+	scope := m.orm.NewScope(Share{})
+	if scope.Dialect().HasTable(tn.Share) {
+		return nil
+	}
+
+	_, err := m.orm.CommonDB().Exec(fmt.Sprintf(`
+		create table %s
+		(
+			id               int unsigned auto_increment primary key,
+			entity_id        int unsigned not null,
+			entity_type		 varchar(255) not null,
+			owner_id       	 int unsigned not null,
+			policy_id        varchar(255) not null,
+			created_at       timestamp    not null,
+			updated_at       timestamp    not null,
+
+			constraint shares_owner_id_fk foreign key (owner_id) references %s (id),
+			constraint shares_policy_id_fk foreign key (policy_id) references %s (id)
+		)
+	`, tn.Share, tn.Owner, tn.Policy))
+	if err != nil {
+		return fmt.Errorf("could not create table %s: %w", tn.Share, err)
+	}
+
+	return nil
+}

--- a/pkg/share/options.go
+++ b/pkg/share/options.go
@@ -1,0 +1,30 @@
+package share
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/kernel"
+	"github.com/justtrackio/gosoline/pkg/log"
+)
+
+func KernelMiddlewareShares(ctx context.Context, config cfg.Config, logger log.Logger) (kernel.Middleware, error) {
+	var err error
+
+	manager, err := ProvideShareManager(ctx, config, logger)
+	if err != nil {
+		return nil, fmt.Errorf("can not create share manager: %w", err)
+	}
+
+	return func(next kernel.MiddlewareHandler) kernel.MiddlewareHandler {
+		return func() {
+			if err := manager.SetupShareTable(); err != nil {
+				logger.Error("can not setup share tables: %s", err.Error())
+				return
+			}
+
+			next()
+		}
+	}, nil
+}

--- a/pkg/share/policy_builder.go
+++ b/pkg/share/policy_builder.go
@@ -1,0 +1,20 @@
+package share
+
+import (
+	"fmt"
+
+	"github.com/ory/ladon"
+)
+
+func BuildSharePolicy(uuid string, entity Shareable, ownerId uint, actions []string) ladon.Policy {
+	return &ladon.DefaultPolicy{
+		ID:          uuid,
+		Description: fmt.Sprintf("entity %d shared with owner %d", *entity.GetId(), ownerId),
+		Subjects: []string{
+			fmt.Sprintf("a:%d", ownerId),
+		},
+		Effect:    ladon.AllowAccess,
+		Resources: entity.GetResources(),
+		Actions:   actions,
+	}
+}

--- a/pkg/share/repository.go
+++ b/pkg/share/repository.go
@@ -1,0 +1,87 @@
+package share
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/justtrackio/gosoline/pkg/appctx"
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/db-repo"
+	"github.com/justtrackio/gosoline/pkg/guard"
+	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/ory/ladon"
+)
+
+type WithPolicy interface {
+	GetPolicyId() string
+}
+
+type repositoryCtxKey string
+
+type sqlRepository struct {
+	db_repo.Repository
+	guard guard.Guard
+}
+
+func ProvideRepository(ctx context.Context, config cfg.Config, logger log.Logger) (db_repo.Repository, error) {
+	return appctx.Provide(ctx, repositoryCtxKey("ShareRepository"), func() (db_repo.Repository, error) {
+		return newRepository(config, logger)
+	})
+}
+
+func newRepository(config cfg.Config, logger log.Logger) (db_repo.Repository, error) {
+	var settings Settings
+	config.UnmarshalKey("shares", &settings)
+	tn := settings.TableName
+
+	fieldMapping := func(field string) db_repo.FieldMapping {
+		return db_repo.NewFieldMapping(fmt.Sprintf("%s.%s", tn.Share, field))
+	}
+
+	dbSettings := db_repo.Settings{
+		Metadata: db_repo.Metadata{
+			TableName:  tn.Share,
+			PrimaryKey: fmt.Sprintf("%s.id", tn.Share),
+			Mappings: db_repo.FieldMappings{
+				"shares.entityId":   fieldMapping("entity_id"),
+				"shares.entityType": fieldMapping("entity_type"),
+				"shares.ownerId":    fieldMapping("owner_id"),
+				"shares.policyId":   fieldMapping("policy_id"),
+			},
+		},
+	}
+
+	repo, err := db_repo.New(config, logger, dbSettings)
+	if err != nil {
+		return nil, fmt.Errorf("can not create repository: %w", err)
+	}
+
+	guard, err := guard.NewGuard(config, logger)
+	if err != nil {
+		return nil, fmt.Errorf("can not create guard: %w", err)
+	}
+
+	return &sqlRepository{
+		Repository: repo,
+		guard:      guard,
+	}, nil
+}
+
+func (r sqlRepository) Delete(ctx context.Context, value db_repo.ModelBased) error {
+	s, ok := value.(WithPolicy)
+	if !ok {
+		return fmt.Errorf("can not get policy id from given entity")
+	}
+
+	err := r.Repository.Delete(ctx, value)
+	if err != nil {
+		return err
+	}
+
+	err = r.guard.DeletePolicy(&ladon.DefaultPolicy{ID: s.GetPolicyId()})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/share/shareable_repository.go
+++ b/pkg/share/shareable_repository.go
@@ -1,0 +1,109 @@
+package share
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/db-repo"
+	"github.com/justtrackio/gosoline/pkg/guard"
+	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/ory/ladon"
+)
+
+type shareRepository struct {
+	db_repo.Repository
+	guard           guard.Guard
+	logger          log.Logger
+	shareRepository db_repo.Repository
+}
+
+func NewShareableRepository(ctx context.Context, config cfg.Config, logger log.Logger, repo db_repo.Repository) (*shareRepository, error) {
+	guard, err := guard.NewGuard(config, logger)
+	if err != nil {
+		return nil, fmt.Errorf("can not create guard: %w", err)
+	}
+
+	shareRepo, err := ProvideRepository(ctx, config, logger)
+	if err != nil {
+		return nil, fmt.Errorf("can not create share repository: %w", err)
+	}
+
+	return &shareRepository{
+		Repository:      repo,
+		logger:          logger,
+		guard:           guard,
+		shareRepository: shareRepo,
+	}, nil
+}
+
+func (r shareRepository) Update(ctx context.Context, value db_repo.ModelBased) error {
+	entity, ok := value.(Shareable)
+	if !ok {
+		return fmt.Errorf("can not get entity name from given value")
+	}
+
+	err := r.Repository.Update(ctx, value)
+	if err != nil {
+		return err
+	}
+
+	shares, err := r.getEntityShares(ctx, entity)
+	if err != nil {
+		return err
+	}
+
+	for _, share := range shares {
+		oldPolicy, err := r.guard.GetPolicy(share.PolicyId)
+		if err != nil {
+			return fmt.Errorf("can not get policy by id: %w", err)
+		}
+
+		updatedPolicy := BuildSharePolicy(share.PolicyId, entity, share.OwnerId, oldPolicy.GetActions())
+		err = r.guard.UpdatePolicy(updatedPolicy)
+		if err != nil {
+			return fmt.Errorf("can not update policy: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r shareRepository) Delete(ctx context.Context, value db_repo.ModelBased) error {
+	entity, ok := value.(Shareable)
+	if !ok {
+		return fmt.Errorf("can not get entity name from given value")
+	}
+
+	shares, err := r.getEntityShares(ctx, entity)
+	if err != nil {
+		return err
+	}
+
+	for _, share := range shares {
+		err = r.shareRepository.Delete(ctx, share)
+		if err != nil {
+			return fmt.Errorf("can not delete share of entity: %w", err)
+		}
+
+		err = r.guard.DeletePolicy(&ladon.DefaultPolicy{ID: share.PolicyId})
+		if err != nil {
+			return fmt.Errorf("can not delete policy of share: %w", err)
+		}
+	}
+
+	return r.Repository.Delete(ctx, value)
+}
+
+func (r shareRepository) getEntityShares(ctx context.Context, entity Shareable) ([]*Share, error) {
+	qb := db_repo.NewQueryBuilder()
+	qb.Where("entity_id = ? and entity_type = ?", *entity.GetId(), entity.GetEntityType())
+
+	var result []*Share
+	err := r.shareRepository.Query(ctx, qb, &result)
+	if err != nil {
+		return nil, fmt.Errorf("can not query shares of entity type %s: %w", entity.GetEntityType(), err)
+	}
+
+	return result, nil
+}

--- a/pkg/test/suite/options_suite.go
+++ b/pkg/test/suite/options_suite.go
@@ -177,6 +177,12 @@ func WithDbRepoChangeHistory() Option {
 	}
 }
 
+func WithApiServerShares() Option {
+	return func(s *suiteOptions) {
+		s.addAppOption(application.WithApiServerShares)
+	}
+}
+
 // WithTestCaseWhitelist returns an option which only runs the tests contained in the given whitelist. A test not in the
 // whitelist is skipped instead, allowing you to easily run a single test (e.g., for debugging).
 func WithTestCaseWhitelist(testCases ...string) Option {


### PR DESCRIPTION
In the future  we want to have the capability to share certain entities with users that do not have full read/write access to parts of the used software. With "sharing" we mean having users with restricted access to specific entities, enforced by guard policies. This PR adds the `share` package which provides a `crud`-like HTTP handler as well as a kernel option and a wrapper for a `db_repo.Repository`. It also defines a `Share` entity, which consists of:
* The ID of the targeted entity
* The ID of the owning entity (i.e. the user)
* The ID of the guard policy (given the SqlWarden is used)

When using this new package to create entity shares there one wants to do the following things:
1. Add the new kernel option the the target applications options - this will create a table for the new shares (similar to the change history option)
2. Configure the table names of the share feature in the application config
3. Create a new  create-handler for shares to a specific entity (it will add a `/share` path to the entity path) and add it in the applications `apiserver.Definer`
4. Wrap the repository of the entity with the new share repository wrapper (so that the shares and policies of an entity will be updated/deleted if the entity itself is updates/deleted), you will need to provide a repository that can access the table of the shares
5. Implement the `Shareable` interface for the entity one wants to share
6. (optional) Implement a list and delete handler for the shares in the new table