### PR TITLE
apiserver: added download handler

### DIFF
--- a/pkg/apiserver/handler.go
+++ b/pkg/apiserver/handler.go
@@ -174,6 +174,10 @@ func CreateStreamHandler(handler HandlerWithStream) gin.HandlerFunc {
 	return handleWithStream(handler, binding.JSON, defaultErrorHandler)
 }
 
+func CreateDownloadHandler(handler HandlerWithStream) gin.HandlerFunc {
+	return handleWithStream(handler, binding.Query, defaultErrorHandler)
+}
+
 func handleWithInput(handler HandlerWithInput, binding binding.Binding, errHandler ErrorHandler) gin.HandlerFunc {
 	return func(ginCtx *gin.Context) {
 		input := handler.GetInput()


### PR DESCRIPTION
Currently the stream handler only supports sending a POST request with a request body. If you want to use a streaming response to continually write a file (i.e. image, zip ...) continually to the HTTP client (so basically just a file download), usually issuing a GET request on URL which completely identifies the resource to download should suffice. Also when using the `download` attribute on an HTML anchor the browser is only able to issue GET requests. This PR adds a new type of stream handler, namely the `DownloadHandler` which can be used to receive GET requests and write out responses like files to the output writer. 