### PR TITLE
guard: added small 1-minute cache for policy queries;

### DIFF
--- a/pkg/guard/cache_sql.go
+++ b/pkg/guard/cache_sql.go
@@ -1,0 +1,56 @@
+package guard
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/justtrackio/gosoline/pkg/kvstore"
+	"github.com/ory/ladon"
+)
+
+type SqlCache interface {
+	WithCache(query string, args []interface{}, provideValue func() (ladon.Policies, error)) (ladon.Policies, error)
+}
+
+type sqlCache struct {
+	cache kvstore.KvStore
+}
+
+func NewCache() SqlCache {
+	return &sqlCache{
+		cache: kvstore.NewInMemoryKvStoreWithInterfaces(&kvstore.Settings{
+			Ttl: time.Minute,
+		}),
+	}
+}
+
+func (k sqlCache) WithCache(query string, args []interface{}, provideValue func() (ladon.Policies, error)) (ladon.Policies, error) {
+	cacheKeyParts := []string{
+		query,
+	}
+	for _, arg := range args {
+		cacheKeyParts = append(cacheKeyParts, fmt.Sprint(arg))
+	}
+	cacheKey := strings.Join(cacheKeyParts, "\u2063")
+
+	result := ladon.Policies{}
+	found, err := k.cache.Get(context.Background(), cacheKey, &result)
+	if err != nil {
+		found = false
+	}
+
+	if found {
+		return result, nil
+	}
+
+	result, err = provideValue()
+	if err != nil {
+		return nil, err
+	}
+
+	_ = k.cache.Put(context.Background(), cacheKey, result)
+
+	return result, nil
+}

--- a/pkg/guard/cache_sql_test.go
+++ b/pkg/guard/cache_sql_test.go
@@ -1,0 +1,62 @@
+package guard_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/guard"
+	"github.com/ory/ladon"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSqlCache_ErrorsNotCached(t *testing.T) {
+	cache := guard.NewCache()
+
+	calledCount := 0
+	for i := 0; i < 10; i++ {
+		result, err := cache.WithCache("query", []interface{}{"arg"}, func() (ladon.Policies, error) {
+			calledCount++
+
+			return nil, fmt.Errorf("fail")
+		})
+		assert.Nil(t, result)
+		assert.EqualError(t, err, "fail")
+		assert.Equal(t, i+1, calledCount)
+	}
+}
+
+func TestSqlCache_ResultsCached(t *testing.T) {
+	cache := guard.NewCache()
+
+	calledCount := 0
+	for i := 0; i < 10; i++ {
+		result, err := cache.WithCache("query", []interface{}{"arg"}, func() (ladon.Policies, error) {
+			calledCount++
+
+			return ladon.Policies{nil}, nil
+		})
+
+		assert.Equal(t, ladon.Policies{nil}, result)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, calledCount)
+	}
+}
+
+func TestSqlCache_DifferentResultsCachedDifferently(t *testing.T) {
+	cache := guard.NewCache()
+
+	calledCount := 0
+	for i := 0; i < 10; i++ {
+		for j := 0; j < 10; j++ {
+			result, err := cache.WithCache("query", []interface{}{"arg", i}, func() (ladon.Policies, error) {
+				calledCount++
+
+				return make(ladon.Policies, i), nil
+			})
+
+			assert.Equal(t, make(ladon.Policies, i), result)
+			assert.NoError(t, err)
+			assert.Equal(t, i+1, calledCount)
+		}
+	}
+}

--- a/pkg/guard/guard.go
+++ b/pkg/guard/guard.go
@@ -25,11 +25,11 @@ type Manager interface {
 	ladon.Manager
 }
 
-type LadonGuard struct {
+type ladonGuard struct {
 	warden *ladon.Ladon
 }
 
-func NewGuard(config cfg.Config, logger log.Logger) (*LadonGuard, error) {
+func NewGuard(config cfg.Config, logger log.Logger) (Guard, error) {
 	sqlManager, err := NewSqlManager(config, logger)
 	if err != nil {
 		return nil, fmt.Errorf("can not create sqlManager: %w", err)
@@ -38,21 +38,21 @@ func NewGuard(config cfg.Config, logger log.Logger) (*LadonGuard, error) {
 	return NewGuardWithInterfaces(sqlManager), nil
 }
 
-func NewGuardWithInterfaces(manager Manager) *LadonGuard {
+func NewGuardWithInterfaces(manager Manager) Guard {
 	warden := &ladon.Ladon{
 		Manager: manager,
 	}
 
-	return &LadonGuard{
+	return &ladonGuard{
 		warden: warden,
 	}
 }
 
-func (g LadonGuard) IsAllowed(request *ladon.Request) error {
+func (g ladonGuard) IsAllowed(request *ladon.Request) error {
 	return g.warden.IsAllowed(request)
 }
 
-func (g LadonGuard) GetPolicies() (ladon.Policies, error) {
+func (g ladonGuard) GetPolicies() (ladon.Policies, error) {
 	policies := make(ladon.Policies, 0)
 
 	offset := int64(0)
@@ -77,7 +77,7 @@ func (g LadonGuard) GetPolicies() (ladon.Policies, error) {
 	return policies, nil
 }
 
-func (g LadonGuard) GetPoliciesBySubject(subject string) (ladon.Policies, error) {
+func (g ladonGuard) GetPoliciesBySubject(subject string) (ladon.Policies, error) {
 	pol, err := g.warden.Manager.FindPoliciesForSubject(subject)
 	if err != nil {
 		return nil, fmt.Errorf("could not get policies by subject: %w", err)
@@ -86,7 +86,7 @@ func (g LadonGuard) GetPoliciesBySubject(subject string) (ladon.Policies, error)
 	return pol, nil
 }
 
-func (g LadonGuard) CreatePolicy(pol ladon.Policy) error {
+func (g ladonGuard) CreatePolicy(pol ladon.Policy) error {
 	err := g.warden.Manager.Create(pol)
 	if err != nil {
 		return fmt.Errorf("could not create policy: %w", err)
@@ -95,7 +95,7 @@ func (g LadonGuard) CreatePolicy(pol ladon.Policy) error {
 	return nil
 }
 
-func (g LadonGuard) UpdatePolicy(pol ladon.Policy) error {
+func (g ladonGuard) UpdatePolicy(pol ladon.Policy) error {
 	err := g.warden.Manager.Update(pol)
 	if err != nil {
 		return fmt.Errorf("could not update policy: %w", err)
@@ -104,7 +104,7 @@ func (g LadonGuard) UpdatePolicy(pol ladon.Policy) error {
 	return nil
 }
 
-func (g LadonGuard) DeletePolicy(pol ladon.Policy) error {
+func (g ladonGuard) DeletePolicy(pol ladon.Policy) error {
 	err := g.warden.Manager.Delete(pol.GetID())
 	if err != nil {
 		return fmt.Errorf("could not delete policy: %w", err)

--- a/pkg/guard/guard_test.go
+++ b/pkg/guard/guard_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/justtrackio/gosoline/pkg/guard/mocks"
 )
 
-// Test LadonGuard::GetPolicies
+// Test ladonGuard::GetPolicies
 // Testing the other functions does not make any sense here, as they're wrapping just manager methods
 
 func TestLadonGuard_GetPolicies(t *testing.T) {


### PR DESCRIPTION
If you load a large number of models, we are currently checking the access permissions to each model. This causes us to make a lot of redundant SQL queries, all asking for the same ladon policies. To reduce this overhead, this commit adds a 1-minute in-memory for these SQL queries, thus we don't repeat them that often, cutting the number of SQL queries we do on some pages by around 30%.