### PR TITLE
Add functional helpers package

### DIFF
--- a/docs/fixtures/readme.md
+++ b/docs/fixtures/readme.md
@@ -72,9 +72,9 @@ func createFixtures() []*fixtures.FixtureSet {
 			Fixtures: []interface{}{
 				&OrmFixtureExample{
 					Model: db_repo.Model{
-						Id: mdl.Uint(1),
+						Id: mdl.Box(uint(1)),
 					},
-					Name: mdl.String("example"),
+					Name: mdl.Box("example"),
 				},
 			},
 		},

--- a/docs/more_details/integration_tests.md
+++ b/docs/more_details/integration_tests.md
@@ -32,8 +32,8 @@ func (s *ConsumerTestSuite) TestSuccessTwice(app suite.AppUnderTest) {
 	consumer := s.Env().StreamInput("consumerInput")
 	s.NotNil(consumer)
 
-	consumer.Publish(mdl.Uint(2), nil)
-	consumer.Publish(mdl.Uint(3), nil)
+	consumer.Publish(mdl.Box(uint(2)), nil)
+	consumer.Publish(mdl.Box(uint(3)), nil)
 
 	app.Stop()
 	app.WaitDone()
@@ -141,7 +141,7 @@ func (s *ConsumerTestSuite) TestSuccess() *suite.StreamTestCase {
 			"consumerInput": {
 				{
 					Attributes: nil,
-					Body:       mdl.Uint(5),
+					Body:       mdl.Box(uint(5)),
 				},
 			},
 		},

--- a/examples/fixtures/main.go
+++ b/examples/fixtures/main.go
@@ -40,9 +40,9 @@ func createFixtures() []*fixtures.FixtureSet {
 			Fixtures: []interface{}{
 				&OrmFixtureExample{
 					Model: db_repo.Model{
-						Id: mdl.Uint(1),
+						Id: mdl.Box(uint(1)),
 					},
-					Name: mdl.String("example"),
+					Name: mdl.Box("example"),
 				},
 			},
 		},

--- a/examples/metrics/prometheus/counter/counter.go
+++ b/examples/metrics/prometheus/counter/counter.go
@@ -23,7 +23,7 @@ func NewCounterController() *counterController {
 
 	return &counterController{
 		mw: mw,
-		c:  mdl.Int64(0),
+		c:  mdl.Box(int64(0)),
 	}
 }
 

--- a/examples/more_details/stream-consumer-test/stream_consumer_test.go
+++ b/examples/more_details/stream-consumer-test/stream_consumer_test.go
@@ -41,7 +41,7 @@ func (s *ConsumerTestSuite) TestSuccess() *suite.StreamTestCase {
 			"consumerInput": {
 				{
 					Attributes: nil,
-					Body:       mdl.Uint(5),
+					Body:       mdl.Box(uint(5)),
 				},
 			},
 		},
@@ -60,8 +60,8 @@ func (s *ConsumerTestSuite) TestSuccessTwice(app suite.AppUnderTest) {
 	consumer := s.Env().StreamInput("consumerInput")
 	s.NotNil(consumer)
 
-	consumer.Publish(mdl.Uint(2), nil)
-	consumer.Publish(mdl.Uint(3), nil)
+	consumer.Publish(mdl.Box(uint(2)), nil)
+	consumer.Publish(mdl.Box(uint(3)), nil)
 
 	app.Stop()
 	app.WaitDone()

--- a/examples/more_details/stream-consumer/consumer/consumer.go
+++ b/examples/more_details/stream-consumer/consumer/consumer.go
@@ -29,7 +29,7 @@ type Consumer struct {
 }
 
 func (c *Consumer) GetModel(map[string]interface{}) interface{} {
-	return mdl.Uint(0)
+	return mdl.Box(uint(0))
 }
 
 func (c *Consumer) Consume(ctx context.Context, model interface{}, _ map[string]interface{}) (bool, error) {

--- a/go.mod
+++ b/go.mod
@@ -64,10 +64,10 @@ require (
 	github.com/sha1sum/aws_signing_client v0.0.0-20170514202702-9088e4c7b34b
 	github.com/spf13/cast v1.4.1
 	github.com/stretchr/testify v1.7.1
-	github.com/thoas/go-funk v0.0.0-20181020164546-fbae87fb5b5c
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	github.com/xitongsys/parquet-go v1.4.0
 	github.com/xitongsys/parquet-go-source v0.0.0-20191104003508-ecfa341356a6
+	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886
 	google.golang.org/api v0.74.0
@@ -121,7 +121,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/googleapis/gax-go/v2 v2.2.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/golang-lru v0.5.1 // indirect
+	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.11.0 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
@@ -129,6 +129,7 @@ require (
 	github.com/jackc/pgproto3/v2 v2.2.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
 	github.com/jackc/pgtype v1.10.0 // indirect
+	github.com/jinzhu/now v1.1.3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/karlseguin/expect v1.0.8 // indirect
@@ -157,12 +158,12 @@ require (
 	github.com/ugorji/go/codec v1.1.7 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.34.0 // indirect
-	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da // indirect
 	go.opencensus.io v0.23.0 // indirect
-	go.uber.org/atomic v1.6.0 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	golang.org/x/net v0.0.0-20220325170049-de3da57026de // indirect
 	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a // indirect

--- a/go.sum
+++ b/go.sum
@@ -656,8 +656,8 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-github/v35 v35.2.0/go.mod h1:s0515YVTI+IMrDoy9Y4pHt9ShGpzHvHO8rZ7L7acgvs=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
@@ -727,8 +727,9 @@ github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
+github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
@@ -814,8 +815,9 @@ github.com/jinzhu/gorm v1.9.16/go.mod h1:G3LB3wezTOWM2ITLzPxEXgSkOXAntiLHS7UdBef
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
-github.com/jinzhu/now v1.1.1 h1:g39TucaRWyV3dwDO++eEc6qf8TVIQ/Da48WmqjZ3i7E=
 github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/jinzhu/now v1.1.3 h1:PlHq1bSCSZL9K0wUhbm2pGLoTWs2GwVhsP6emvGV/ZI=
+github.com/jinzhu/now v1.1.3/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -1167,8 +1169,6 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
-github.com/thoas/go-funk v0.0.0-20181020164546-fbae87fb5b5c h1:3sFKuGerP3mGyXo7gDR1dGQ6GdIrI8s5KWmct0R5J6A=
-github.com/thoas/go-funk v0.0.0-20181020164546-fbae87fb5b5c/go.mod h1:mlR+dHGb+4YgXkf13rkQTuzrneeHANxOm6+ZnEV9HsA=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -1202,8 +1202,9 @@ github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVT
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=
-github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
@@ -1247,8 +1248,9 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
-go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
+go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
+go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
@@ -1299,6 +1301,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d h1:vtUKgx8dahOomfFzLREU8nSv25YHnTgLBn4rDnWZdU0=
+golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -1319,7 +1323,6 @@ golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRu
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -1634,7 +1637,6 @@ golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/apiserver/auth/config_key.go
+++ b/pkg/apiserver/auth/config_key.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"net/http"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/gin-gonic/gin"
 	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/funk"
 	"github.com/justtrackio/gosoline/pkg/log"
-	"github.com/thoas/go-funk"
 )
 
 const (
@@ -46,7 +48,7 @@ func NewConfigKeyHandler(config cfg.Config, logger log.Logger, provider ApiKeyPr
 
 func NewConfigKeyAuthenticator(config cfg.Config, logger log.Logger, provider ApiKeyProvider) Authenticator {
 	keys := config.GetStringSlice(configApiKeys)
-	keys = funk.FilterString(keys, func(key string) bool {
+	keys = funk.Filter(keys, func(key string) bool {
 		return key != ""
 	})
 
@@ -72,7 +74,7 @@ func (a *configKeyAuthenticator) IsValid(ginCtx *gin.Context) (bool, error) {
 		return false, fmt.Errorf("there are no api keys configured")
 	}
 
-	if !funk.ContainsString(a.keys, apiKey) {
+	if !slices.Contains(a.keys, apiKey) {
 		return false, fmt.Errorf("api key does not match")
 	}
 

--- a/pkg/apiserver/crud/crud_test.go
+++ b/pkg/apiserver/crud/crud_test.go
@@ -98,13 +98,13 @@ func (h Handler) List(_ context.Context, _ *db_repo.QueryBuilder, _ string) (int
 	return []Model{
 		{
 			Model: db_repo.Model{
-				Id: mdl.Uint(1),
+				Id: mdl.Box(uint(1)),
 				Timestamps: db_repo.Timestamps{
-					UpdatedAt: mdl.Time(date),
-					CreatedAt: mdl.Time(date),
+					UpdatedAt: mdl.Box(date),
+					CreatedAt: mdl.Box(date),
 				},
 			},
-			Name: mdl.String("foobar"),
+			Name: mdl.Box("foobar"),
 		},
 	}, nil
 }
@@ -117,11 +117,11 @@ func NewTransformer() Handler {
 	}
 }
 
-var id1 = mdl.Uint(1)
+var id1 = mdl.Box(uint(1))
 
 func TestCreateHandler_Handle(t *testing.T) {
 	model := &Model{
-		Name: mdl.String("foobar"),
+		Name: mdl.Box("foobar"),
 	}
 
 	logger := logMocks.NewLoggerMockedAll()
@@ -129,12 +129,12 @@ func TestCreateHandler_Handle(t *testing.T) {
 
 	transformer.Repo.On("Create", mock.AnythingOfType("*context.emptyCtx"), model).Run(func(args mock.Arguments) {
 		model := args.Get(1).(*Model)
-		model.Id = mdl.Uint(1)
+		model.Id = mdl.Box(uint(1))
 	}).Return(nil)
-	transformer.Repo.On("Read", mock.AnythingOfType("*context.emptyCtx"), mdl.Uint(1), &Model{}).Run(func(args mock.Arguments) {
+	transformer.Repo.On("Read", mock.AnythingOfType("*context.emptyCtx"), mdl.Box(uint(1)), &Model{}).Run(func(args mock.Arguments) {
 		model := args.Get(2).(*Model)
-		model.Id = mdl.Uint(1)
-		model.Name = mdl.String("foobar")
+		model.Id = mdl.Box(uint(1))
+		model.Name = mdl.Box("foobar")
 		model.UpdatedAt = &time.Time{}
 		model.CreatedAt = &time.Time{}
 	}).Return(nil)
@@ -152,7 +152,7 @@ func TestCreateHandler_Handle(t *testing.T) {
 
 func TestCreateHandler_Handle_ValidationError(t *testing.T) {
 	model := &Model{
-		Name: mdl.String("foobar"),
+		Name: mdl.Box("foobar"),
 	}
 
 	logger := logMocks.NewLoggerMockedAll()
@@ -178,10 +178,10 @@ func TestReadHandler_Handle(t *testing.T) {
 
 	logger := logMocks.NewLoggerMockedAll()
 	transformer := NewTransformer()
-	transformer.Repo.On("Read", mock.AnythingOfType("*context.emptyCtx"), mdl.Uint(1), model).Run(func(args mock.Arguments) {
+	transformer.Repo.On("Read", mock.AnythingOfType("*context.emptyCtx"), mdl.Box(uint(1)), model).Run(func(args mock.Arguments) {
 		model := args.Get(2).(*Model)
-		model.Id = mdl.Uint(1)
-		model.Name = mdl.String("foobar")
+		model.Id = mdl.Box(uint(1))
+		model.Name = mdl.Box("foobar")
 		model.UpdatedAt = &time.Time{}
 		model.CreatedAt = &time.Time{}
 	}).Return(nil)
@@ -200,23 +200,23 @@ func TestUpdateHandler_Handle(t *testing.T) {
 	readModel := &Model{}
 	updateModel := &Model{
 		Model: db_repo.Model{
-			Id: mdl.Uint(1),
+			Id: mdl.Box(uint(1)),
 			Timestamps: db_repo.Timestamps{
 				UpdatedAt: &time.Time{},
 				CreatedAt: &time.Time{},
 			},
 		},
-		Name: mdl.String("updated"),
+		Name: mdl.Box("updated"),
 	}
 
 	logger := logMocks.NewLoggerMockedAll()
 	transformer := NewTransformer()
 
 	transformer.Repo.On("Update", mock.AnythingOfType("*context.emptyCtx"), updateModel).Return(nil)
-	transformer.Repo.On("Read", mock.AnythingOfType("*context.emptyCtx"), mdl.Uint(1), readModel).Run(func(args mock.Arguments) {
+	transformer.Repo.On("Read", mock.AnythingOfType("*context.emptyCtx"), mdl.Box(uint(1)), readModel).Run(func(args mock.Arguments) {
 		model := args.Get(2).(*Model)
-		model.Id = mdl.Uint(1)
-		model.Name = mdl.String("updated")
+		model.Id = mdl.Box(uint(1))
+		model.Name = mdl.Box("updated")
 		model.UpdatedAt = &time.Time{}
 		model.CreatedAt = &time.Time{}
 	}).Return(nil)
@@ -236,13 +236,13 @@ func TestUpdateHandler_Handle_ValidationError(t *testing.T) {
 	readModel := &Model{}
 	updateModel := &Model{
 		Model: db_repo.Model{
-			Id: mdl.Uint(1),
+			Id: mdl.Box(uint(1)),
 			Timestamps: db_repo.Timestamps{
 				UpdatedAt: &time.Time{},
 				CreatedAt: &time.Time{},
 			},
 		},
-		Name: mdl.String("updated"),
+		Name: mdl.Box("updated"),
 	}
 
 	logger := logMocks.NewLoggerMockedAll()
@@ -251,10 +251,10 @@ func TestUpdateHandler_Handle_ValidationError(t *testing.T) {
 	transformer.Repo.On("Update", mock.AnythingOfType("*context.emptyCtx"), updateModel).Return(&validation.Error{
 		Errors: []error{fmt.Errorf("invalid foobar")},
 	})
-	transformer.Repo.On("Read", mock.AnythingOfType("*context.emptyCtx"), mdl.Uint(1), readModel).Run(func(args mock.Arguments) {
+	transformer.Repo.On("Read", mock.AnythingOfType("*context.emptyCtx"), mdl.Box(uint(1)), readModel).Run(func(args mock.Arguments) {
 		model := args.Get(2).(*Model)
-		model.Id = mdl.Uint(1)
-		model.Name = mdl.String("updated")
+		model.Id = mdl.Box(uint(1))
+		model.Name = mdl.Box("updated")
 		model.UpdatedAt = &time.Time{}
 		model.CreatedAt = &time.Time{}
 	}).Return(nil)
@@ -280,7 +280,7 @@ func TestDeleteHandler_Handle(t *testing.T) {
 				CreatedAt: &time.Time{},
 			},
 		},
-		Name: mdl.String("foobar"),
+		Name: mdl.Box("foobar"),
 	}
 
 	logger := logMocks.NewLoggerMockedAll()
@@ -288,7 +288,7 @@ func TestDeleteHandler_Handle(t *testing.T) {
 	transformer.Repo.On("Read", mock.AnythingOfType("*context.emptyCtx"), mock.AnythingOfType("*uint"), model).Run(func(args mock.Arguments) {
 		model := args.Get(2).(*Model)
 		model.Id = id1
-		model.Name = mdl.String("foobar")
+		model.Name = mdl.Box("foobar")
 		model.UpdatedAt = &time.Time{}
 		model.CreatedAt = &time.Time{}
 	}).Return(nil)
@@ -314,7 +314,7 @@ func TestDeleteHandler_Handle_ValidationError(t *testing.T) {
 				CreatedAt: &time.Time{},
 			},
 		},
-		Name: mdl.String("foobar"),
+		Name: mdl.Box("foobar"),
 	}
 
 	logger := logMocks.NewLoggerMockedAll()
@@ -322,7 +322,7 @@ func TestDeleteHandler_Handle_ValidationError(t *testing.T) {
 	transformer.Repo.On("Read", mock.AnythingOfType("*context.emptyCtx"), mock.AnythingOfType("*uint"), model).Run(func(args mock.Arguments) {
 		model := args.Get(2).(*Model)
 		model.Id = id1
-		model.Name = mdl.String("foobar")
+		model.Name = mdl.Box("foobar")
 		model.UpdatedAt = &time.Time{}
 		model.CreatedAt = &time.Time{}
 	}).Return(nil)

--- a/pkg/apiserver/error.go
+++ b/pkg/apiserver/error.go
@@ -10,7 +10,7 @@ type ErrorHandler func(statusCode int, err error) *Response
 func errorHandlerJson(statusCode int, err error) *Response {
 	return &Response{
 		StatusCode:  statusCode,
-		ContentType: mdl.String(ContentTypeJson),
+		ContentType: mdl.Box(ContentTypeJson),
 		Body:        gin.H{"err": err.Error()},
 	}
 }

--- a/pkg/apiserver/handler.go
+++ b/pkg/apiserver/handler.go
@@ -63,7 +63,7 @@ func NewResponse(body interface{}, contentType string, statusCode int, header ht
 func NewHtmlResponse(body interface{}) *Response {
 	return &Response{
 		StatusCode:  http.StatusOK,
-		ContentType: mdl.String(ContentTypeHtml),
+		ContentType: mdl.Box(ContentTypeHtml),
 		Body:        body,
 		Header:      make(http.Header),
 	}
@@ -72,7 +72,7 @@ func NewHtmlResponse(body interface{}) *Response {
 func NewJsonResponse(body interface{}) *Response {
 	return &Response{
 		StatusCode:  http.StatusOK,
-		ContentType: mdl.String(ContentTypeJson),
+		ContentType: mdl.Box(ContentTypeJson),
 		Body:        body,
 		Header:      make(http.Header),
 	}

--- a/pkg/apiserver/param_reader.go
+++ b/pkg/apiserver/param_reader.go
@@ -10,22 +10,22 @@ func GetUintFromRequest(request *Request, name string) (*uint, bool) {
 	paramString, found := request.Params.Get(name)
 
 	if !found {
-		return mdl.Uint(0), false
+		return mdl.Box(uint(0)), false
 	}
 
 	param, err := strconv.Atoi(paramString)
 	if err != nil {
-		return mdl.Uint(0), false
+		return mdl.Box(uint(0)), false
 	}
 
-	return mdl.Uint(uint(param)), true
+	return mdl.Box(uint(param)), true
 }
 
 func GetStringFromRequest(request *Request, name string) (*string, bool) {
 	paramString, found := request.Params.Get(name)
 
 	if !found {
-		return mdl.String(""), false
+		return mdl.Box(""), false
 	}
 
 	return &paramString, true

--- a/pkg/blob/service.go
+++ b/pkg/blob/service.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/justtrackio/gosoline/pkg/funk"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -11,7 +13,6 @@ import (
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	gosoS3 "github.com/justtrackio/gosoline/pkg/cloud/aws/s3"
 	"github.com/justtrackio/gosoline/pkg/log"
-	"github.com/thoas/go-funk"
 )
 
 type Service struct {
@@ -30,7 +31,7 @@ func NewService(ctx context.Context, config cfg.Config, logger log.Logger) (*Ser
 }
 
 func (s *Service) DeleteObjects(ctx context.Context, bucket string, objects []*types.Object) error {
-	chunks := funk.Chunk(objects, 1000).([][]*types.Object)
+	chunks := funk.Chunk(objects, 1000)
 
 	for _, chunk := range chunks {
 		if err := s.deleteChunk(ctx, bucket, chunk); err != nil {

--- a/pkg/blob/store.go
+++ b/pkg/blob/store.go
@@ -142,8 +142,8 @@ func NewStoreWithInterfaces(logger log.Logger, channels *BatchRunnerChannels, cl
 		logger:   logger,
 		channels: channels,
 		client:   client,
-		bucket:   mdl.String(settings.Bucket),
-		prefix:   mdl.String(settings.Prefix),
+		bucket:   mdl.Box(settings.Bucket),
+		prefix:   mdl.Box(settings.Prefix),
 	}
 }
 
@@ -308,10 +308,10 @@ func (o *CopyObject) GetFullKey() string {
 }
 
 func getFullKey(prefixPtr, keyPtr *string) string {
-	key := mdl.EmptyStringIfNil(keyPtr)
+	key := mdl.EmptyIfNil(keyPtr)
 	key = strings.TrimLeft(key, "/")
 
-	prefix := mdl.EmptyStringIfNil(prefixPtr)
+	prefix := mdl.EmptyIfNil(prefixPtr)
 	prefix = strings.TrimRight(prefix, "/")
 
 	fullKey := fmt.Sprintf("%s/%s", prefix, key)
@@ -320,7 +320,7 @@ func getFullKey(prefixPtr, keyPtr *string) string {
 }
 
 func (o *CopyObject) getSource() string {
-	sourceKey := mdl.EmptyStringIfNil(o.SourceKey)
+	sourceKey := mdl.EmptyIfNil(o.SourceKey)
 	if o.SourceBucket == nil {
 		sourceKey = getFullKey(o.prefix, o.SourceKey)
 		o.SourceBucket = o.bucket
@@ -330,7 +330,7 @@ func (o *CopyObject) getSource() string {
 		sourceKey = "/" + sourceKey
 	}
 
-	return fmt.Sprintf("%s%s", mdl.EmptyStringIfNil(o.SourceBucket), sourceKey)
+	return fmt.Sprintf("%s%s", mdl.EmptyIfNil(o.SourceBucket), sourceKey)
 }
 
 func isBucketAlreadyExistsError(err error) bool {

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -12,7 +12,7 @@ import (
 	"github.com/justtrackio/gosoline/pkg/mapx"
 	"github.com/justtrackio/gosoline/pkg/refl"
 	"github.com/spf13/cast"
-	"github.com/thoas/go-funk"
+	"golang.org/x/exp/maps"
 )
 
 type LookupEnv func(key string) (string, bool)
@@ -75,7 +75,7 @@ func NewWithInterfaces(envProvider EnvProvider) GosoConf {
 }
 
 func (c *config) AllKeys() []string {
-	return funk.Keys(c.settings.Msi()).([]string)
+	return maps.Keys(c.settings.Msi())
 }
 
 func (c *config) AllSettings() map[string]interface{} {

--- a/pkg/cfg/debug.go
+++ b/pkg/cfg/debug.go
@@ -3,22 +3,22 @@ package cfg
 import (
 	"crypto/md5"
 	"fmt"
-	"github.com/jeremywohl/flatten"
-	"github.com/thoas/go-funk"
 	"sort"
 	"strings"
+
+	"github.com/jeremywohl/flatten"
+	"golang.org/x/exp/maps"
 )
 
 func DebugConfig(config Config, logger Logger) error {
 	settings := config.AllSettings()
 	flattened, err := flatten.Flatten(settings, "", flatten.DotStyle)
-
 	if err != nil {
 		return fmt.Errorf("can not flatten config settings")
 	}
 
 	hashValues := make([]string, len(flattened))
-	keys := funk.Keys(flattened).([]string)
+	keys := maps.Keys(flattened)
 	sort.Strings(keys)
 
 	for i, key := range keys {

--- a/pkg/cloud/aws/kinesis/checkpoint.go
+++ b/pkg/cloud/aws/kinesis/checkpoint.go
@@ -72,7 +72,7 @@ func (c *checkpoint) Done(sequenceNumber SequenceNumber) error {
 	}
 	defer c.lck.Unlock()
 
-	c.finishedAt = mdl.Time(c.clock.Now())
+	c.finishedAt = mdl.Box(c.clock.Now())
 	c.finalSequenceNumber = sequenceNumber
 
 	return nil
@@ -89,7 +89,7 @@ func (c *checkpoint) Persist(ctx context.Context) (shouldRelease bool, err error
 			Namespace: c.namespace,
 			Resource:  string(c.shardId),
 			UpdatedAt: c.clock.Now(),
-			Ttl:       mdl.Int64(c.clock.Now().Add(ShardTimeout).Unix()),
+			Ttl:       mdl.Box(c.clock.Now().Add(ShardTimeout).Unix()),
 		},
 		OwningClientId: c.owningClientId,
 		SequenceNumber: c.sequenceNumber,
@@ -118,7 +118,7 @@ func (c *checkpoint) Release(ctx context.Context) error {
 			WithRange(c.shardId).
 			Remove("owningClientId").
 			Set("updatedAt", c.clock.Now()).
-			Set("ttl", mdl.Int64(c.clock.Now().Add(ShardTimeout).Unix())).
+			Set("ttl", mdl.Box(c.clock.Now().Add(ShardTimeout).Unix())).
 			Set("sequenceNumber", c.sequenceNumber).
 			WithCondition(ddb.Eq("owningClientId", c.owningClientId))
 		if result, err := c.repo.UpdateItem(ctx, qb, &CheckpointRecord{}); err != nil {

--- a/pkg/cloud/aws/kinesis/kinsumer.go
+++ b/pkg/cloud/aws/kinesis/kinsumer.go
@@ -302,7 +302,7 @@ func (k *kinsumer) listShardIds(ctx context.Context) ([]ShardId, error) {
 		}
 
 		for _, s := range res.Shards {
-			shardId := ShardId(mdl.EmptyStringIfNil(s.ShardId))
+			shardId := ShardId(mdl.EmptyIfNil(s.ShardId))
 			finished, err := k.metadataRepository.IsShardFinished(ctx, shardId)
 			if err != nil {
 				return nil, fmt.Errorf("could not check if shard is already finished: %w", err)
@@ -310,7 +310,7 @@ func (k *kinsumer) listShardIds(ctx context.Context) ([]ShardId, error) {
 
 			shardMap[shardId] = shardInfo{
 				finished: finished,
-				parent:   ShardId(mdl.EmptyStringIfNil(s.ParentShardId)),
+				parent:   ShardId(mdl.EmptyIfNil(s.ParentShardId)),
 			}
 		}
 

--- a/pkg/cloud/aws/kinesis/kinsumer_test.go
+++ b/pkg/cloud/aws/kinesis/kinsumer_test.go
@@ -313,28 +313,28 @@ func (s *kinsumerTestSuite) TestShardListFinishedShardHandling() {
 		NextToken: nil,
 		Shards: []types.Shard{
 			{
-				ShardId:       mdl.String("finished shard with no parent"),
+				ShardId:       mdl.Box("finished shard with no parent"),
 				ParentShardId: nil,
 			},
 			{
-				ShardId:       mdl.String("finished shard with parent"),
-				ParentShardId: mdl.String("finished shard with no parent"),
+				ShardId:       mdl.Box("finished shard with parent"),
+				ParentShardId: mdl.Box("finished shard with no parent"),
 			},
 			{
-				ShardId:       mdl.String("unfinished shard with no parent"),
+				ShardId:       mdl.Box("unfinished shard with no parent"),
 				ParentShardId: nil,
 			},
 			{
-				ShardId:       mdl.String("unfinished shard with non-existing parent"),
-				ParentShardId: mdl.String("doesn't exist"),
+				ShardId:       mdl.Box("unfinished shard with non-existing parent"),
+				ParentShardId: mdl.Box("doesn't exist"),
 			},
 			{
-				ShardId:       mdl.String("unfinished shard with unfinished parent"),
-				ParentShardId: mdl.String("unfinished shard with no parent"),
+				ShardId:       mdl.Box("unfinished shard with unfinished parent"),
+				ParentShardId: mdl.Box("unfinished shard with no parent"),
 			},
 			{
-				ShardId:       mdl.String("unfinished shard with finished parent"),
-				ParentShardId: mdl.String("finished shard with no parent"),
+				ShardId:       mdl.Box("unfinished shard with finished parent"),
+				ParentShardId: mdl.Box("finished shard with no parent"),
 			},
 		},
 	}, nil).Once()

--- a/pkg/cloud/aws/kinesis/metadata_repository.go
+++ b/pkg/cloud/aws/kinesis/metadata_repository.go
@@ -167,7 +167,7 @@ func (m *metadataRepository) RegisterClient(ctx context.Context) (clientIndex in
 			Namespace: namespace,
 			Resource:  string(m.clientId),
 			UpdatedAt: m.clock.Now(),
-			Ttl:       mdl.Int64(m.clock.Now().Add(m.clientTimeout).Unix()),
+			Ttl:       mdl.Box(m.clock.Now().Add(m.clientTimeout).Unix()),
 		},
 	})
 	if err != nil {
@@ -256,7 +256,7 @@ func (m *metadataRepository) AcquireShard(ctx context.Context, shardId ShardId) 
 				Namespace: namespace,
 				Resource:  string(shardId),
 				UpdatedAt: m.clock.Now(),
-				Ttl:       mdl.Int64(m.clock.Now().Add(ShardTimeout).Unix()),
+				Ttl:       mdl.Box(m.clock.Now().Add(ShardTimeout).Unix()),
 			},
 			OwningClientId: m.clientId,
 			SequenceNumber: "",
@@ -283,7 +283,7 @@ func (m *metadataRepository) AcquireShard(ctx context.Context, shardId ShardId) 
 
 		record.OwningClientId = m.clientId
 		record.UpdatedAt = m.clock.Now()
-		record.Ttl = mdl.Int64(m.clock.Now().Add(ShardTimeout).Unix())
+		record.Ttl = mdl.Box(m.clock.Now().Add(ShardTimeout).Unix())
 	}
 
 	putQb := m.repo.PutItemBuilder().

--- a/pkg/cloud/aws/kinesis/record_writer.go
+++ b/pkg/cloud/aws/kinesis/record_writer.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/justtrackio/gosoline/pkg/funk"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
@@ -16,7 +18,6 @@ import (
 	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/justtrackio/gosoline/pkg/metric"
 	"github.com/justtrackio/gosoline/pkg/uuid"
-	"github.com/thoas/go-funk"
 )
 
 const (
@@ -108,7 +109,7 @@ func (w *recordWriter) PutRecords(ctx context.Context, records []*Record) error 
 	})
 
 	var err, errs error
-	chunks := funk.Chunk(records, kinesisBatchSizeMax).([][]*Record)
+	chunks := funk.Chunk(records, kinesisBatchSizeMax)
 
 	for _, chunk := range chunks {
 		if err = w.putRecordsBatch(ctx, chunk); err != nil {

--- a/pkg/cloud/aws/kinesis/shard_reader_test.go
+++ b/pkg/cloud/aws/kinesis/shard_reader_test.go
@@ -486,7 +486,7 @@ func (s *shardReaderTestSuite) TestConsumeDelayWithWait() {
 			{
 				Data:                        []byte("data 1"),
 				SequenceNumber:              aws.String("seq 1"),
-				ApproximateArrivalTimestamp: mdl.Time(s.clock.Now()),
+				ApproximateArrivalTimestamp: mdl.Box(s.clock.Now()),
 			},
 		},
 		MillisBehindLatest: aws.Int64(0),
@@ -545,7 +545,7 @@ func (s *shardReaderTestSuite) TestConsumeDelayWithOldRecord() {
 			{
 				Data:                        []byte("data 1"),
 				SequenceNumber:              aws.String("seq 1"),
-				ApproximateArrivalTimestamp: mdl.Time(recordArrivalTime),
+				ApproximateArrivalTimestamp: mdl.Box(recordArrivalTime),
 			},
 		},
 		MillisBehindLatest: aws.Int64(0),
@@ -607,7 +607,7 @@ func (s *shardReaderTestSuite) TestConsumeDelayWithCancelDuringWait() {
 			{
 				Data:                        []byte("data 1"),
 				SequenceNumber:              aws.String("seq 1"),
-				ApproximateArrivalTimestamp: mdl.Time(s.clock.Now()),
+				ApproximateArrivalTimestamp: mdl.Box(s.clock.Now()),
 			},
 		},
 		MillisBehindLatest: aws.Int64(0),

--- a/pkg/cloud/aws/sns/topic.go
+++ b/pkg/cloud/aws/sns/topic.go
@@ -3,6 +3,7 @@ package sns
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -13,7 +14,6 @@ import (
 	"github.com/justtrackio/gosoline/pkg/exec"
 	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/justtrackio/gosoline/pkg/mdl"
-	"github.com/thoas/go-funk"
 )
 
 const MaxBatchSize = 10
@@ -158,7 +158,7 @@ func (t *snsTopic) computeEntries(messages []string, attributes []map[string]int
 		}
 
 		result[i] = types.PublishBatchRequestEntry{
-			Id:                mdl.String(strconv.Itoa(i)),
+			Id:                mdl.Box(strconv.Itoa(i)),
 			Message:           &messages[i],
 			MessageAttributes: messageAttributes,
 		}
@@ -305,7 +305,7 @@ func (t *snsTopic) subscriptionAttributesMatch(ctx context.Context, subscription
 		return false, fmt.Errorf("can not unmarshal expected filter policy: %w", err)
 	}
 
-	matches := funk.IsEqual(expectedAttributes, actualAttributes)
+	matches := reflect.DeepEqual(expectedAttributes, actualAttributes)
 
 	return matches, nil
 }

--- a/pkg/cloud/aws/sns/topic_test.go
+++ b/pkg/cloud/aws/sns/topic_test.go
@@ -200,8 +200,8 @@ func (s *TopicTestSuite) TestPublishBatch() {
 	entries := make([]types.PublishBatchRequestEntry, 10)
 	for i := 0; i < 10; i++ {
 		entries[i] = types.PublishBatchRequestEntry{
-			Id:                mdl.String(fmt.Sprintf("%d", i)),
-			Message:           mdl.String(fmt.Sprintf("%d", i+1)),
+			Id:                mdl.Box(fmt.Sprintf("%d", i)),
+			Message:           mdl.Box(fmt.Sprintf("%d", i+1)),
 			MessageAttributes: make(map[string]types.MessageAttributeValue),
 		}
 	}
@@ -216,8 +216,8 @@ func (s *TopicTestSuite) TestPublishBatch() {
 		TopicArn: aws.String("topicArn"),
 		PublishBatchRequestEntries: []types.PublishBatchRequestEntry{
 			{
-				Id:                mdl.String("10"),
-				Message:           mdl.String("11"),
+				Id:                mdl.Box("10"),
+				Message:           mdl.Box("11"),
 				MessageAttributes: make(map[string]types.MessageAttributeValue),
 			},
 		},

--- a/pkg/cloud/aws/sqs/queue.go
+++ b/pkg/cloud/aws/sqs/queue.go
@@ -13,9 +13,9 @@ import (
 	"github.com/justtrackio/gosoline/pkg/appctx"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/exec"
+	"github.com/justtrackio/gosoline/pkg/funk"
 	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/justtrackio/gosoline/pkg/uuid"
-	"github.com/thoas/go-funk"
 )
 
 const (
@@ -165,7 +165,7 @@ func (q *queue) SendBatch(ctx context.Context, messages []*Message) error {
 
 		half := float64(len(messages)) / 2
 		chunkSize := int(math.Ceil(half))
-		messageChunks := funk.Chunk(messages, chunkSize).([][]*Message)
+		messageChunks := funk.Chunk(messages, chunkSize)
 
 		for _, msgChunk := range messageChunks {
 			if err = q.SendBatch(ctx, msgChunk); err != nil {

--- a/pkg/db-repo/change_history_metadata.go
+++ b/pkg/db-repo/change_history_metadata.go
@@ -1,9 +1,11 @@
 package db_repo
 
 import (
-	"github.com/jinzhu/gorm"
-	"github.com/thoas/go-funk"
 	"strings"
+
+	"github.com/jinzhu/gorm"
+	"github.com/justtrackio/gosoline/pkg/funk"
+	"golang.org/x/exp/slices"
 )
 
 type columnMetadata struct {
@@ -117,17 +119,17 @@ func (m *tableMetadata) columnDefinitions() []string {
 func (m *tableMetadata) namesQuoted(items []columnMetadata) []string {
 	return funk.Map(items, func(item columnMetadata) string {
 		return item.nameQuoted
-	}).([]string)
+	})
 }
 
 func (m *tableMetadata) definitions(items []columnMetadata) []string {
 	return funk.Map(items, func(item columnMetadata) string {
 		return item.definition
-	}).([]string)
+	})
 }
 
 func (m *tableMetadata) columnNamesQuotedExcludingValue(excluded ...string) []string {
 	return m.namesQuoted(funk.Filter(m.columns, func(item columnMetadata) bool {
-		return !funk.ContainsString(excluded, item.name)
-	}).([]columnMetadata))
+		return !slices.Contains(excluded, item.name)
+	}))
 }

--- a/pkg/db-repo/notification_publisher_test.go
+++ b/pkg/db-repo/notification_publisher_test.go
@@ -18,7 +18,7 @@ func Test_Publish_Notifier(t *testing.T) {
 	}
 
 	transformer := func(view string, version int, in interface{}) (out interface{}) {
-		assert.Equal(t, mdl.Uint(3), in.(db_repo.ModelBased).GetId())
+		assert.Equal(t, mdl.Box(uint(3)), in.(db_repo.ModelBased).GetId())
 		assert.Equal(t, "api", view)
 		assert.Equal(t, 1, version)
 

--- a/pkg/db-repo/notification_sns_test.go
+++ b/pkg/db-repo/notification_sns_test.go
@@ -36,7 +36,7 @@ func Test_SNS_Notifier(t *testing.T) {
 	output := streamMocks.Output{}
 	output.On("WriteOne", context.Background(), &streamMessage).Return(nil).Once()
 	transformer := func(view string, version int, in interface{}) (out interface{}) {
-		assert.Equal(t, mdl.Uint(3), in.(db_repo.ModelBased).GetId())
+		assert.Equal(t, mdl.Box(uint(3)), in.(db_repo.ModelBased).GetId())
 		assert.Equal(t, "api", view)
 		assert.Equal(t, 55, version)
 
@@ -57,7 +57,7 @@ type modelBased struct {
 }
 
 func (m *modelBased) GetId() *uint {
-	return mdl.Uint(3)
+	return mdl.Box(uint(3))
 }
 
 func (m *modelBased) SetUpdatedAt(updatedAt *time.Time) {

--- a/pkg/db-repo/query_builder.go
+++ b/pkg/db-repo/query_builder.go
@@ -2,7 +2,7 @@ package db_repo
 
 import (
 	"github.com/justtrackio/gosoline/pkg/db"
-	"github.com/thoas/go-funk"
+	"github.com/justtrackio/gosoline/pkg/funk"
 )
 
 type page struct {
@@ -40,7 +40,7 @@ func (qb *QueryBuilder) Table(table string) db.QueryBuilder {
 }
 
 func (qb *QueryBuilder) Joins(joins []string) db.QueryBuilder {
-	qb.joins = funk.UniqString(joins)
+	qb.joins = funk.Uniq(joins)
 
 	return qb
 }

--- a/pkg/db-repo/repository.go
+++ b/pkg/db-repo/repository.go
@@ -194,14 +194,14 @@ func (r *repository) Update(ctx context.Context, value ModelBased) error {
 	err := r.orm.Save(value).Error
 
 	if db.IsDuplicateEntryError(err) {
-		logger.Warn("could not update model of type %s with id %d due to duplicate entry error: %s", modelId, mdl.EmptyUintIfNil(value.GetId()), err.Error())
+		logger.Warn("could not update model of type %s with id %d due to duplicate entry error: %s", modelId, mdl.EmptyIfNil(value.GetId()), err.Error())
 		return &db.DuplicateEntryError{
 			Err: err,
 		}
 	}
 
 	if err != nil {
-		logger.Error("could not update model of type %s with id %d: %w", modelId, mdl.EmptyUintIfNil(value.GetId()), err)
+		logger.Error("could not update model of type %s with id %d: %w", modelId, mdl.EmptyIfNil(value.GetId()), err)
 		return err
 	}
 

--- a/pkg/db-repo/repository_test.go
+++ b/pkg/db-repo/repository_test.go
@@ -111,9 +111,9 @@ func (a idMatcher) Match(id driver.Value) bool {
 }
 
 var (
-	id1  = mdl.Uint(1)
-	id42 = mdl.Uint(42)
-	id24 = mdl.Uint(24)
+	id1  = mdl.Box(uint(1))
+	id42 = mdl.Box(uint(42))
+	id24 = mdl.Box(uint(24))
 )
 
 func TestRepository_Create(t *testing.T) {

--- a/pkg/db/query_builder.go
+++ b/pkg/db/query_builder.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"github.com/Masterminds/squirrel"
-	"github.com/thoas/go-funk"
+	"github.com/justtrackio/gosoline/pkg/funk"
 )
 
 //go:generate mockery --name QueryBuilder
@@ -32,7 +32,7 @@ func (b *RawQueryBuilder) Table(table string) QueryBuilder {
 }
 
 func (b *RawQueryBuilder) Joins(joins []string) QueryBuilder {
-	for _, join := range funk.UniqString(joins) {
+	for _, join := range funk.Uniq(joins) {
 		b.Builder = b.Builder.JoinClause(join)
 	}
 

--- a/pkg/ddb/metadata.go
+++ b/pkg/ddb/metadata.go
@@ -1,6 +1,8 @@
 package ddb
 
-import "github.com/thoas/go-funk"
+import (
+	"golang.org/x/exp/slices"
+)
 
 const (
 	tagKey    = "key"
@@ -98,7 +100,7 @@ func (f metadataFields) GetKeyFields() []string {
 }
 
 func (f metadataFields) ContainsField(field string) bool {
-	return funk.ContainsString(f.Fields, field)
+	return slices.Contains(f.Fields, field)
 }
 
 func (f metadataFields) GetFields() []string {
@@ -115,5 +117,7 @@ type metadataMain struct {
 	metadataCapacity
 }
 
-type metaLocal map[string]metadataFields
-type metaGlobal map[string]metadataMain
+type (
+	metaLocal  map[string]metadataFields
+	metaGlobal map[string]metadataMain
+)

--- a/pkg/ddb/metadata_factory.go
+++ b/pkg/ddb/metadata_factory.go
@@ -121,9 +121,9 @@ func (f *metadataFactory) getFields(model interface{}, hashTag string, rangeTag 
 		return metadataFields{}, err
 	}
 
-	hashKey = mdl.String(hashAttribute.AttributeName)
+	hashKey = mdl.Box(hashAttribute.AttributeName)
 	if rangeAttribute != nil {
-		rangeKey = mdl.String(rangeAttribute.AttributeName)
+		rangeKey = mdl.Box(rangeAttribute.AttributeName)
 	}
 
 	if fields, err = MetadataReadFields(model); err != nil {

--- a/pkg/ddb/service.go
+++ b/pkg/ddb/service.go
@@ -12,8 +12,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	gosoDynamodb "github.com/justtrackio/gosoline/pkg/cloud/aws/dynamodb"
+	"github.com/justtrackio/gosoline/pkg/funk"
 	"github.com/justtrackio/gosoline/pkg/log"
-	"github.com/thoas/go-funk"
+	"golang.org/x/exp/slices"
 )
 
 type TableDescription struct {
@@ -213,7 +214,7 @@ func (s *Service) getKeyFields(metadata *Metadata) []string {
 		fields = append(fields, data.GetKeyFields()...)
 	}
 
-	fields = funk.UniqString(fields)
+	fields = funk.Uniq(fields)
 	sort.Strings(fields)
 
 	return fields
@@ -324,7 +325,7 @@ func (s *Service) projectedFields(main FieldAware, second FieldAware) (*types.Pr
 	secondFields := second.GetFields()
 
 	for _, field := range secondFields {
-		if !funk.Contains(mainFields, field) {
+		if !slices.Contains(mainFields, field) {
 			return nil, fmt.Errorf("can't project field '%s' cause the main table is missing this field", field)
 		}
 	}

--- a/pkg/funk/README.md
+++ b/pkg/funk/README.md
@@ -1,0 +1,20 @@
+Benchmarks
+
+```sh
+BenchmarkMap-16                                      146           8168550 ns/op         8289055 B/op          1 all
+BenchmarkUniq-16                                      10         103630461 ns/op        34581937 B/op         23 all
+BenchmarkUniqThoas-16                                  4         283696922 ns/op        92759996 B/op    2000015 all
+BenchmarkUniqStruct-16                                 6         177865631 ns/op        70916293 B/op         26 all
+BenchmarkUniqThoasStruct-16                            3         374595307 ns/op        127689090 B/op   2000018 all
+BenchmarkChunk-16                                    111          10232891 ns/op         9581239 B/op      10001 all
+BenchmarkChunkReduce-16                               99          11395557 ns/op         9626752 B/op      10001 all
+BenchmarkChunkThoas-16                                13         112813206 ns/op        49245217 B/op    1100025 all
+BenchmarkDifferenceRandomStruct-16                 75243             13358 ns/op            7366 B/op         30 all
+BenchmarkDifferenceThoasRandomStruct-16              470           2306334 ns/op          344273 B/op      20820 all
+BenchmarkDifferenceRandom-16                       47986             24955 ns/op           13975 B/op         28 all
+BenchmarkDifferenceThoasRandom-16                    868           1476350 ns/op          178580 B/op      20820 all
+BenchmarkDifferenceStatic-16                      110392             10376 ns/op            3285 B/op         14 all
+BenchmarkDifferenceThoasStatic-16                   1707            719145 ns/op           90498 B/op      10704 all
+BenchmarkIntersect-16                              97228             13425 ns/op            5578 B/op         25 all
+BenchmarkIntersectThoas-16                         27148             46202 ns/op           15720 B/op        517 all
+```

--- a/pkg/funk/map.go
+++ b/pkg/funk/map.go
@@ -1,0 +1,47 @@
+package funk
+
+func MergeMaps[K comparable, V any, M ~map[K]V](m ...M) M {
+	var length int
+	for _, item := range m {
+		length += len(item)
+	}
+
+	out := make(M, length)
+	for _, item := range m {
+		for k, v := range item {
+			out[k] = v
+		}
+	}
+
+	return out
+}
+
+func IntersectMaps[K comparable, V any, M ~map[K]V](m1, m2 M) M {
+	result := make(M)
+
+	for k, v := range m1 {
+		if _, ok := m2[k]; ok {
+			result[k] = v
+		}
+	}
+
+	return result
+}
+
+func DifferenceMaps[K comparable, V1, V2 any, M1 ~map[K]V1, M2 ~map[K]V2](left M1, right M2) (inLeft M1, inRight M2) {
+	inLeft, inRight = make(M1, len(left)), make(M2, len(right))
+
+	for k, v := range left {
+		if _, ok := right[k]; !ok {
+			inLeft[k] = v
+		}
+	}
+
+	for k, v := range right {
+		if _, ok := left[k]; !ok {
+			inRight[k] = v
+		}
+	}
+
+	return inLeft, inRight
+}

--- a/pkg/funk/set.go
+++ b/pkg/funk/set.go
@@ -1,0 +1,21 @@
+package funk
+
+type Set[T comparable] map[T]struct{}
+
+func (s Set[T]) Set(item T) {
+	s[item] = struct{}{}
+}
+
+func (s Set[T]) Contains(item T) bool {
+	_, ok := s[item]
+	return ok
+}
+
+func SetToSlice[T comparable](s Set[T]) []T {
+	out := make([]T, 0, len(s))
+	for k := range s {
+		out = append(out, k)
+	}
+
+	return out
+}

--- a/pkg/funk/slice.go
+++ b/pkg/funk/slice.go
@@ -1,0 +1,279 @@
+package funk
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/justtrackio/gosoline/pkg/mdl"
+
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+// CastSlice casts a []any slice to the given type.
+// The parameter sliceType is required to correctly infer the target type.
+func CastSlice[T any, I ~[]any](sl I, sliceType T) ([]T, error) {
+	result := make([]T, len(sl))
+
+	for i := 0; i < len(sl); i++ {
+		el, ok := sl[i].(T)
+		if !ok {
+			return nil, fmt.Errorf("could not cast element at index %d", i)
+		}
+
+		result[i] = el
+	}
+
+	return result, nil
+}
+
+func Chunk[S ~[]T, T any](sl S, size int) [][]T {
+	if size <= 0 {
+		return nil
+	}
+
+	if len(sl) == 0 {
+		return make([][]T, 0)
+	}
+
+	chunkCount := len(sl) / size
+	result := make([][]T, chunkCount)
+
+	for i := 0; i < chunkCount; i++ {
+		result[i] = make([]T, 0, size)
+	}
+
+	if rem := len(sl) % size; rem != 0 {
+		result = append(result, make([]T, 0, rem))
+	}
+
+	for i := 0; i < len(sl); i++ {
+		result[i/size] = append(result[i/size], sl[i])
+	}
+
+	return result
+}
+
+func Contains[T any](in []T, elem T) bool {
+	equalTo := equal(elem)
+
+	return ContainsFunc(in, equalTo)
+}
+
+func ContainsFunc[S ~[]T, T any](sl S, pred func(T) bool) bool {
+	_, ok := FindFirstFunc(sl, pred)
+
+	return ok
+}
+
+func Difference[S ~[]T, T comparable](left, right S) (inLeft, inRight []T) {
+	set1, set2 := SliceToSet(left), SliceToSet(right)
+
+	inLeft = make([]T, 0, len(set1))
+	inRight = make([]T, 0, len(set2))
+
+	for _, item := range left {
+		if !set2.Contains(item) {
+			inLeft = append(inLeft, item)
+		}
+	}
+
+	for _, item := range right {
+		if !set1.Contains(item) {
+			inRight = append(inRight, item)
+		}
+	}
+
+	return inLeft, inRight
+}
+
+func DifferenceKeyed[S1 ~[]T1, S2 ~[]T2, T1, T2 mdl.Keyed](left S1, right S2) (inLeft S1, inRight S2) {
+	inLeftS, inRightS := DifferenceMaps(KeyedToMap(left), KeyedToMap(right))
+
+	return maps.Values(inLeftS), maps.Values(inRightS)
+}
+
+func Filter[S ~[]T, T any](sl S, pred func(T) bool) []T {
+	if len(sl) == 0 {
+		return []T{}
+	}
+
+	result := make([]T, 0, len(sl))
+	for _, item := range sl {
+		if pred(item) {
+			result = append(result, item)
+		}
+	}
+
+	return slices.Clip(result)
+}
+
+func FindFirst[S ~[]T, T comparable](sl S, el T) (out T, ok bool) {
+	for _, item := range sl {
+		if item == el {
+			return item, true
+		}
+	}
+
+	return
+}
+
+func FindFirstFunc[S ~[]T, T any](sl S, pred func(T) bool) (out T, ok bool) {
+	for _, item := range sl {
+		if pred(item) {
+			return item, true
+		}
+	}
+
+	return
+}
+
+func First[S ~[]T, T any](sl S) (out T, ok bool) {
+	if len(sl) >= 1 {
+		return sl[0], true
+	}
+
+	return
+}
+
+func Flatten[S ~[]T, T any](sl []S) []T {
+	result := make([]T, 0)
+	for _, items := range sl {
+		result = append(result, items...)
+	}
+
+	return result
+}
+
+func Index[T any](sl []T, e T) int {
+	for i, v := range sl {
+		equalTo := equal(e)
+
+		if equalTo(v) {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func Intersect[S ~[]T, T comparable](sl1, sl2 S) []T {
+	set2 := SliceToSet(sl2)
+	result := make(Set[T])
+
+	for _, item := range sl1 {
+		if set2.Contains(item) {
+			result.Set(item)
+		}
+	}
+
+	return maps.Keys(result)
+}
+
+func IntersectKeyed[S ~[]T, T mdl.Keyed](s1, s2 S) S {
+	return maps.Values(IntersectMaps(KeyedToMap(s1), KeyedToMap(s2)))
+}
+
+func KeyedToMap[S ~[]T, T mdl.Keyed](sl S) map[string]T {
+	out := make(map[string]T, len(sl))
+
+	for _, item := range sl {
+		out[item.GetKey()] = item
+	}
+
+	return out
+}
+
+func Last[T any](sl []T) T {
+	if len(sl) == 0 {
+		var ret T
+		return ret
+	}
+
+	return sl[len(sl)-1]
+}
+
+func Map[S ~[]T1, T1, T2 any, F func(T1) T2](sl S, op F) []T2 {
+	result := make([]T2, len(sl))
+	for idx, item := range sl {
+		result[idx] = op(item)
+	}
+
+	return result
+}
+
+func Reduce[S ~[]T1, T1, T2 any](sl S, op func(T2, T1, int) T2, init T2) T2 {
+	result := init
+
+	for idx, item := range sl {
+		result = op(result, item, idx)
+	}
+
+	return result
+}
+
+func SliceToMap[S ~[]T, T, V any, K comparable](sl S, keyer func(T) (K, V)) map[K]V {
+	out := make(map[K]V, len(sl))
+
+	for _, item := range sl {
+		k, v := keyer(item)
+		out[k] = v
+	}
+
+	return out
+}
+
+func SliceToSet[S ~[]T, T comparable](sl S) Set[T] {
+	result := make(Set[T], len(sl))
+
+	for _, item := range sl {
+		result.Set(item)
+	}
+
+	return result
+}
+
+func Repeat[T any](el T, times int) []T {
+	if times < 0 {
+		return nil
+	}
+
+	if times == 0 {
+		return []T{}
+	}
+
+	result := make([]T, times)
+
+	for i := 0; i < times; i++ {
+		result[i] = el
+	}
+
+	return result
+}
+
+func Reverse[S ~[]T, T any](sl S) S {
+	out := make(S, len(sl))
+	for i, j := 0, len(sl)-1; i < len(sl) && j >= 0; i, j = i+1, j-1 {
+		out[i] = sl[j]
+	}
+
+	return out
+}
+
+func Tail[T any](sl []T) []T {
+	if len(sl) < 2 {
+		return sl
+	}
+
+	return sl[1:]
+}
+
+func Uniq[S ~[]T, T comparable](sl S) (out []T) {
+	return SetToSlice(SliceToSet(sl))
+}
+
+func equal[T any](expected T) func(actualValue T) bool {
+	return func(actualValue T) bool {
+		return reflect.DeepEqual(actualValue, expected)
+	}
+}

--- a/pkg/funk/slice_bench_test.go
+++ b/pkg/funk/slice_bench_test.go
@@ -1,0 +1,159 @@
+package funk_test
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/justtrackio/gosoline/pkg/funk"
+)
+
+var (
+	s = rand.NewSource(time.Now().UnixNano())
+	r = rand.New(s)
+)
+
+var (
+	mapResult []float64
+	mapOp     = func(i int) float64 {
+		return 1 / math.Sqrt(float64(i))
+	}
+)
+
+func BenchmarkMap(b *testing.B) {
+	var res []float64
+	inp := randomIntSlice(1_000_000)
+
+	for n := 0; n < b.N; n++ {
+		res = funk.Map(inp, mapOp)
+	}
+
+	mapResult = res
+}
+
+var uniqResult []int
+
+func BenchmarkUniq(b *testing.B) {
+	var res []int
+	inp := randomIntSlice(1_000_000)
+
+	for n := 0; n < b.N; n++ {
+		res = funk.Uniq(inp)
+	}
+
+	uniqResult = res
+}
+
+type testStruct struct {
+	test1 int
+	test3 float64
+}
+
+var uniqStructResult []testStruct
+
+func BenchmarkUniqStruct(b *testing.B) {
+	var res []testStruct
+	inp := randomStructSlice(1_000_000)
+
+	for n := 0; n < b.N; n++ {
+		res = funk.Uniq(inp)
+	}
+
+	uniqStructResult = res
+}
+
+var chunkResult [][]int
+
+func BenchmarkChunk(b *testing.B) {
+	var res [][]int
+	inp := randomIntSlice(1_000_000)
+	for n := 0; n < b.N; n++ {
+		res = funk.Chunk(inp, 100)
+	}
+
+	chunkResult = res
+}
+
+var (
+	differenceResultA       []int
+	differenceResultB       []int
+	differenceResultAStruct []testStruct
+	differenceResultBStruct []testStruct
+)
+
+func BenchmarkDifferenceRandomStruct(b *testing.B) {
+	var resA, resB []int
+	as := randomIntSlice(100)
+	bs := randomIntSlice(100)
+	for n := 0; n < b.N; n++ {
+		resA, resB = funk.Difference(as, bs)
+	}
+
+	differenceResultA, differenceResultB = resA, resB
+}
+
+func BenchmarkDifferenceRandom(b *testing.B) {
+	var resA, resB []testStruct
+	as := randomStructSlice(100)
+	bs := randomStructSlice(100)
+	for n := 0; n < b.N; n++ {
+		resA, resB = funk.Difference(as, bs)
+	}
+
+	differenceResultAStruct, differenceResultBStruct = resA, resB
+}
+
+func BenchmarkDifferenceStatic(b *testing.B) {
+	var resA, resB []int
+	as := staticIntSlice(100)
+	bs := staticIntSlice(100)
+	for n := 0; n < b.N; n++ {
+		resA, resB = funk.Difference(as, bs)
+	}
+
+	differenceResultA, differenceResultB = resA, resB
+}
+
+var intersectResult []int
+
+func BenchmarkIntersect(b *testing.B) {
+	var res []int
+	as := staticIntSlice(100)
+	bs := staticIntSlice(100)
+	for n := 0; n < b.N; n++ {
+		res = funk.Intersect(as, bs)
+	}
+
+	intersectResult = res
+}
+
+func randomIntSlice(length int) []int {
+	var res []int
+	for i := 0; i < length; i++ {
+		res = append(res, r.Int())
+	}
+
+	return res
+}
+
+func randomStructSlice(length int) []testStruct {
+	var res []testStruct
+	for i := 0; i < length; i++ {
+		res = append(res, testStruct{
+			test1: r.Int(),
+			test3: r.Float64(),
+		})
+	}
+
+	return res
+}
+
+func staticIntSlice(length int) []int {
+	var a []int
+	for i := 0; i < length; i++ {
+		a = append(a, i)
+	}
+
+	return a
+}

--- a/pkg/funk/slice_test.go
+++ b/pkg/funk/slice_test.go
@@ -1,0 +1,400 @@
+package funk_test
+
+import (
+	"testing"
+
+	"golang.org/x/exp/slices"
+
+	"github.com/justtrackio/gosoline/pkg/funk"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCastSlice(t *testing.T) {
+	inputSlice := []any{"", ""}
+	expectedSlice := []string{"", ""}
+
+	target, err := funk.CastSlice(inputSlice, "")
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, expectedSlice, target)
+}
+
+func TestContains(t *testing.T) {
+	type test struct {
+		Foo string
+	}
+
+	in := []test{{
+		Foo: "bar",
+	}}
+
+	out := funk.Contains(in, test{Foo: "bar"})
+	assert.True(t, out)
+}
+
+func TestChunk(t *testing.T) {
+	type input struct {
+		Sl   []int
+		Size int
+	}
+
+	tests := map[string]struct {
+		Name string
+		In   input
+		Out  [][]int
+	}{
+		"remainder one": {
+			In: input{
+				Sl:   []int{0, 1, 2, 3, 4, 5, 6},
+				Size: 3,
+			},
+			Out: [][]int{
+				{0, 1, 2},
+				{3, 4, 5},
+				{6},
+			},
+		},
+		"remainder two": {
+			In: input{
+				Sl:   []int{0, 1, 2, 3, 4, 5, 6, 7},
+				Size: 3,
+			},
+			Out: [][]int{
+				{0, 1, 2},
+				{3, 4, 5},
+				{6, 7},
+			},
+		},
+		"size negative": {
+			In: input{
+				Sl:   []int{0, 1, 2, 3, 4, 5, 6},
+				Size: -3,
+			},
+			Out: nil,
+		},
+		"size zero": {
+			In: input{
+				Sl:   []int{0, 1, 2, 3, 4, 5, 6},
+				Size: 0,
+			},
+			Out: nil,
+		},
+		"size one": {
+			In: input{
+				Sl:   []int{0, 1, 2, 3},
+				Size: 1,
+			},
+			Out: [][]int{{0}, {1}, {2}, {3}},
+		},
+		"size larger than slice": {
+			In: input{
+				Sl:   []int{0, 1, 2, 3},
+				Size: 5,
+			},
+			Out: [][]int{{0, 1, 2, 3}},
+		},
+		"no values": {
+			In: input{
+				Sl:   []int{},
+				Size: 5,
+			},
+			Out: [][]int{},
+		},
+	}
+	for name, data := range tests {
+		data := data
+		t.Run(name, func(t *testing.T) {
+			res := funk.Chunk(data.In.Sl, data.In.Size)
+			assert.Equalf(t, data.Out, res, "Test static failed: %s", data.Name)
+		})
+	}
+}
+
+func TestDifference(t *testing.T) {
+	tests := map[string]struct {
+		Input1 []int
+		Input2 []int
+
+		Out1 []int
+		Out2 []int
+	}{
+		"simple": {
+			Input1: []int{1, 2, 3, 4},
+			Input2: []int{2, 3, 5, 6},
+			Out1:   []int{1, 4},
+			Out2:   []int{5, 6},
+		},
+		"identical": {
+			Input1: []int{1, 2, 3},
+			Input2: []int{1, 2, 3},
+			Out1:   []int{},
+			Out2:   []int{},
+		},
+		"disjunct": {
+			Input1: []int{1, 2},
+			Input2: []int{3, 4},
+			Out1:   []int{1, 2},
+			Out2:   []int{3, 4},
+		},
+		"left empty": {
+			Input1: []int{},
+			Input2: []int{3, 4},
+			Out1:   []int{},
+			Out2:   []int{3, 4},
+		},
+		"right empty": {
+			Input1: []int{1, 2},
+			Input2: []int{},
+			Out1:   []int{1, 2},
+			Out2:   []int{},
+		},
+	}
+
+	for name, data := range tests {
+		data := data
+		t.Run(name, func(t *testing.T) {
+			l, r := funk.Difference(data.Input1, data.Input2)
+			assert.ElementsMatch(t, l, data.Out1)
+			assert.ElementsMatch(t, r, data.Out2)
+		})
+	}
+}
+
+func TestFlatten(t *testing.T) {
+	tl := [][]string{{"foo", "bar"}, {"raz"}}
+	expected := []string{"foo", "bar", "raz"}
+
+	tlf := funk.Flatten(tl)
+
+	assert.Equal(t, expected, tlf)
+}
+
+func TestIndex(t *testing.T) {
+	type obj struct {
+		Foo string
+	}
+
+	var tests = map[string]struct {
+		in    []obj
+		index int
+	}{
+		"exists": {
+			in:    []obj{{Foo: "bar"}},
+			index: 0,
+		},
+		"missing": {
+			in:    []obj{{Foo: "foo"}},
+			index: -1,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			out := funk.Index(test.in, obj{Foo: "bar"})
+
+			assert.Equal(t, test.index, out)
+		})
+	}
+}
+
+func TestIntersect(t *testing.T) {
+	tests := map[string]struct {
+		Input1 []int
+		Input2 []int
+
+		Out []int
+	}{
+		"simple": {
+			Input1: []int{1: 2, 3, 4},
+			Input2: []int{2, 3, 5, 6},
+			Out:    []int{2, 3},
+		},
+		"identical": {
+			Input1: []int{1, 2, 3},
+			Input2: []int{1, 2, 3},
+			Out:    []int{1, 2, 3},
+		},
+		"disjunct": {
+			Input1: []int{1, 2},
+			Input2: []int{3, 4},
+			Out:    []int{},
+		},
+		"left empty": {
+			Input1: []int{},
+			Input2: []int{3, 4},
+			Out:    []int{},
+		},
+		"right empty": {
+			Input1: []int{1, 2},
+			Input2: []int{},
+			Out:    []int{},
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			res := funk.Intersect(test.Input1, test.Input2)
+			assert.ElementsMatch(t, res, test.Out)
+		})
+	}
+}
+
+func TestMapEmptyInterface(t *testing.T) {
+	type test []interface{}
+	tl := test{
+		"blah", "test",
+	}
+
+	tlf := funk.Map(tl, func(i interface{}) string {
+		return i.(string)
+	})
+	assert.True(t, slices.Contains(tlf, "blah"))
+}
+
+func TestRepeatPrimitive(t *testing.T) {
+	tests := map[string]struct {
+		Times   int
+		Element int
+
+		Out []int
+	}{
+		"simple": {
+			Times:   5,
+			Element: 1,
+			Out:     []int{1, 1, 1, 1, 1},
+		},
+		"slice len 0": {
+			Times:   0,
+			Element: 1,
+			Out:     []int{},
+		},
+		"single": {
+			Times:   1,
+			Element: 1,
+			Out:     []int{1},
+		},
+		"empty value as input": {
+			Times:   5,
+			Element: 0,
+			Out:     []int{0, 0, 0, 0, 0},
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			out := funk.Repeat(test.Element, test.Times)
+			assert.Equal(t, out, test.Out)
+		})
+	}
+}
+
+func TestRepeatStructPointer(t *testing.T) {
+	type test struct{ field int }
+
+	test1 := &test{1}
+
+	tests := map[string]struct {
+		Times   int
+		Element *test
+
+		Out []*test
+	}{
+		"simple": {
+			Times:   5,
+			Element: test1,
+			Out:     []*test{test1, test1, test1, test1, test1},
+		},
+		"nil": {
+			Times:   5,
+			Element: nil,
+			Out:     []*test{nil, nil, nil, nil, nil},
+		},
+		"nil wit empty slice": {
+			Times:   0,
+			Element: nil,
+			Out:     []*test{},
+		},
+		"negative number": {
+			Times:   -5,
+			Element: test1,
+			Out:     nil,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			out := funk.Repeat(test.Element, test.Times)
+			for idx, el := range out {
+				if el != test.Out[idx] {
+					t.Logf("Pointers are not equal %p == %p", el, test.Out[idx])
+					t.Fail()
+				}
+			}
+			assert.Equal(t, test.Out, out)
+		})
+	}
+}
+
+func TestTail(t *testing.T) {
+	var tests = map[string]struct {
+		input    []string
+		expected []string
+	}{
+		"pop 1": {
+			input:    []string{"1", "2", "3"},
+			expected: []string{"2", "3"},
+		},
+		"pop none": {
+			input:    []string{"1"},
+			expected: []string{"1"},
+		},
+		"empty": {
+			input:    []string{},
+			expected: []string{},
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			output := funk.Tail(test.input)
+
+			assert.Equal(t, test.expected, output)
+		})
+	}
+}
+
+func TestReverse(t *testing.T) {
+	tests := map[string]struct {
+		In  []int
+		Out []int
+	}{
+		"odd values": {
+			In:  []int{1, 2, 3, 4, 5},
+			Out: []int{5, 4, 3, 2, 1},
+		},
+		"even values": {
+			In:  []int{1, 2, 3, 4},
+			Out: []int{4, 3, 2, 1},
+		},
+		"no values": {
+			In:  []int{},
+			Out: []int{},
+		},
+		"one value": {
+			In:  []int{1},
+			Out: []int{1},
+		},
+	}
+
+	for name, data := range tests {
+		data := data
+		t.Run(name, func(t *testing.T) {
+			res := funk.Reverse(data.In)
+			assert.Equal(t, data.Out, res)
+		})
+	}
+}

--- a/pkg/guard/manager_sql.go
+++ b/pkg/guard/manager_sql.go
@@ -8,9 +8,9 @@ import (
 	"github.com/Masterminds/squirrel"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/db"
+	"github.com/justtrackio/gosoline/pkg/funk"
 	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/ory/ladon"
-	"github.com/thoas/go-funk"
 )
 
 const (
@@ -259,9 +259,9 @@ func (m SqlManager) queryPolicies(sel squirrel.SelectBuilder) (ladon.Policies, e
 
 	unique := make(ladon.Policies, 0)
 	for _, pol := range policies {
-		pol.Subjects = funk.UniqString(pol.Subjects)
-		pol.Resources = funk.UniqString(pol.Resources)
-		pol.Actions = funk.UniqString(pol.Actions)
+		pol.Subjects = funk.Uniq(pol.Subjects)
+		pol.Resources = funk.Uniq(pol.Resources)
+		pol.Actions = funk.Uniq(pol.Actions)
 
 		unique = append(unique, pol)
 	}

--- a/pkg/kvstore/in_memory.go
+++ b/pkg/kvstore/in_memory.go
@@ -194,7 +194,7 @@ func (s *InMemoryKvStore) PutBatch(ctx context.Context, values interface{}) erro
 }
 
 func (s *InMemoryKvStore) EstimateSize() *int64 {
-	return mdl.Int64(atomic.LoadInt64(s.cacheSize))
+	return mdl.Box(atomic.LoadInt64(s.cacheSize))
 }
 
 func (s *InMemoryKvStore) Delete(_ context.Context, key interface{}) error {

--- a/pkg/kvstore/redis_test.go
+++ b/pkg/kvstore/redis_test.go
@@ -162,7 +162,7 @@ func TestRedisKvStore_EstimateSize(t *testing.T) {
 
 	size := store.(kvstore.SizedStore).EstimateSize()
 
-	assert.Equal(t, mdl.Int64(42), size)
+	assert.Equal(t, mdl.Box(int64(42)), size)
 	client.AssertExpectations(t)
 }
 

--- a/pkg/mdl/factory.go
+++ b/pkg/mdl/factory.go
@@ -3,106 +3,32 @@ package mdl
 import (
 	"reflect"
 	"time"
+
+	"golang.org/x/exp/constraints"
 )
 
-func Bool(v bool) *bool {
-	return &v
+type Basic interface {
+	~bool | constraints.Float | constraints.Integer | time.Time | ~string
 }
 
-func Float32(v float32) *float32 {
-	return &v
-}
-
-func Float64(v float64) *float64 {
-	return &v
-}
-
-func Int(v int) *int {
-	return &v
-}
-
-func Int32(v int32) *int32 {
-	return &v
-}
-
-func Int64(v int64) *int64 {
-	return &v
-}
-
-func String(v string) *string {
-	return &v
-}
-
-func Uint(v uint) *uint {
-	return &v
-}
-
-func EmptyBoolIfNil(b *bool) bool {
-	if b == nil {
-		return false
+func EmptyIfNil[T comparable](v *T) (out T) {
+	if v != nil {
+		return *v
 	}
 
-	return *b
+	return
 }
 
-func EmptyFloat32IfNil(v *float32) float32 {
-	if v == nil {
-		return 0.0
+func NilIfEmpty[T comparable](in T) *T {
+	if *new(T) == in {
+		return nil
 	}
 
-	return *v
+	return &in
 }
 
-func EmptyFloat64IfNil(v *float64) float64 {
-	if v == nil {
-		return 0.0
-	}
-
-	return *v
-}
-
-func EmptyIntIfNil(v *int) int {
-	if v == nil {
-		return 0
-	}
-
-	return *v
-}
-
-func EmptyInt64IfNil(v *int64) int64 {
-	if v == nil {
-		return 0
-	}
-
-	return *v
-}
-
-func EmptyStringIfNil(s *string) string {
-	if s == nil {
-		return ""
-	}
-
-	return *s
-}
-
-func EmptyTimeIfNil(t *time.Time) time.Time {
-	if t == nil {
-		return time.Time{}
-	}
-
-	return *t
-}
-
-func EmptyUintIfNil(i *uint) uint {
-	if i == nil {
-		return 0
-	}
-
-	return *i
-}
-
-func Time(t time.Time) *time.Time {
-	return &t
+func Box[T Basic](v T) (out *T) {
+	return &v
 }
 
 func IsNil(m interface{}) bool {

--- a/pkg/mdl/model.go
+++ b/pkg/mdl/model.go
@@ -60,6 +60,10 @@ type Identifiable interface {
 	GetId() *uint
 }
 
+type Keyed interface {
+	GetKey() string
+}
+
 type Identifier struct {
 	Id *uint `json:"id" binding:"required"`
 }

--- a/pkg/metric/writer_prometheus.go
+++ b/pkg/metric/writer_prometheus.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/justtrackio/gosoline/pkg/appctx"
 	"github.com/justtrackio/gosoline/pkg/cfg"
-	"github.com/justtrackio/gosoline/pkg/clock"
 	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/justtrackio/gosoline/pkg/mdl"
 	"github.com/prometheus/client_golang/prometheus"
@@ -24,9 +23,11 @@ const (
 	UnitPromSummary   StandardUnit = "prom-summary"
 )
 
-type registryAppCtxKey string
-type promMetricFactory func(*Datum) prometheus.Metric
-type promMetricPersister func(metric prometheus.Metric, data *Datum)
+type (
+	registryAppCtxKey   string
+	promMetricFactory   func(*Datum) prometheus.Metric
+	promMetricPersister func(metric prometheus.Metric, data *Datum)
+)
 
 func ProvideRegistry(ctx context.Context, name string) (*prometheus.Registry, error) {
 	return appctx.Provide(ctx, registryAppCtxKey(name), func() (*prometheus.Registry, error) {
@@ -40,7 +41,6 @@ func ProvideRegistry(ctx context.Context, name string) (*prometheus.Registry, er
 
 type promWriter struct {
 	logger      log.Logger
-	clock       clock.Clock
 	promMetrics sync.Map
 	registry    *prometheus.Registry
 	namespace   string
@@ -69,7 +69,7 @@ func NewPromWriterWithInterfaces(logger log.Logger, registry *prometheus.Registr
 		registry:    registry,
 		namespace:   namespace,
 		metricLimit: metricLimit,
-		metrics:     mdl.Int64(0),
+		metrics:     mdl.Box(int64(0)),
 	}
 }
 

--- a/pkg/parquet/writer.go
+++ b/pkg/parquet/writer.go
@@ -199,8 +199,8 @@ func makeTags(tags map[string]string) []types.Tag {
 
 	for key, value := range tags {
 		s3Tags = append(s3Tags, types.Tag{
-			Key:   mdl.String(key),
-			Value: mdl.String(value),
+			Key:   mdl.Box(key),
+			Value: mdl.Box(value),
 		})
 	}
 

--- a/pkg/stream/consumer_batch_test.go
+++ b/pkg/stream/consumer_batch_test.go
@@ -107,7 +107,7 @@ func (s *BatchConsumerTestSuite) TestRun_ProcessOnStop() {
 
 	s.callback.On("GetModel", mock.AnythingOfType("map[string]interface {}")).
 		Return(func(_ map[string]interface{}) interface{} {
-			return mdl.String("")
+			return mdl.Box("")
 		})
 
 	s.callback.On("Run", mock.AnythingOfType("*context.cancelCtx")).
@@ -154,7 +154,7 @@ func (s *BatchConsumerTestSuite) TestRun_BatchSizeReached() {
 
 	s.callback.On("GetModel", mock.AnythingOfType("map[string]interface {}")).
 		Return(func(_ map[string]interface{}) interface{} {
-			return mdl.String("")
+			return mdl.Box("")
 		})
 
 	s.callback.On("Run", mock.AnythingOfType("*context.cancelCtx")).
@@ -254,7 +254,7 @@ func (s *BatchConsumerTestSuite) TestRun_AggregateMessage() {
 
 	s.callback.
 		On("GetModel", mock.AnythingOfType("map[string]interface {}")).
-		Return(mdl.String("")).
+		Return(mdl.Box("")).
 		Twice()
 
 	err = s.batchConsumer.Run(s.kernelCtx)

--- a/pkg/stream/consumer_test.go
+++ b/pkg/stream/consumer_test.go
@@ -133,7 +133,7 @@ func (s *ConsumerTestSuite) TestRun() {
 
 	s.callback.On("GetModel", mock.AnythingOfType("map[string]interface {}")).
 		Return(func(_ map[string]interface{}) interface{} {
-			return mdl.String("")
+			return mdl.Box("")
 		})
 
 	s.callback.On("Run", mock.AnythingOfType("*context.cancelCtx")).Return(nil)
@@ -207,7 +207,7 @@ func (s *ConsumerTestSuite) TestRun_CallbackRunPanic() {
 	s.callback.
 		On("GetModel", mock.AnythingOfType("map[string]interface {}")).
 		Return(func(_ map[string]interface{}) interface{} {
-			return mdl.String("")
+			return mdl.Box("")
 		})
 
 	retryMsg := &stream.Message{
@@ -279,7 +279,7 @@ func (s *ConsumerTestSuite) TestRun_AggregateMessage() {
 
 	expectedModelAttributes1 := map[string]interface{}{"attr1": "a", "encoding": "application/json"}
 	s.callback.On("GetModel", expectedModelAttributes1).
-		Return(mdl.String(""))
+		Return(mdl.Box(""))
 
 	expectedAttributes2 := map[string]interface{}{"attr1": "b"}
 	s.callback.On("Consume", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*string"), expectedAttributes2).
@@ -291,7 +291,7 @@ func (s *ConsumerTestSuite) TestRun_AggregateMessage() {
 
 	expectedModelAttributes2 := map[string]interface{}{"attr1": "b", "encoding": "application/json"}
 	s.callback.On("GetModel", expectedModelAttributes2).
-		Return(mdl.String(""))
+		Return(mdl.Box(""))
 
 	err = s.consumer.Run(s.kernelCtx)
 
@@ -349,7 +349,7 @@ func (s *ConsumerTestSuite) TestRunWithRetry() {
 	s.callback.
 		On("GetModel", mock.AnythingOfType("map[string]interface {}")).
 		Return(func(_ map[string]interface{}) interface{} {
-			return mdl.String("")
+			return mdl.Box("")
 		}).
 		Twice()
 

--- a/pkg/stream/output_kinesis.go
+++ b/pkg/stream/output_kinesis.go
@@ -76,11 +76,11 @@ func (o *kinesisOutput) IsPartitionedOutput() bool {
 }
 
 func (o *kinesisOutput) GetMaxMessageSize() *int {
-	return mdl.Int(1024 * 1024)
+	return mdl.Box(1024 * 1024)
 }
 
 func (o *kinesisOutput) GetMaxBatchSize() *int {
-	return mdl.Int(500)
+	return mdl.Box(500)
 }
 
 func (o *kinesisOutput) buildRecord(msg WritableMessage) (*gosoKinesis.Record, error) {

--- a/pkg/stream/output_sns.go
+++ b/pkg/stream/output_sns.go
@@ -94,9 +94,9 @@ func (o *snsOutput) computeMessagesAttributes(batch []WritableMessage) ([]string
 }
 
 func (o *snsOutput) GetMaxMessageSize() *int {
-	return mdl.Int(256 * 1024)
+	return mdl.Box(256 * 1024)
 }
 
 func (o *snsOutput) GetMaxBatchSize() *int {
-	return mdl.Int(10)
+	return mdl.Box(10)
 }

--- a/pkg/test/env/component_localstack.go
+++ b/pkg/test/env/component_localstack.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	gosoAws "github.com/justtrackio/gosoline/pkg/cloud/aws"
-	"github.com/thoas/go-funk"
+	"golang.org/x/exp/slices"
 )
 
 type localstackComponent struct {
@@ -34,7 +34,7 @@ func (c *localstackComponent) CfgOptions() []cfg.Option {
 		}),
 	}
 
-	if funk.ContainsString(c.services, localstackServiceS3) {
+	if slices.Contains(c.services, localstackServiceS3) {
 		options = append(options, cfg.WithConfigMap(map[string]interface{}{
 			"aws_s3_endpoint":   c.Address(),
 			"aws_s3_autoCreate": true,

--- a/pkg/test/suite/options_suite.go
+++ b/pkg/test/suite/options_suite.go
@@ -13,7 +13,7 @@ import (
 	"github.com/justtrackio/gosoline/pkg/stream"
 	"github.com/justtrackio/gosoline/pkg/test/env"
 	"github.com/spf13/cast"
-	"github.com/thoas/go-funk"
+	"golang.org/x/exp/slices"
 )
 
 type suiteOptions struct {
@@ -51,7 +51,7 @@ func (s *suiteOptions) addEnvOption(opt env.Option) {
 }
 
 func (s *suiteOptions) shouldSkip(name string) bool {
-	return len(s.testCaseWhitelist) > 0 && !funk.ContainsString(s.testCaseWhitelist, name)
+	return len(s.testCaseWhitelist) > 0 && !slices.Contains(s.testCaseWhitelist, name)
 }
 
 type Option func(s *suiteOptions)

--- a/test/db-repo/change_history/change_history_test.go
+++ b/test/db-repo/change_history/change_history_test.go
@@ -130,13 +130,13 @@ func (s *ChangeHistoryTestSuite) TestChangeHistoryMigration_Migrate_CreateTable(
 	s.NoError(err)
 
 	model := &TestModel1{
-		Name: mdl.String("name1"),
+		Name: mdl.Box("name1"),
 	}
 
 	err = modelRepo.Create(context.Background(), model)
 	s.NoError(err)
 
-	model.Name = mdl.String("name2")
+	model.Name = mdl.Box("name2")
 	err = modelRepo.Update(context.Background(), model)
 	s.NoError(err)
 
@@ -182,15 +182,15 @@ func (s *ChangeHistoryTestSuite) TestChangeHistoryMigration_Migrate_UpdateTable(
 	s.NoError(err)
 
 	model := &TestModel2{
-		Name:         mdl.String("name1"),
-		Foo:          mdl.String("foo1"),
-		ChangeAuthor: mdl.String("john@example.com"),
+		Name:         mdl.Box("name1"),
+		Foo:          mdl.Box("foo1"),
+		ChangeAuthor: mdl.Box("john@example.com"),
 	}
 
 	err = modelRepo.Create(context.Background(), model)
 	s.NoError(err)
 
-	model.Foo = mdl.String("foo2")
+	model.Foo = mdl.Box("foo2")
 	err = modelRepo.Update(context.Background(), model)
 	s.NoError(err)
 

--- a/test/db-repo/query/query_test.go
+++ b/test/db-repo/query/query_test.go
@@ -65,14 +65,14 @@ func (s *DbRepoQueryTestSuite) TestCreateCorrectModel() {
 	s.NoError(err)
 
 	model := &TestModel{
-		Name: mdl.String("nameCreate1"),
+		Name: mdl.Box("nameCreate1"),
 	}
 
 	err = repo.Create(context.Background(), model)
 	s.NoError(err)
 
 	where := &TestModel{
-		Name: mdl.String("nameCreate1"),
+		Name: mdl.Box("nameCreate1"),
 	}
 
 	qb := db_repo.NewQueryBuilder()
@@ -95,7 +95,7 @@ func (s *DbRepoQueryTestSuite) TestCreateWrongModel() {
 	s.NoError(err)
 
 	model := &WrongTestModel{
-		WrongName: mdl.String("nameCreateWrong1"),
+		WrongName: mdl.Box("nameCreateWrong1"),
 	}
 
 	err = repo.Create(context.Background(), model)
@@ -112,7 +112,7 @@ func (s *DbRepoQueryTestSuite) TestReadCorrectModel() {
 	s.NoError(err)
 
 	model := &TestModel{
-		Name: mdl.String("nameRead1"),
+		Name: mdl.Box("nameRead1"),
 	}
 
 	err = repo.Create(context.Background(), model)
@@ -136,7 +136,7 @@ func (s *DbRepoQueryTestSuite) TestReadWrongModel() {
 
 	model := &WrongTestModel{}
 
-	err = repo.Read(context.Background(), mdl.Uint(1), model)
+	err = repo.Read(context.Background(), mdl.Box(uint(1)), model)
 	s.EqualError(err, "cross reading wrong model from repo")
 }
 
@@ -150,14 +150,14 @@ func (s *DbRepoQueryTestSuite) TestUpdateCorrectModel() {
 	s.NoError(err)
 
 	model := &TestModel{
-		Name: mdl.String("nameUpdate1"),
+		Name: mdl.Box("nameUpdate1"),
 	}
 
 	err = repo.Create(context.Background(), model)
 	s.NoError(err)
 
 	where := &TestModel{
-		Name: mdl.String("nameUpdate1"),
+		Name: mdl.Box("nameUpdate1"),
 	}
 
 	qb := db_repo.NewQueryBuilder()
@@ -169,13 +169,13 @@ func (s *DbRepoQueryTestSuite) TestUpdateCorrectModel() {
 	s.Equal(1, len(models), "expected 1 test model")
 	s.Equal(*model, models[0])
 
-	model.Name = mdl.String("nameUpdate1Updated")
+	model.Name = mdl.Box("nameUpdate1Updated")
 
 	err = repo.Update(context.Background(), model)
 	s.NoError(err)
 
 	where = &TestModel{
-		Name: mdl.String("nameUpdate1Updated"),
+		Name: mdl.Box("nameUpdate1Updated"),
 	}
 
 	qb = db_repo.NewQueryBuilder()
@@ -198,7 +198,7 @@ func (s *DbRepoQueryTestSuite) TestUpdateWrongModel() {
 	s.NoError(err)
 
 	model := &WrongTestModel{
-		WrongName: mdl.String("nameUpdateWrong1"),
+		WrongName: mdl.Box("nameUpdateWrong1"),
 	}
 
 	err = repo.Update(context.Background(), model)
@@ -215,7 +215,7 @@ func (s *DbRepoQueryTestSuite) TestDeleteCorrectModel() {
 	s.NoError(err)
 
 	model := &TestModel{
-		Name: mdl.String("nameDelete1"),
+		Name: mdl.Box("nameDelete1"),
 	}
 
 	err = repo.Create(context.Background(), model)
@@ -235,7 +235,7 @@ func (s *DbRepoQueryTestSuite) TestDeleteWrongModel() {
 	s.NoError(err)
 
 	model := &WrongTestModel{
-		WrongName: mdl.String("nameUpdateWrong1"),
+		WrongName: mdl.Box("nameUpdateWrong1"),
 	}
 
 	err = repo.Delete(context.Background(), model)
@@ -252,21 +252,21 @@ func (s *DbRepoQueryTestSuite) TestQueryCorrectModel() {
 	s.NoError(err)
 
 	model := &TestModel{
-		Name: mdl.String("name1"),
+		Name: mdl.Box("name1"),
 	}
 
 	err = repo.Create(context.Background(), model)
 	s.NoError(err)
 
 	model = &TestModel{
-		Name: mdl.String("name2"),
+		Name: mdl.Box("name2"),
 	}
 
 	err = repo.Create(context.Background(), model)
 	s.NoError(err)
 
 	where := &TestModel{
-		Name: mdl.String("name1"),
+		Name: mdl.Box("name1"),
 	}
 
 	qb := db_repo.NewQueryBuilder()
@@ -281,7 +281,7 @@ func (s *DbRepoQueryTestSuite) TestQueryCorrectModel() {
 	whereStr := "name = ?"
 
 	qb = db_repo.NewQueryBuilder()
-	qb.Where(whereStr, mdl.String("name2"))
+	qb.Where(whereStr, mdl.Box("name2"))
 
 	models = make([]TestModel, 0)
 	err = repo.Query(context.Background(), qb, &models)
@@ -300,21 +300,21 @@ func (s *DbRepoQueryTestSuite) TestQueryWrongResultModel() {
 	s.NoError(err)
 
 	model := &TestModel{
-		Name: mdl.String("name3"),
+		Name: mdl.Box("name3"),
 	}
 
 	err = repo.Create(context.Background(), model)
 	s.NoError(err)
 
 	model = &TestModel{
-		Name: mdl.String("name4"),
+		Name: mdl.Box("name4"),
 	}
 
 	err = repo.Create(context.Background(), model)
 	s.NoError(err)
 
 	where := &TestModel{
-		Name: mdl.String("name3"),
+		Name: mdl.Box("name3"),
 	}
 
 	qb := db_repo.NewQueryBuilder()
@@ -339,7 +339,7 @@ func (s *DbRepoQueryTestSuite) TestQueryWrongModel() {
 	s.NoError(err)
 
 	where := &WrongTestModel{
-		WrongName: mdl.String("name1"),
+		WrongName: mdl.Box("name1"),
 	}
 
 	qb := db_repo.NewQueryBuilder()
@@ -350,7 +350,7 @@ func (s *DbRepoQueryTestSuite) TestQueryWrongModel() {
 	s.EqualError(err, "cross querying wrong model from repo")
 
 	whereStruct := WrongTestModel{
-		WrongName: mdl.String("name1"),
+		WrongName: mdl.Box("name1"),
 	}
 
 	qb = db_repo.NewQueryBuilder()

--- a/test/fixtures/dynamodb/dynamodb_test.go
+++ b/test/fixtures/dynamodb/dynamodb_test.go
@@ -20,7 +20,6 @@ import (
 
 type DynamoDbSuite struct {
 	suite.Suite
-	ddbSettings *ddb.Settings
 }
 
 func (s *DynamoDbSuite) SetupSuite() []suite.Option {

--- a/test/fixtures/mysql/mysql_test.go
+++ b/test/fixtures/mysql/mysql_test.go
@@ -120,7 +120,7 @@ func ormMysqlTestFixtures() []*fixtures.FixtureSet {
 			Writer:  fixtures.MysqlOrmFixtureWriterFactory(&MysqlTestModelMetadata),
 			Fixtures: []interface{}{
 				&MysqlTestModel{
-					Name: mdl.String("testName"),
+					Name: mdl.Box("testName"),
 				},
 			},
 		},
@@ -135,7 +135,7 @@ func ormMysqlTestFixturesWithPurge() []*fixtures.FixtureSet {
 			Writer:  fixtures.MysqlOrmFixtureWriterFactory(&MysqlTestModelMetadata),
 			Fixtures: []interface{}{
 				&MysqlTestModel{
-					Name: mdl.String("purgedBefore"),
+					Name: mdl.Box("purgedBefore"),
 				},
 			},
 		},

--- a/test/fixtures/s3/s3_test.go
+++ b/test/fixtures/s3/s3_test.go
@@ -6,7 +6,6 @@ package s3_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -88,7 +87,7 @@ func (s *S3TestSuite) TestS3WithPurge() {
 
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(bucketName),
-		Key:    aws.String(fmt.Sprint("subDir/nyan_cat1.gif")),
+		Key:    aws.String("subDir/nyan_cat1.gif"),
 	}
 	output, err := s3Client.GetObject(context.Background(), input)
 	s.NoError(err)
@@ -103,7 +102,7 @@ func (s *S3TestSuite) TestS3WithPurge() {
 
 	input = &s3.GetObjectInput{
 		Bucket: aws.String(bucketName),
-		Key:    aws.String(fmt.Sprint("nyan_cat3.gif")),
+		Key:    aws.String("nyan_cat3.gif"),
 	}
 	output, err = s3Client.GetObject(context.Background(), input)
 	s.NoError(err)
@@ -115,7 +114,7 @@ func (s *S3TestSuite) TestS3WithPurge() {
 
 	input = &s3.GetObjectInput{
 		Bucket: aws.String(bucketName),
-		Key:    aws.String(fmt.Sprint("nyan_cat2.gif")),
+		Key:    aws.String("nyan_cat2.gif"),
 	}
 	output, err = s3Client.GetObject(context.Background(), input)
 


### PR DESCRIPTION
As Go 1.18 introduced generics, it is now possible to write some functional code in a typesafe manner. This can replace packages like `thoas/go-funk`, which uses reflection pretty heavily to implement functions that work for a given subset of types. Using reflection has a pretty heavy performance impact, which can be mitigated by using generics. The other non-generic approach of monomorphizing "by hand" (i.e. writing a function for each type) on the other hand causes heavy code duplication, while allowing for optimal performance. Using generics is a good middle ground here.

This PR implements a minimal set of useful functional helpers and benchmarks them against `thoas/go-funk`. The set of functions is kept minimal, because of the possibility that some third party library solves them even more efficiently in the future (`go-funk` does not yet have generics in place). 