### PR TITLE
test: add response templating to wiremock;

### DIFF
--- a/pkg/test/env/factory_wiremock.go
+++ b/pkg/test/env/factory_wiremock.go
@@ -54,6 +54,7 @@ func (f *wiremockFactory) configureContainer(settings interface{}) *containerCon
 			"8080/tcp": s.Port,
 		},
 		ExpireAfter: s.ExpireAfter,
+		Cmd:         []string{"--local-response-templating"},
 	}
 }
 


### PR DESCRIPTION
We want to be able to use [response templating](https://wiremock.org/docs/response-templating/) in our integration test