### PR TITLE
apiserver/auth: added new mandatory parameter to specify the apiKey provider to NewUncheckedKeyHandler and NewUncheckedKeyAuthenticator

### DIFF
--- a/pkg/apiserver/auth/unchecked_key_test.go
+++ b/pkg/apiserver/auth/unchecked_key_test.go
@@ -10,7 +10,7 @@ import (
 func TestUncheckedKey_Authenticate_InvalidKeyError(t *testing.T) {
 	logger, ginCtx := getHeaderKeyMocks("")
 
-	a := auth.NewUncheckedKeyAuthenticatorWithInterfaces(logger)
+	a := auth.NewUncheckedKeyAuthenticatorWithInterfaces(logger, auth.ProvideValueFromHeader(auth.HeaderApiKey))
 	_, err := a.IsValid(ginCtx)
 
 	if assert.Error(t, err) {
@@ -21,7 +21,7 @@ func TestUncheckedKey_Authenticate_InvalidKeyError(t *testing.T) {
 func TestUncheckedKey_Authenticate_ValidKey(t *testing.T) {
 	logger, ginCtx := getHeaderKeyMocks("t")
 
-	a := auth.NewUncheckedKeyAuthenticatorWithInterfaces(logger)
+	a := auth.NewUncheckedKeyAuthenticatorWithInterfaces(logger, auth.ProvideValueFromHeader(auth.HeaderApiKey))
 	_, err := a.IsValid(ginCtx)
 
 	ctx := ginCtx.Request.Context()


### PR DESCRIPTION
This is a breaking change. You can migrate your code without changing behavior like this:
- `auth.NewUncheckedKeyHandler(config, logger)` -> `auth.NewUncheckedKeyHandler(config, logger, auth.ProvideValueFromHeader(auth.HeaderApiKey))`
- `auth.NewUncheckedKeyAuthenticator(config, logger)` -> `auth.NewUncheckedKeyAuthenticator(config, logger, auth.ProvideValueFromHeader(auth.HeaderApiKey))`