### PR TITLE
mdlsub: allow delaying persisting subscribed models

### DIFF
--- a/pkg/mdlsub/delay_op.go
+++ b/pkg/mdlsub/delay_op.go
@@ -1,0 +1,38 @@
+package mdlsub
+
+import (
+	"errors"
+	"fmt"
+)
+
+type DelayOpError struct {
+	Err error
+}
+
+func (e DelayOpError) Unwrap() error {
+	return e.Err
+}
+
+func NewDelayOpError(err error) DelayOpError {
+	return DelayOpError{
+		Err: err,
+	}
+}
+
+func IsDelayOpError(err error) bool {
+	return errors.As(err, &DelayOpError{})
+}
+
+func (e DelayOpError) Error() string {
+	return fmt.Sprintf("delayed op error: %s", e.Err.Error())
+}
+
+func (e DelayOpError) As(target interface{}) bool {
+	if t, ok := target.(*DelayOpError); ok {
+		*t = e
+
+		return true
+	}
+
+	return false
+}

--- a/pkg/mdlsub/delay_op_test.go
+++ b/pkg/mdlsub/delay_op_test.go
@@ -1,0 +1,17 @@
+package mdlsub_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/mdlsub"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDelayOpError(t *testing.T) {
+	err := mdlsub.NewDelayOpError(fmt.Errorf("fail"))
+	assert.True(t, mdlsub.IsDelayOpError(err))
+	assert.False(t, mdlsub.IsDelayOpError(err.Unwrap()))
+
+	assert.EqualError(t, err, "delayed op error: fail")
+}


### PR DESCRIPTION
If your subscriber needs to wait before persisting a model, it can now return mdlsub.NewDelayOpError(err) from the transformer. This will then cause only a note get logged instead of an error and the model eventually retried.