### PR TITLE
kvstore: randomize ttl slightly by default;

### DIFF
--- a/pkg/kvstore/configurable.go
+++ b/pkg/kvstore/configurable.go
@@ -24,6 +24,7 @@ type ChainConfiguration struct {
 	Type                string                `cfg:"type" default:"chain" validate:"eq=chain"`
 	Elements            []string              `cfg:"elements" validate:"min=1"`
 	Ttl                 time.Duration         `cfg:"ttl"`
+	TtlRandomization    float64               `cfg:"ttl_randomization" default:"0.5" validate:"min=0,max=2"`
 	BatchSize           int                   `cfg:"batch_size" default:"100" validate:"min=1"`
 	MissingCacheEnabled bool                  `cfg:"missing_cache_enabled" default:"false"`
 	MetricsEnabled      bool                  `cfg:"metrics_enabled" default:"false"`
@@ -63,10 +64,11 @@ func newKvStoreChainFromConfig(ctx context.Context, config cfg.Config, logger lo
 			Family:      configuration.Family,
 			Application: configuration.Application,
 		},
-		Name:           name,
-		Ttl:            configuration.Ttl,
-		BatchSize:      configuration.BatchSize,
-		MetricsEnabled: configuration.MetricsEnabled,
+		Name:             name,
+		Ttl:              configuration.Ttl,
+		TtlRandomization: configuration.TtlRandomization,
+		BatchSize:        configuration.BatchSize,
+		MetricsEnabled:   configuration.MetricsEnabled,
 		InMemorySettings: InMemorySettings{
 			MaxSize:        configuration.InMemory.MaxSize,
 			Buckets:        configuration.InMemory.Buckets,

--- a/pkg/kvstore/in_memory.go
+++ b/pkg/kvstore/in_memory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/bits"
+	"math/rand"
 	"reflect"
 	"sync/atomic"
 	"time"
@@ -171,7 +172,11 @@ func (s *InMemoryKvStore) Put(_ context.Context, key interface{}, value interfac
 		value = rv.Interface()
 	}
 
-	s.cache.Set(keyStr, value, s.settings.Ttl)
+	ttl := s.settings.Ttl
+	factor := (rand.Float64() - 0.5) * s.settings.TtlRandomization
+	ttl = ttl + time.Duration(factor*float64(ttl))
+
+	s.cache.Set(keyStr, value, ttl)
 
 	atomic.AddInt64(s.cacheSize, 1)
 

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -13,10 +13,11 @@ import (
 
 type Settings struct {
 	cfg.AppId
-	Name           string
-	Ttl            time.Duration
-	BatchSize      int
-	MetricsEnabled bool
+	Name             string
+	Ttl              time.Duration
+	TtlRandomization float64
+	BatchSize        int
+	MetricsEnabled   bool
 	InMemorySettings
 }
 


### PR DESCRIPTION
Imagine you have a service and are using a kvstore. You deploy the service with some capacity in DDB for the initial load of requests until the caches are warmed up. After 1h the caches expire and you now have a thundering herd trying to refresh these caches, so you run into capacity problems because of your cache expiring almost all elements at the same time.

To combat this, this commit introduces and enables by default a randomization factor (default: between 75% and 125% of the TTL is applied, but you can go as far as 0% to 200% if you really want to) to the time we store data in the in-memory store and Redis. Thus, different elements in your cache will expire at different times even though they were initially requested at the same time, spreading the load.