### PR TITLE
redis: add sorted sets operations

### DIFF
--- a/pkg/redis/client.go
+++ b/pkg/redis/client.go
@@ -69,6 +69,19 @@ type Client interface {
 	PFCount(ctx context.Context, keys ...string) (int64, error)
 	PFMerge(ctx context.Context, dest string, keys ...string) (string, error)
 
+	ZAdd(ctx context.Context, key string, score float64, member string) (int64, error)
+	ZCard(ctx context.Context, key string) (int64, error)
+	ZCount(ctx context.Context, key string, min string, max string) (int64, error)
+	ZIncrBy(ctx context.Context, key string, increment float64, member string) (float64, error)
+	ZScore(ctx context.Context, key string, member string) (float64, error)
+	ZMScore(ctx context.Context, key string, members ...string) ([]float64, error)
+	ZRange(ctx context.Context, key string, start int64, stop int64) ([]string, error)
+	ZRandMember(ctx context.Context, key string, count int, withScores bool) ([]string, error)
+	ZRank(ctx context.Context, key string, member string) (int64, error)
+	ZRem(ctx context.Context, key string, members ...string) (int64, error)
+	ZRevRange(ctx context.Context, key string, start int64, stop int64) ([]string, error)
+	ZRevRank(ctx context.Context, key string, member string) (int64, error)
+
 	IsAlive(ctx context.Context) bool
 
 	Pipeline() Pipeliner
@@ -387,6 +400,107 @@ func (c *redisClient) PFMerge(ctx context.Context, dest string, keys ...string) 
 	})
 
 	return cmd.(*baseRedis.StatusCmd).Val(), err
+}
+
+func (c *redisClient) ZAdd(ctx context.Context, key string, score float64, member string) (int64, error) {
+	z := &baseRedis.Z{
+		Score:  score,
+		Member: member,
+	}
+
+	cmd, err := c.execute(ctx, func() ErrCmder {
+		return c.base.ZAdd(ctx, key, z)
+	})
+
+	return cmd.(*baseRedis.IntCmd).Val(), err
+}
+
+func (c *redisClient) ZCard(ctx context.Context, key string) (int64, error) {
+	cmd, err := c.execute(ctx, func() ErrCmder {
+		return c.base.ZCard(ctx, key)
+	})
+
+	return cmd.(*baseRedis.IntCmd).Val(), err
+}
+
+func (c *redisClient) ZCount(ctx context.Context, key string, min string, max string) (int64, error) {
+	cmd, err := c.execute(ctx, func() ErrCmder {
+		return c.base.ZCount(ctx, key, min, max)
+	})
+
+	return cmd.(*baseRedis.IntCmd).Val(), err
+}
+
+func (c *redisClient) ZIncrBy(ctx context.Context, key string, increment float64, member string) (float64, error) {
+	cmd, err := c.execute(ctx, func() ErrCmder {
+		return c.base.ZIncrBy(ctx, key, increment, member)
+	})
+
+	return cmd.(*baseRedis.FloatCmd).Val(), err
+}
+
+func (c *redisClient) ZScore(ctx context.Context, key string, member string) (float64, error) {
+	cmd, err := c.execute(ctx, func() ErrCmder {
+		return c.base.ZScore(ctx, key, member)
+	})
+
+	return cmd.(*baseRedis.FloatCmd).Val(), err
+}
+
+func (c *redisClient) ZMScore(ctx context.Context, key string, members ...string) ([]float64, error) {
+	cmd, err := c.execute(ctx, func() ErrCmder {
+		return c.base.ZMScore(ctx, key, members...)
+	})
+
+	return cmd.(*baseRedis.FloatSliceCmd).Val(), err
+}
+
+func (c *redisClient) ZRange(ctx context.Context, key string, start int64, stop int64) ([]string, error) {
+	cmd, err := c.execute(ctx, func() ErrCmder {
+		return c.base.ZRange(ctx, key, start, stop)
+	})
+
+	return cmd.(*baseRedis.StringSliceCmd).Val(), err
+}
+
+func (c *redisClient) ZRandMember(ctx context.Context, key string, count int, withScores bool) ([]string, error) {
+	cmd, err := c.execute(ctx, func() ErrCmder {
+		return c.base.ZRandMember(ctx, key, count, withScores)
+	})
+
+	return cmd.(*baseRedis.StringSliceCmd).Val(), err
+}
+
+func (c *redisClient) ZRank(ctx context.Context, key string, member string) (int64, error) {
+	cmd, err := c.execute(ctx, func() ErrCmder {
+		return c.base.ZRank(ctx, key, member)
+	})
+
+	return cmd.(*baseRedis.IntCmd).Val(), err
+}
+
+func (c *redisClient) ZRem(ctx context.Context, key string, members ...string) (int64, error) {
+	cmd, err := c.execute(ctx, func() ErrCmder {
+		return c.base.ZRem(ctx, key, members)
+	})
+
+	return cmd.(*baseRedis.IntCmd).Val(), err
+}
+
+func (c *redisClient) ZRevRange(ctx context.Context, key string, start int64, stop int64) ([]string, error) {
+	cmd, err := c.execute(ctx, func() ErrCmder {
+		return c.base.ZRevRange(ctx, key, start, stop)
+	})
+
+	return cmd.(*baseRedis.StringSliceCmd).Val(), err
+}
+
+func (c *redisClient) ZRevRank(ctx context.Context, key string, member string) (int64, error) {
+	cmd, err := c.execute(ctx, func() ErrCmder {
+		return c.base.ZRevRank(ctx, key, member)
+	})
+
+	return cmd.(*baseRedis.IntCmd).Val(), err
 }
 
 func (c *redisClient) IsAlive(ctx context.Context) bool {

--- a/pkg/redis/client_test.go
+++ b/pkg/redis/client_test.go
@@ -240,6 +240,134 @@ func (s *ClientWithMiniRedisTestSuite) TestDecr() {
 	s.Equal(int64(3), val)
 }
 
+func (s *ClientWithMiniRedisTestSuite) TestZAdd() {
+	inserts, err := s.client.ZAdd(context.Background(), "key", 10.0, "member")
+	s.NoError(err, "there should be no error on ZAdd")
+	s.EqualValues(1, inserts)
+}
+
+func (s *ClientWithMiniRedisTestSuite) TestZCard() {
+	cardinality, err := s.client.ZCard(context.Background(), "key")
+	s.NoError(err, "there should be no error on ZCard")
+	s.EqualValues(0, cardinality)
+
+	_, err = s.client.ZAdd(context.Background(), "key", 10.0, "member0")
+	s.NoError(err, "there should be no error on ZAdd")
+
+	_, err = s.client.ZAdd(context.Background(), "key", 10.0, "member1")
+	s.NoError(err, "there should be no error on ZAdd")
+
+	_, err = s.client.ZAdd(context.Background(), "key", 11.0, "member2")
+	s.NoError(err, "there should be no error on ZAdd")
+
+	_, err = s.client.ZAdd(context.Background(), "key", 12.0, "member3")
+	s.NoError(err, "there should be no error on ZAdd")
+
+	cardinality, err = s.client.ZCard(context.Background(), "key")
+	s.NoError(err, "there should be no error on ZCard")
+	s.EqualValues(4, cardinality)
+}
+
+func (s *ClientWithMiniRedisTestSuite) TestZScore() {
+	_, err := s.client.ZAdd(context.Background(), "key", 10.0, "member")
+
+	score, err := s.client.ZScore(context.Background(), "key", "member")
+	s.NoError(err, "there should be no error on ZScore")
+	s.EqualValues(10.0, score)
+}
+
+func (s *ClientWithMiniRedisTestSuite) TestZRange() {
+	_, err := s.client.ZAdd(context.Background(), "key", 10, "member0")
+	_, err = s.client.ZAdd(context.Background(), "key", 50, "member1")
+	_, err = s.client.ZAdd(context.Background(), "key", 90, "member2")
+	_, err = s.client.ZAdd(context.Background(), "key", 100, "member3")
+	_, err = s.client.ZAdd(context.Background(), "key", 120, "member4")
+
+	members, err := s.client.ZRange(context.Background(), "key", 1, 2)
+	s.NoError(err, "there should be no error on ZRange")
+	s.EqualValues(2, len(members))
+	s.Equal("member1", members[0])
+	s.Equal("member2", members[1])
+}
+
+func (s *ClientWithMiniRedisTestSuite) TestZRevRange() {
+	_, err := s.client.ZAdd(context.Background(), "key", 10, "member0")
+	_, err = s.client.ZAdd(context.Background(), "key", 50, "member1")
+	_, err = s.client.ZAdd(context.Background(), "key", 90, "member2")
+	_, err = s.client.ZAdd(context.Background(), "key", 100, "member3")
+	_, err = s.client.ZAdd(context.Background(), "key", 120, "member4")
+
+	members, err := s.client.ZRevRange(context.Background(), "key", 1, 2)
+	s.NoError(err, "there should be no error on ZRevRange")
+	s.EqualValues(2, len(members))
+	s.Equal("member3", members[0])
+	s.Equal("member2", members[1])
+}
+
+func (s *ClientWithMiniRedisTestSuite) TestZRank() {
+	_, err := s.client.ZAdd(context.Background(), "key", 10, "member0")
+	_, err = s.client.ZAdd(context.Background(), "key", 50, "member1")
+	_, err = s.client.ZAdd(context.Background(), "key", 90, "member2")
+	_, err = s.client.ZAdd(context.Background(), "key", 100, "member3")
+	_, err = s.client.ZAdd(context.Background(), "key", 120, "member4")
+
+	rank, err := s.client.ZRank(context.Background(), "key", "member3")
+	s.NoError(err, "there should be no error on ZRank")
+	s.EqualValues(3, rank)
+}
+
+func (s *ClientWithMiniRedisTestSuite) TestZRevRank() {
+	_, err := s.client.ZAdd(context.Background(), "key", 10, "member0")
+	_, err = s.client.ZAdd(context.Background(), "key", 50, "member1")
+	_, err = s.client.ZAdd(context.Background(), "key", 90, "member2")
+	_, err = s.client.ZAdd(context.Background(), "key", 100, "member3")
+	_, err = s.client.ZAdd(context.Background(), "key", 120, "member4")
+
+	rank, err := s.client.ZRevRank(context.Background(), "key", "member3")
+	s.NoError(err, "there should be no error on ZRevRank")
+	s.EqualValues(1, rank)
+}
+
+func (s *ClientWithMiniRedisTestSuite) TestZRem() {
+	_, err := s.client.ZAdd(context.Background(), "key", 10, "member0")
+	_, err = s.client.ZAdd(context.Background(), "key", 50, "member1")
+	_, err = s.client.ZAdd(context.Background(), "key", 90, "member2")
+	_, err = s.client.ZAdd(context.Background(), "key", 100, "member3")
+	_, err = s.client.ZAdd(context.Background(), "key", 120, "member4")
+
+	removes, err := s.client.ZRem(context.Background(), "key", "member2", "member3", "memberX")
+	s.NoError(err, "there should be no error on ZRem")
+	s.EqualValues(2, removes)
+}
+
+// Following commented redis v8 operations are not supported by miniredis yet
+// so we can't unit-test them.
+// Issue: https://github.com/alicebob/miniredis/issues/302
+// TODO: Check if miniredis supports redis v8 already and update
+
+//func (s *ClientWithMiniRedisTestSuite) TestZRandMember() {
+//
+//	_, err := s.client.ZAdd(context.Background(), "key", 10, "member0")
+//	_, err = s.client.ZAdd(context.Background(), "key", 50, "member1")
+//	_, err = s.client.ZAdd(context.Background(), "key", 90, "member2")
+//	_, err = s.client.ZAdd(context.Background(), "key", 100, "member3")
+//	_, err = s.client.ZAdd(context.Background(), "key", 120, "member4")
+//
+//	members, err := s.client.ZRandMember(context.Background(), "key", 2, true)
+//	s.NoError(err, "there should be no error on ZRandMember")
+//	s.EqualValues(2, len(members))
+//}
+
+//func (s *ClientWithMiniRedisTestSuite) TestZMScore() {
+//	_, err := s.client.ZAdd(context.Background(), "key", 10, "member0")
+//	_, err = s.client.ZAdd(context.Background(), "key", 50, "member1")
+//
+//	scores, err := s.client.ZMScore(context.Background(), "key", "member0", "member1")
+//	s.NoError(err, "there should be no error on ZMScore")
+//	s.EqualValues(10.0, scores[0])
+//	s.EqualValues(50.0, scores[1])
+//}
+
 func (s *ClientWithMiniRedisTestSuite) TestExpire() {
 	_, _ = s.client.Incr(context.Background(), "key")
 


### PR DESCRIPTION
I added some of the [sorted set operations](https://redis.io/commands/?group=sorted-set) supported by redis.

- `ZAdd`
- `ZCard`
- `ZCount`
- `ZIncrBy`
- `ZScore`
- `ZMScore`
- `ZRange`
- `ZRandMember`
- `ZRank`
- `ZRem`