### PR TITLE
apiserver: don't trigger an error for unknown routes or /;

### DIFF
--- a/pkg/apiserver/middleware_metric.go
+++ b/pkg/apiserver/middleware_metric.go
@@ -30,8 +30,17 @@ func NewMetricMiddleware() (gin.HandlerFunc, func(definitions []Definition)) {
 func metricMiddleware(ginCtx *gin.Context, writer metric.Writer) {
 	start := time.Now()
 	path := ginCtx.FullPath()
+	if path == "" {
+		// the path was not found, so no need to print anything
+		return
+	}
+
 	path = strings.TrimRight(path, "/")
 	path = removeDuplicates(path)
+	if path == "" {
+		// we have a route at the root, so we have to use a single slash; empty dimensions are forbidden by cloudwatch
+		path = "/"
+	}
 
 	ginCtx.Next()
 


### PR DESCRIPTION
- / would be trimmed to an empty string should you have a route there, now we write the metric with / as path
- unknown routes also return an empty string, we don't need to write metrics for them