### PR TITLE
sqs: use a configurable naming pattern instead of a coded strategy

### DIFF
--- a/pkg/cloud/aws/awsv2.go
+++ b/pkg/cloud/aws/awsv2.go
@@ -53,8 +53,8 @@ func UnmarshalClientSettings(config cfg.Config, settings ClientSettingsAware, se
 		name = "default"
 	}
 
-	clientsKey := fmt.Sprintf("cloud.aws.%s.clients.%s", service, name)
-	defaultClientKey := fmt.Sprintf("cloud.aws.%s.clients.default", service)
+	clientsKey := GetClientConfigKey(service, name)
+	defaultClientKey := GetClientConfigKey(service, "default")
 
 	config.UnmarshalKey(clientsKey, settings, []cfg.UnmarshalDefaults{
 		cfg.UnmarshalWithDefaultsFromKey("cloud.aws.defaults.region", "region"),
@@ -178,4 +178,8 @@ func (l Logger) WithContext(ctx context.Context) logging.Logger {
 	return &Logger{
 		base: l.base.WithContext(ctx),
 	}
+}
+
+func GetClientConfigKey(service string, name string) string {
+	return fmt.Sprintf("cloud.aws.%s.clients.%s", service, name)
 }

--- a/pkg/cloud/aws/sqs/naming_test.go
+++ b/pkg/cloud/aws/sqs/naming_test.go
@@ -1,0 +1,74 @@
+package sqs_test
+
+import (
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/cloud/aws/sqs"
+	"github.com/justtrackio/gosoline/pkg/stream"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestGetSqsQueueNameTestSuite(t *testing.T) {
+	suite.Run(t, new(GetSqsQueueNameTestSuite))
+}
+
+type GetSqsQueueNameTestSuite struct {
+	suite.Suite
+	config   cfg.GosoConf
+	settings stream.SqsOutputSettings
+}
+
+func (s *GetSqsQueueNameTestSuite) SetupTest() {
+	s.config = cfg.New()
+	s.settings = stream.SqsOutputSettings{
+		AppId: cfg.AppId{
+			Project:     "justtrack",
+			Environment: "test",
+			Family:      "gosoline",
+			Application: "producer",
+		},
+		ClientName: "default",
+		QueueId:    "event",
+	}
+}
+
+func (s *GetSqsQueueNameTestSuite) setupConfig(settings map[string]interface{}) {
+	err := s.config.Option(cfg.WithConfigMap(settings))
+	s.NoError(err, "there should be no error on setting up the config")
+}
+
+func (s *GetSqsQueueNameTestSuite) TestDefault() {
+	name, err := sqs.GetQueueName(s.config, s.settings)
+	s.NoError(err)
+	s.Equal("justtrack-test-gosoline-producer-event", name)
+}
+
+func (s *GetSqsQueueNameTestSuite) TestDefaultFifo() {
+	s.settings.Fifo.Enabled = true
+
+	name, err := sqs.GetQueueName(s.config, s.settings)
+	s.NoError(err)
+	s.Equal("justtrack-test-gosoline-producer-event.fifo", name)
+}
+
+func (s *GetSqsQueueNameTestSuite) TestDefaultWithPattern() {
+	s.setupConfig(map[string]interface{}{
+		"cloud.aws.sqs.clients.default.naming.pattern": "{app}-{queueId}",
+	})
+
+	name, err := sqs.GetQueueName(s.config, s.settings)
+	s.NoError(err)
+	s.Equal("producer-event", name)
+}
+
+func (s *GetSqsQueueNameTestSuite) TestSpecificClientWithPattern() {
+	s.settings.ClientName = "specific"
+	s.setupConfig(map[string]interface{}{
+		"cloud.aws.sqs.clients.specific.naming.pattern": "{app}-{queueId}",
+	})
+
+	name, err := sqs.GetQueueName(s.config, s.settings)
+	s.NoError(err)
+	s.Equal("producer-event", name)
+}

--- a/pkg/cloud/aws/sqs/service.go
+++ b/pkg/cloud/aws/sqs/service.go
@@ -17,7 +17,11 @@ import (
 	"github.com/justtrackio/gosoline/pkg/log"
 )
 
-const DefaultVisibilityTimeout = "30"
+const (
+	DefaultVisibilityTimeout = "30"
+	DeadletterFifoSuffix     = "-dead.fifo"
+	FifoSuffix               = ".fifo"
+)
 
 type ServiceSettings struct {
 	AutoCreate bool
@@ -245,7 +249,7 @@ func (s *service) createDeadLetterQueue(ctx context.Context, settings *Settings)
 
 	if settings.Fifo.Enabled {
 		deadLetterAttributes[string(types.QueueAttributeNameFifoQueue)] = "true"
-		deadLetterName = strings.Replace(settings.QueueName, fifoSuffix, deadletterFifoSuffix, 1)
+		deadLetterName = strings.Replace(settings.QueueName, FifoSuffix, DeadletterFifoSuffix, 1)
 	}
 
 	deadLetterInput := &sqs.CreateQueueInput{

--- a/pkg/stream/input_configurable.go
+++ b/pkg/stream/input_configurable.go
@@ -220,7 +220,7 @@ type sqsInputConfiguration struct {
 	RunnerCount         int               `cfg:"runner_count" default:"1" validate:"min=1"`
 	Fifo                sqs.FifoSettings  `cfg:"fifo"`
 	RedrivePolicy       sqs.RedrivePolicy `cfg:"redrive_policy"`
-	ClientName          string            `cfg:"client_name"`
+	ClientName          string            `cfg:"client_name" default:"default"`
 	Unmarshaller        string            `cfg:"unmarshaller" default:"msg"`
 }
 
@@ -229,11 +229,6 @@ func readSqsInputSettings(config cfg.Config, name string) *SqsInputSettings {
 
 	configuration := sqsInputConfiguration{}
 	config.UnmarshalKey(key, &configuration)
-
-	clientName := configuration.ClientName
-	if clientName == "" {
-		clientName = fmt.Sprintf("stream-input-%s", name)
-	}
 
 	settings := &SqsInputSettings{
 		AppId: cfg.AppId{
@@ -247,7 +242,7 @@ func readSqsInputSettings(config cfg.Config, name string) *SqsInputSettings {
 		RunnerCount:         configuration.RunnerCount,
 		Fifo:                configuration.Fifo,
 		RedrivePolicy:       configuration.RedrivePolicy,
-		ClientName:          clientName,
+		ClientName:          configuration.ClientName,
 		Unmarshaller:        configuration.Unmarshaller,
 	}
 

--- a/pkg/stream/input_sns.go
+++ b/pkg/stream/input_sns.go
@@ -28,6 +28,10 @@ func (s SnsInputSettings) GetAppid() cfg.AppId {
 	return s.AppId
 }
 
+func (s SnsInputSettings) GetClientName() string {
+	return s.ClientName
+}
+
 func (s SnsInputSettings) GetQueueId() string {
 	return s.QueueId
 }

--- a/pkg/stream/output_configurable.go
+++ b/pkg/stream/output_configurable.go
@@ -187,18 +187,13 @@ type SqsOutputConfiguration struct {
 	VisibilityTimeout int               `cfg:"visibility_timeout" default:"30" validate:"gt=0"`
 	RedrivePolicy     sqs.RedrivePolicy `cfg:"redrive_policy"`
 	Fifo              sqs.FifoSettings  `cfg:"fifo"`
-	ClientName        string            `cfg:"client_name"`
+	ClientName        string            `cfg:"client_name" default:"default"`
 }
 
 func newSqsOutputFromConfig(ctx context.Context, config cfg.Config, logger log.Logger, name string) (Output, error) {
 	key := ConfigurableOutputKey(name)
 	configuration := SqsOutputConfiguration{}
 	config.UnmarshalKey(key, &configuration)
-
-	clientName := configuration.ClientName
-	if clientName == "" {
-		clientName = fmt.Sprintf("stream-output-%s", name)
-	}
 
 	return NewSqsOutput(ctx, config, logger, &SqsOutputSettings{
 		AppId: cfg.AppId{
@@ -210,7 +205,7 @@ func newSqsOutputFromConfig(ctx context.Context, config cfg.Config, logger log.L
 		VisibilityTimeout: configuration.VisibilityTimeout,
 		RedrivePolicy:     configuration.RedrivePolicy,
 		Fifo:              configuration.Fifo,
-		ClientName:        clientName,
+		ClientName:        configuration.ClientName,
 	})
 }
 

--- a/pkg/stream/retry_sqs.go
+++ b/pkg/stream/retry_sqs.go
@@ -17,7 +17,7 @@ func init() {
 
 type RetryHandlerSqsSettings struct {
 	RetryHandlerSettings
-	ClientName          string `cfg:"client_name"`
+	ClientName          string `cfg:"client_name" default:"default"`
 	MaxNumberOfMessages int32  `cfg:"max_number_of_messages" default:"10" validate:"min=1,max=10"`
 	WaitTime            int32  `cfg:"wait_time" default:"10"`
 	RunnerCount         int    `cfg:"runner_count" default:"1"`


### PR DESCRIPTION
To make it easier to configure different naming pattern for different sqs clients, we want to be able to configure the queue name patterns on client level:

```
cloud:
  aws:
    sqs:
      clients:
        account_a:
          naming:
            pattern: {env}-{family}-{app}-{queueId}
        account_b:
          naming:
            pattern: {app}_{queueId}
```