### PR TITLE
cfg: introduce nodecode flag to disable string augmentation

### DIFF
--- a/pkg/cfg/config_test.go
+++ b/pkg/cfg/config_test.go
@@ -177,6 +177,14 @@ func (s *ConfigTestSuite) TestConfig_GetString() {
 	s.Equal("default", s.config.GetString("missing", "default"))
 }
 
+func (s *ConfigTestSuite) TestConfig_GetStringNoDecode() {
+	s.setupConfigValues(map[string]interface{}{
+		"nodecode": "!nodecode {this}-should-{be}-plain",
+	})
+
+	s.Equal("{this}-should-{be}-plain", s.config.GetString("nodecode"))
+}
+
 func (s *ConfigTestSuite) TestConfig_GetStringMapString() {
 	s.setupConfigValues(map[string]interface{}{
 		"map": map[string]interface{}{


### PR DESCRIPTION
string values can be prefixed with !nodecode to disable string augmentation..
E.g. setting an env variable like `FOO="!nodecode this should be {plain} bar"` will not try to replace `{plain}`..