### PR TITLE
Fix blob runner test suite exit

### DIFF
--- a/pkg/funk/slice.go
+++ b/pkg/funk/slice.go
@@ -27,6 +27,17 @@ func CastSlice[T any, I ~[]any](sl I) ([]T, error) {
 	return result, nil
 }
 
+func Partition[S ~[]T, T any, E comparable](sl S, keyer func(T) E) map[E][]T {
+	result := make(map[E][]T)
+
+	for i := 0; i < len(sl); i++ {
+		key := keyer(sl[i])
+		result[key] = append(result[key], sl[i])
+	}
+
+	return result
+}
+
 func Chunk[S ~[]T, T any](sl S, size int) [][]T {
 	if size <= 0 {
 		return nil

--- a/pkg/funk/slice_test.go
+++ b/pkg/funk/slice_test.go
@@ -174,7 +174,7 @@ func TestIndex(t *testing.T) {
 		Foo string
 	}
 
-	var tests = map[string]struct {
+	tests := map[string]struct {
 		in    []obj
 		index int
 	}{
@@ -339,7 +339,7 @@ func TestRepeatStructPointer(t *testing.T) {
 }
 
 func TestTail(t *testing.T) {
-	var tests = map[string]struct {
+	tests := map[string]struct {
 		input    []string
 		expected []string
 	}{
@@ -394,6 +394,68 @@ func TestReverse(t *testing.T) {
 		data := data
 		t.Run(name, func(t *testing.T) {
 			res := funk.Reverse(data.In)
+			assert.Equal(t, data.Out, res)
+		})
+	}
+}
+
+type partitionable struct {
+	name string
+	time int
+}
+
+func TestPartition(t *testing.T) {
+	tests := map[string]struct {
+		In  []partitionable
+		Out map[int][]partitionable
+	}{
+		"simple": {
+			In: []partitionable{
+				{"a", 1},
+				{"b", 1},
+				{"c", 2},
+				{"d", 2},
+				{"e", 4},
+			},
+			Out: map[int][]partitionable{
+				1: {
+					{"a", 1},
+					{"b", 1},
+				},
+				2: {
+					{"c", 2},
+					{"d", 2},
+				},
+				4: {
+					{"e", 4},
+				},
+			},
+		},
+		"empty": {
+			In:  []partitionable{},
+			Out: map[int][]partitionable{},
+		},
+		"all in one partition": {
+			In: []partitionable{
+				{"a", 1},
+				{"b", 1},
+			},
+			Out: map[int][]partitionable{
+				1: {
+					{"a", 1},
+					{"b", 1},
+				},
+			},
+		},
+	}
+
+	for name, data := range tests {
+		data := data
+		t.Run(name, func(t *testing.T) {
+			res := funk.Partition(data.In, func(t partitionable) int {
+				return t.time
+			})
+
 			assert.Equal(t, data.Out, res)
 		})
 	}


### PR DESCRIPTION
With the current implementation of the application test suite we can run into problems with foreground modules:
If we have some module running in the service stage that coordinates its exit using the context provided by the kernel that our test depends on, the test will be started in the application stage. If the test application then exists, the kernel package will not teardown modules in the service or essential stage, which will lead to our service being run indefinitely.
This PR makes every module in the application stage (the app under test) an essential module, which will lead to all other modules being teared down correctly. 