### PR TITLE
apiserver/auth: added new error to communicate wrong bearers to the caller;

### DIFF
--- a/pkg/apiserver/auth/token_bearer_test.go
+++ b/pkg/apiserver/auth/token_bearer_test.go
@@ -52,7 +52,9 @@ func makeKvStoreProvider(test *tokenBearerTestCase) (auth.TokenBearerProvider, [
 		}).Return(test.bearer != nil, test.bearerErr).Once()
 	}
 
-	return auth.ProvideTokenBearerFromGetter(repo, func() auth.TokenBearer {
+	return auth.ProvideTokenBearerFromGetter(func(ctx context.Context, key string, value auth.TokenBearer) (bool, error) {
+		return repo.Get(ctx, key, value)
+	}, func() auth.TokenBearer {
 		return &bearer{}
 	}), []hasExpectations{repo}
 }


### PR DESCRIPTION
Suppose you have some combination of key ID and key and are presented with a valid key, but an invalid key ID. You could just reject the request, but it might be helpful to include the information of the invalid key ID in your error message (instead of leaving the user scratching their head as the key itself is clearly correct). An attacker is unlikely to learn something in this case as long as they can't easily guess your keys (so doing this for normal user/password combinations would be bad, but if you have long randomly generated keys, it is fine).