### PR TITLE
http: added retry reset readers to http client configuration;

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -88,8 +88,8 @@ jobs:
       - name: Static code analysis (golangci-lint)
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45.2
-          args: --timeout 5m --print-issued-lines --print-linter-name --disable structcheck
+          version: v1.51.2
+          args: --timeout 5m --print-issued-lines --print-linter-name --disable structcheck --disable unused
 
   go-test:
     name: go test

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/go-playground/mold/v4 v4.2.0
 	github.com/go-playground/validator/v10 v10.10.1
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/go-resty/resty/v2 v2.7.0
+	github.com/go-resty/resty/v2 v2.7.1-0.20230308051516-1578007c3c8d
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/golang-migrate/migrate/v4 v4.15.1
 	github.com/google/go-querystring v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -584,8 +584,8 @@ github.com/go-playground/validator/v10 v10.10.1/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4
 github.com/go-redis/redis/v8 v8.11.0/go.mod h1:DLomh7y2e3ggQXQLd1YgmvIfecPJoFl7WU5SOQ/r06M=
 github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
 github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
-github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
-github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
+github.com/go-resty/resty/v2 v2.7.1-0.20230308051516-1578007c3c8d h1:ju69VdB9OlXEbh4ZJrrMnUnhSOZvXEv7LNxb2OkYkDs=
+github.com/go-resty/resty/v2 v2.7.1-0.20230308051516-1578007c3c8d/go.mod h1:GBD5wXFU+xeYWzRR14az38bMLVpl1tMxb2l/FFP/zIQ=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
@@ -1478,7 +1478,6 @@ golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211013171255-e13a2654a71e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -69,11 +69,12 @@ type client struct {
 }
 
 type Settings struct {
-	RequestTimeout   time.Duration `cfg:"request_timeout" default:"30s"`
-	RetryCount       int           `cfg:"retry_count" default:"5"`
-	RetryWaitTime    time.Duration `cfg:"retry_wait_time" default:"100ms"`
-	RetryMaxWaitTime time.Duration `cfg:"retry_max_wait_time" default:"2000ms"`
-	FollowRedirects  bool          `cfg:"follow_redirects" default:"true"`
+	FollowRedirects   bool          `cfg:"follow_redirects" default:"true"`
+	RequestTimeout    time.Duration `cfg:"request_timeout" default:"30s"`
+	RetryCount        int           `cfg:"retry_count" default:"5"`
+	RetryMaxWaitTime  time.Duration `cfg:"retry_max_wait_time" default:"2000ms"`
+	RetryResetReaders bool          `cfg:"retry_reset_readers" default:"true"`
+	RetryWaitTime     time.Duration `cfg:"retry_wait_time" default:"100ms"`
 }
 
 func NewHttpClient(config cfg.Config, logger log.Logger) Client {
@@ -106,6 +107,7 @@ func NewHttpClient(config cfg.Config, logger log.Logger) Client {
 	httpClient.SetTimeout(settings.RequestTimeout)
 	httpClient.SetRetryWaitTime(settings.RetryWaitTime)
 	httpClient.SetRetryMaxWaitTime(settings.RetryMaxWaitTime)
+	httpClient.SetRetryResetReaders(settings.RetryResetReaders)
 
 	return NewHttpClientWithInterfaces(logger, c, mo, httpClient)
 }


### PR DESCRIPTION
We want to update the resty version, as our PR was merged to support resetting io.ReadSeekers for files when they were read by the client. This lead to problems in services before as the reader is exhausted and the data can no longer be accessed in case of a retry. 