### PR TITLE
fixing the issue for invalid dimension

### DIFF
--- a/pkg/apiserver/definition.go
+++ b/pkg/apiserver/definition.go
@@ -24,7 +24,7 @@ func (d *Definition) getAbsolutePath() string {
 	groupPath := d.group.getAbsolutePath()
 
 	absolutePath := fmt.Sprintf("%s/%s", groupPath, d.relativePath)
-	absolutePath = strings.TrimRight(absolutePath, "/")
+	absolutePath = trimRightPath(absolutePath)
 
 	return removeDuplicates(absolutePath)
 }
@@ -67,7 +67,7 @@ func (d *Definitions) Use(middleware ...gin.HandlerFunc) {
 }
 
 func (d *Definitions) Handle(httpMethod, relativePath string, handlers ...gin.HandlerFunc) {
-	relativePath = strings.TrimRight(relativePath, "/")
+	relativePath = trimRightPath(relativePath)
 
 	d.routes = append(d.routes, Definition{
 		group:        d,
@@ -138,4 +138,14 @@ func removeDuplicates(s string) string {
 	}
 
 	return buf.String()
+}
+
+func trimRightPath(path string) string {
+	absolutePath := strings.TrimRight(path, "/")
+
+	if absolutePath == "" {
+		absolutePath = "/"
+	}
+
+	return absolutePath
 }

--- a/pkg/apiserver/middleware_metric.go
+++ b/pkg/apiserver/middleware_metric.go
@@ -2,7 +2,6 @@ package apiserver
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -35,12 +34,8 @@ func metricMiddleware(ginCtx *gin.Context, writer metric.Writer) {
 		return
 	}
 
-	path = strings.TrimRight(path, "/")
+	path = trimRightPath(path)
 	path = removeDuplicates(path)
-	if path == "" {
-		// we have a route at the root, so we have to use a single slash; empty dimensions are forbidden by cloudwatch
-		path = "/"
-	}
 
 	ginCtx.Next()
 


### PR DESCRIPTION
before publishing data points to metrics, in or log we get this error:

```
invalid metric dimension: 1 error occurred:
	* invalid dimension 'path' = '' for metric NAME, this will later be rejected
```

The issue is that we send '/' as the path, but due to the use of TrimRight in the getAbsolutePath() method, the path gets deleted. To resolve this problem, we can add an 'if' statement to check whether the absolutePath is empty, and if so, we can add '/' to it.

