### PR TITLE
Fix change history migration

### DIFF
--- a/pkg/db-repo/change_history_manager.go
+++ b/pkg/db-repo/change_history_manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/justtrackio/gosoline/pkg/appctx"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/coffin"
+	"github.com/justtrackio/gosoline/pkg/funk"
 	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/justtrackio/gosoline/pkg/mdl"
 )
@@ -58,7 +59,7 @@ func (c *ChangeHistoryManager) RunMigrations() error {
 	cfn := coffin.New()
 
 	cfn.Go(func() error {
-		for _, model := range c.models {
+		for _, model := range funk.UniqByType(c.models) {
 			model := model
 			cfn.Go(func() error {
 				if err := c.RunMigration(model); err != nil {

--- a/pkg/funk/slice.go
+++ b/pkg/funk/slice.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 
 	"github.com/justtrackio/gosoline/pkg/mdl"
-
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 )
@@ -279,7 +278,7 @@ func Tail[T any](sl []T) []T {
 	return sl[1:]
 }
 
-func Uniq[S ~[]T, T comparable](sl S) (out []T) {
+func Uniq[S ~[]T, T comparable](sl S) S {
 	set := make(Set[T], len(sl))
 	res := make(S, 0)
 
@@ -293,6 +292,21 @@ func Uniq[S ~[]T, T comparable](sl S) (out []T) {
 	}
 
 	return res
+}
+
+func UniqByType[S ~[]T, T any](sl S) S {
+	types := map[reflect.Type]bool{}
+
+	return Filter(sl, func(a T) bool {
+		t := reflect.TypeOf(a)
+		if types[t] {
+			return false
+		}
+
+		types[t] = true
+
+		return true
+	})
 }
 
 func equal[T any](expected T) func(actualValue T) bool {

--- a/pkg/funk/slice_test.go
+++ b/pkg/funk/slice_test.go
@@ -460,3 +460,100 @@ func TestPartition(t *testing.T) {
 		})
 	}
 }
+
+func TestUniq(t *testing.T) {
+	tests := map[string]struct {
+		In  []string
+		Out []string
+	}{
+		"nil": {
+			In:  nil,
+			Out: []string{},
+		},
+		"empty": {
+			In:  []string{},
+			Out: []string{},
+		},
+		"single": {
+			In:  []string{"a"},
+			Out: []string{"a"},
+		},
+		"repeated": {
+			In:  []string{"a", "a"},
+			Out: []string{"a"},
+		},
+		"pair": {
+			In:  []string{"a", "b"},
+			Out: []string{"a", "b"},
+		},
+		"repeatedPair": {
+			In:  []string{"a", "b", "a", "b"},
+			Out: []string{"a", "b"},
+		},
+	}
+
+	for name, data := range tests {
+		data := data
+		t.Run(name, func(t *testing.T) {
+			res := funk.Uniq(data.In)
+
+			assert.Equal(t, data.Out, res)
+		})
+	}
+}
+
+func TestUniqByType(t *testing.T) {
+	type A struct {
+		Value int
+	}
+	type B struct {
+		Value string
+	}
+
+	tests := map[string]struct {
+		In  []any
+		Out []any
+	}{
+		"nil": {
+			In:  nil,
+			Out: []any{},
+		},
+		"empty": {
+			In:  []any{},
+			Out: []any{},
+		},
+		"single": {
+			In:  []any{&A{}},
+			Out: []any{&A{}},
+		},
+		"repeated": {
+			In:  []any{&A{}, &A{}},
+			Out: []any{&A{}},
+		},
+		"pair": {
+			In:  []any{&A{}, &B{}},
+			Out: []any{&A{}, &B{}},
+		},
+		"repeatedPair": {
+			In:  []any{&A{}, &B{}, &A{}, &B{}},
+			Out: []any{&A{}, &B{}},
+		},
+		"repeatedPairWithValues": {
+			In:  []any{&A{Value: 1}, &B{Value: "1"}, &A{Value: 2}, &B{Value: "2"}},
+			Out: []any{&A{Value: 1}, &B{Value: "1"}},
+		},
+		"repeatedPairMixedPointers": {
+			In:  []any{&A{Value: 1}, &B{Value: "1"}, A{Value: 2}, B{Value: "2"}},
+			Out: []any{&A{Value: 1}, &B{Value: "1"}, A{Value: 2}, B{Value: "2"}},
+		},
+	}
+
+	for name, data := range tests {
+		data := data
+		t.Run(name, func(t *testing.T) {
+			res := funk.UniqByType(data.In)
+
+			assert.Equal(t, data.Out, res)
+		})
+	}
+}


### PR DESCRIPTION
This fixes a bug when migration change history tables caused by having models specified more than once and running migrations in parallel.