### PR TITLE
added aws_client_name to all metadata aware inputs and outputs

### DIFF
--- a/pkg/cloud/aws/sqs/queue.go
+++ b/pkg/cloud/aws/sqs/queue.go
@@ -36,6 +36,14 @@ type Queue interface {
 	SendBatch(ctx context.Context, messages []*Message) error
 }
 
+type QueueMetadata struct {
+	AwsClientName string `json:"aws_client_name"`
+	QueueArn      string `json:"queue_arn"`
+	QueueName     string `json:"queue_name"`
+	QueueNameFull string `json:"queue_name_full"`
+	QueueUrl      string `json:"queue_url"`
+}
+
 type Message struct {
 	DelaySeconds           int32
 	MessageGroupId         *string
@@ -102,7 +110,15 @@ func NewQueue(ctx context.Context, config cfg.Config, logger log.Logger, setting
 		return nil, fmt.Errorf("could not create or get properties of queue %s: %w", settings.QueueName, err)
 	}
 
-	if err = appctx.MetadataAppend(ctx, MetadataKeyQueues, settings.QueueName); err != nil {
+	metadata := QueueMetadata{
+		AwsClientName: settings.ClientName,
+		QueueArn:      props.Arn,
+		QueueName:     settings.QueueName,
+		QueueNameFull: props.Name,
+		QueueUrl:      props.Url,
+	}
+
+	if err = appctx.MetadataAppend(ctx, MetadataKeyQueues, metadata); err != nil {
 		return nil, fmt.Errorf("can not access the appctx metadata: %w", err)
 	}
 

--- a/pkg/ddb/repository.go
+++ b/pkg/ddb/repository.go
@@ -64,6 +64,11 @@ type Repository interface {
 	UpdateItemBuilder() UpdateItemBuilder
 }
 
+type TableMetadata struct {
+	AwsClientName string `json:"aws_client_name"`
+	TableName     string `json:"table_name"`
+}
+
 type repository struct {
 	logger log.Logger
 	tracer tracing.Tracer
@@ -109,7 +114,12 @@ func NewRepository(ctx context.Context, config cfg.Config, logger log.Logger, se
 		}
 	}
 
-	if err = appctx.MetadataAppend(ctx, MetadataKeyTables, metadataFactory.GetTableName()); err != nil {
+	metadata := TableMetadata{
+		AwsClientName: settings.ClientName,
+		TableName:     metadataFactory.GetTableName(),
+	}
+
+	if err = appctx.MetadataAppend(ctx, MetadataKeyTables, metadata); err != nil {
 		return nil, fmt.Errorf("can not access the appctx metadata: %w", err)
 	}
 

--- a/pkg/stream/consumer_base.go
+++ b/pkg/stream/consumer_base.go
@@ -130,6 +130,7 @@ func NewBaseConsumer(ctx context.Context, config cfg.Config, logger log.Logger, 
 		RetryType:    settings.Retry.Type,
 		RunnerCount:  settings.RunnerCount,
 	}
+
 	if err = appctx.MetadataAppend(ctx, metadataKeyConsumers, consumerMetadata); err != nil {
 		return nil, fmt.Errorf("can not access the appctx metadata: %w", err)
 	}

--- a/pkg/stream/producer.go
+++ b/pkg/stream/producer.go
@@ -67,6 +67,7 @@ func NewProducer(ctx context.Context, config cfg.Config, logger log.Logger, name
 		Name:          name,
 		DaemonEnabled: settings.Daemon.Enabled,
 	}
+
 	if err = appctx.MetadataAppend(ctx, MetadataKeyProducers, metadata); err != nil {
 		return nil, fmt.Errorf("can not access the appctx metadata: %w", err)
 	}


### PR DESCRIPTION
This is a first (untested) draft for adding the client name to all inputs/outputs that are metadata aware