### PR TITLE
ddb: sanitize settings with more default values

### DIFF
--- a/pkg/ddb/service.go
+++ b/pkg/ddb/service.go
@@ -29,9 +29,7 @@ type Service struct {
 }
 
 func NewService(ctx context.Context, config cfg.Config, logger log.Logger, settings *Settings, optFns ...gosoDynamodb.ClientOption) (*Service, error) {
-	if len(settings.ClientName) == 0 {
-		settings.ClientName = "default"
-	}
+	sanitizeSettings(settings)
 
 	var err error
 	var client gosoDynamodb.Client

--- a/pkg/ddb/service_test.go
+++ b/pkg/ddb/service_test.go
@@ -8,8 +8,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/justtrackio/gosoline/pkg/appctx"
+	"github.com/justtrackio/gosoline/pkg/cfg"
 	dynamodbMocks "github.com/justtrackio/gosoline/pkg/cloud/aws/dynamodb/mocks"
 	"github.com/justtrackio/gosoline/pkg/ddb"
+	"github.com/justtrackio/gosoline/pkg/log"
 	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
 	"github.com/justtrackio/gosoline/pkg/mdl"
 	"github.com/stretchr/testify/assert"
@@ -42,6 +45,21 @@ type globalModel1 struct {
 	Rev       string    `json:"rev" ddb:"global=hash"`
 	CreatedAt time.Time `json:"createdAt" ddb:"global=range"`
 	Header    string    `json:"header"`
+}
+
+func TestService_sanitizeSettings(t *testing.T) {
+	ctx := appctx.WithContainer(context.Background())
+	config := cfg.New()
+	logger := log.NewLogger()
+
+	settings := &ddb.Settings{}
+
+	_, err := ddb.NewService(ctx, config, logger, settings)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "default", settings.ClientName)
+	assert.Equal(t, int64(1), settings.Main.ReadCapacityUnits)
+	assert.Equal(t, int64(1), settings.Main.WriteCapacityUnits)
 }
 
 func TestService_CreateTable(t *testing.T) {

--- a/pkg/ddb/settings.go
+++ b/pkg/ddb/settings.go
@@ -1,6 +1,8 @@
 package ddb
 
 import (
+	"math"
+
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/justtrackio/gosoline/pkg/mdl"
 )
@@ -44,4 +46,18 @@ type SimpleSettings struct {
 	StreamView         string
 	ReadCapacityUnits  int64
 	WriteCapacityUnits int64
+}
+
+func sanitizeSettings(settings *Settings) {
+	if len(settings.ClientName) == 0 {
+		settings.ClientName = "default"
+	}
+
+	settings.Main.ReadCapacityUnits = int64(math.Max(1, float64(settings.Main.ReadCapacityUnits)))
+	settings.Main.WriteCapacityUnits = int64(math.Max(1, float64(settings.Main.WriteCapacityUnits)))
+
+	for _, global := range settings.Global {
+		global.ReadCapacityUnits = int64(math.Max(1, float64(global.ReadCapacityUnits)))
+		global.WriteCapacityUnits = int64(math.Max(1, float64(global.WriteCapacityUnits)))
+	}
 }


### PR DESCRIPTION
if there are no capacity values configured, we should go with a value of 1