### PR TITLE
apiserver: Fix panic for Gin handlers registered on the main ("/") route

### DIFF
--- a/pkg/apiserver/handler.go
+++ b/pkg/apiserver/handler.go
@@ -413,6 +413,10 @@ func parseCookies(request *http.Request) map[string]string {
 
 func parseUrl(ctx *gin.Context) (*url.URL, error) {
 	ginUrl := location.Get(ctx)
+	ginUrl := ctx.Request.URL
+	if ginUrl == nil {
+		ginUrl = &url.URL{}
+	}
 
 	reqUrl := ctx.Request.URL
 	if reqUrl == nil {

--- a/pkg/apiserver/handler.go
+++ b/pkg/apiserver/handler.go
@@ -413,7 +413,6 @@ func parseCookies(request *http.Request) map[string]string {
 
 func parseUrl(ctx *gin.Context) (*url.URL, error) {
 	ginUrl := location.Get(ctx)
-	ginUrl := ctx.Request.URL
 	if ginUrl == nil {
 		ginUrl = &url.URL{}
 	}


### PR DESCRIPTION
Fixes a panic, that occurs when the `/` route is hit, for example when registered like this:

```go
package main

import (
	"context"
	"fmt"

	"github.com/gin-gonic/gin"
	"github.com/bogdanfinn/tls-client-api/internal/tls-client-api/api"

	"github.com/justtrackio/gosoline/pkg/cfg"
	"github.com/justtrackio/gosoline/pkg/log"
)

func main() {
	r := gin.Default()

	config := cfg.New()
	logger := log.NewLogger()

	forwardedRequestHandler, err := api.NewForwardedRequestHandler(context.Background(), config, logger)
	if err != nil {
		panic(fmt.Errorf("can not create forwardedRequestHandler: %w", err))
	}

        // from my limited debugging, registering it as "/" here causes the ginUrl obtained with ginUrl := location.Get(ctx)
        // to be nil, which then makes the mergo.Merge call panic
	r.POST("/", forwardedRequestHandler)
	r.Run("localhost:8080")
}
```

---

<details>
  <summary>Example trace</summary>

```
2023/11/06 13:49:35 [Recovery] 2023/11/06 - 13:49:35 panic recovered:
POST / HTTP/1.1
Host: localhost:8080
Accept: */*
Content-Length: 882
Content-Type: application/json
User-Agent: [REDACTED]

reflect: call of reflect.Value.Type on zero Value
[PATH]/go/1.21.3/libexec/src/reflect/value.go:2634 (0x104f55713)
    Value.typeSlow: panic(&ValueError{"reflect.Value.Type", Invalid})
[PATH]/go/1.21.3/libexec/src/reflect/value.go:2629 (0x105388bfb)
    Value.Type: return v.typeSlow()
[MODULE_PATH]/github.com/imdario/mergo@v0.3.12/merge.go:363 (0x105388ba4)
    merge: if vDst.Type() != vSrc.Type() {
[MODULE_PATH]/github.com/imdario/mergo@v0.3.12/merge.go:296 (0x1057e167f)
    Merge: return merge(dst, src, opts...)
[MODULE_PATH]/github.com/justtrackio/gosoline@v0.8.0/pkg/apiserver/handler.go:422 (0x1057e1650)
    parseUrl: if err := mergo.Merge(reqUrl, ginUrl); err != nil {
[MODULE_PATH]/github.com/justtrackio/gosoline@v0.8.0/pkg/apiserver/handler.go:321 (0x1057e0f9f)
    handle: ginUrl, err := parseUrl(ginCtx)
[MODULE_PATH]/github.com/justtrackio/gosoline@v0.8.0/pkg/apiserver/handler.go:197 (0x1058fceb3)
    main.NewForwardedRequestHandler.CreateJsonHandler.handleWithInput.func1: handle(ginCtx, handler, input, errHandler)
[MODULE_PATH]/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x10534b27f)
    (*Context).Next: c.handlers[c.index](c)
[MODULE_PATH]/github.com/gin-gonic/gin@v1.9.1/recovery.go:102 (0x10534b264)
    CustomRecoveryWithWriter.func1: c.Next()
[MODULE_PATH]/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x10534a61f)
    (*Context).Next: c.handlers[c.index](c)
[MODULE_PATH]/github.com/gin-gonic/gin@v1.9.1/logger.go:240 (0x10534a5f0)
    LoggerWithConfig.func1: c.Next()
[MODULE_PATH]/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x105349753)
    (*Context).Next: c.handlers[c.index](c)
[MODULE_PATH]/github.com/gin-gonic/gin@v1.9.1/gin.go:620 (0x10534947c)
    (*Engine).handleHTTPRequest: c.Next()
[MODULE_PATH]/github.com/gin-gonic/gin@v1.9.1/gin.go:576 (0x10534909f)
    (*Engine).ServeHTTP: engine.handleHTTPRequest(c)
[PATH]/go/1.21.3/libexec/src/net/http/server.go:2938 (0x10514943b)
    serverHandler.ServeHTTP: handler.ServeHTTP(rw, req)
[PATH]/go/1.21.3/libexec/src/net/http/server.go:2009 (0x105145837)
    (*conn).serve: serverHandler{c.server}.ServeHTTP(w, w.req)
[PATH]/go/1.21.3/libexec/src/runtime/asm_arm64.s:1197 (0x104ef9a63)
    goexit: MOVD    R0, R0  // NOP
```
</details>