### PR TITLE
Add custom CodeBlock component

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,13 +2,13 @@
 
 This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
 
-### Installation
+##  Installation
 
 ```
 $ yarn
 ```
 
-### Local Development
+##  Local Development
 
 ```
 $ yarn start
@@ -16,7 +16,7 @@ $ yarn start
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
 
-### Build
+##  Build
 
 ```
 $ yarn build
@@ -24,7 +24,7 @@ $ yarn build
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
 
-### Deployment
+##  Deployment
 
 Using SSH:
 
@@ -39,3 +39,78 @@ $ GIT_USER=<Your GitHub username> yarn deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+
+## Custom Components
+
+### CodeBlock
+
+To improve the reusability and maintainability of our code blocks, we've implemented a wrapper around Docusaurus's classic CodeBlock component that you can use to show snippets from a code file.
+
+To use this component, first add snippet comments to your code. For example:
+
+Yaml:
+
+```yaml
+port: 80
+host: example.com
+
+# snippet-start: example
+struct_example:
+  port: 80
+  host: example.com
+  timeout: 5s
+  threshold: 100
+# snippet-end: example
+```
+
+Go:
+
+```go
+package main
+
+import (
+	"github.com/justtrackio/gosoline/pkg/cfg"
+)
+
+// snippet-start: main
+func main() {
+	config := cfg.New()
+	
+	// snippet-start: configure options
+	options := []cfg.Option{
+		cfg.WithConfigSetting("host", "localhost"),
+		cfg.WithConfigSetting("port", "80"),
+	}
+	// snippet-end: configure options
+    
+	if err := config.Option(options...); err != nil {
+		panic(err)
+	}
+}
+// snippet-end: main
+```
+
+Note that:
+
+1. Every snippet must have a `snippet-start` and `snippet-end` comment.
+2. The name of the snippet must be the same.
+3. Snippets can be nested.
+4. Two types of comments are currently supported (`#` and `//`)
+5. The snippet comment belongs on its own line.
+
+To use these snippets in your mdx file, you first need to import the custom `CodeBlock` component:
+
+```mdx
+import { CodeBlock } from '../components.jsx';
+```
+
+Then, you'll use it the same way you'd use the Docusaurus `CodeBlock` component, but you'll include the snippet name:
+
+```mdx
+import Main from "!!raw-loader!./src/test/test.go";
+
+<CodeBlock showLineNumbers language="go" snippet="main">{Main}</CodeBlock>
+<CodeBlock showLineNumbers language="go" snippet="configure options">{Main}</CodeBlock>
+```
+
+In the output, you'll get just the snippet from the code file. If you have highlight comments, those will still work in the snippets. If you have nested snippet comments, they won't appear in the output.

--- a/docs/docs/components.jsx
+++ b/docs/docs/components.jsx
@@ -8,10 +8,11 @@ import LayersIcon from '@mui/icons-material/Layers';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import Grid from '@mui/material/Grid';
 import CloudQueueIcon from '@mui/icons-material/CloudQueue';
+import ThemeCodeBlock from '@theme/CodeBlock';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { useColorMode } from '@docusaurus/theme-common'
 
-export default function PrimaryUseCases() {
+export function PrimaryUseCases() {
     const { isDarkTheme } = useColorMode();
 
     const darkTheme = createTheme({
@@ -64,3 +65,38 @@ export default function PrimaryUseCases() {
       </ThemeProvider>
     )
   }
+
+export function CodeBlock({ children, snippet, ...props }) {
+    let code = children.replace(/\n$/, '');
+    var foundMatch = false;
+    if (snippet) {
+      // Find the snippet
+      const snippetPattern = new RegExp(
+        `(?:\/\/|#) snippet-start: ${snippet}(.*)(?:\/\/|#) snippet-end: ${snippet}`, 
+        's'
+      );
+      let match = code.match(snippetPattern)
+      if (match) {
+        code = match[1];
+        foundMatch = true;
+      }
+    }    
+
+    // Remove all other potential snippet comments as well as the first and last empty lines
+    code = code.split('\n').filter(
+        function(line) {
+            let leftoverCommentsPattern = new RegExp('\w*?(?:\/\/|#) snippet.*\n*?$', 'g')
+            return !leftoverCommentsPattern.test(line)
+        }
+    )
+    
+    if (foundMatch) {
+        code = code.slice(1, -1)
+    }
+
+    code = code.join('\n')
+
+    // Remove potential leftover newlines and whitespace
+
+    return <ThemeCodeBlock {...props}>{code}</ThemeCodeBlock>
+}

--- a/docs/docs/components.jsx
+++ b/docs/docs/components.jsx
@@ -96,7 +96,5 @@ export function CodeBlock({ children, snippet, ...props }) {
 
     code = code.join('\n')
 
-    // Remove potential leftover newlines and whitespace
-
     return <ThemeCodeBlock {...props}>{code}</ThemeCodeBlock>
 }

--- a/docs/docs/overview.mdx
+++ b/docs/docs/overview.mdx
@@ -4,7 +4,7 @@ slug: /
 title: Overview
 ---
 
-import PrimaryUseCases from './components.jsx';
+import { PrimaryUseCases } from './components.jsx';
 
 Gosoline is a Golang-based application framework specialized for building microservices in the cloud. It provides tools for handling most of the common challenges like configuration, logging, structured code execution, handling http requests, asynchronous message processing, writing integration tests and much more.
 

--- a/docs/docs/quickstart/api-server/create-an-api-server.mdx
+++ b/docs/docs/quickstart/api-server/create-an-api-server.mdx
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: Create an API server
 ---
 
-import CodeBlock from '@theme/CodeBlock';
+import { CodeBlock } from '../../components.jsx';
 import ConfigDist from "!!raw-loader!./src/create-an-api-server/config.dist.yml";
 import Handler from "!!raw-loader!./src/create-an-api-server/handler.go";
 import Main from "!!raw-loader!./src/create-an-api-server/main.go";
@@ -75,18 +75,7 @@ Now, you'll walkthrough this file in detail to learn how it works.
 
 At the top of `handler.go`, you declared the package and imported some dependencies:
 
-```go title=handler.go
-package main
-
-import (
-	"context"
-	"time"
-
-	"github.com/justtrackio/gosoline/pkg/apiserver"
-	"github.com/justtrackio/gosoline/pkg/cfg"
-	"github.com/justtrackio/gosoline/pkg/log"
-)
-```
+<CodeBlock language="go" title="handler.go" snippet="imports">{Handler}</CodeBlock>
 
 Here, you declared the package as `main`. Then, you imported the `context` and `time` modules along with three gosoline dependencies:
 
@@ -98,13 +87,7 @@ Here, you declared the package as `main`. Then, you imported the `context` and `
 
 Next, you created a `Todo` struct:
 
-```go title=handler.go
-type Todo struct {
-	Id        int    `form:"id"`
-	Text      string `form:"text"`
-	CreatedAt time.Time
-}
-```
+<CodeBlock language="go" title="handler.go" snippet="todo struct">{Handler}</CodeBlock>
 
 Later in this file, you'll use this to bind the data from the HTTP querystring. Referring back to the specification for your todo service, the expected querystring looks like this:
 
@@ -118,11 +101,7 @@ So, in your struct, you have an `Id` and a `Text`. With the `form:` tag, you've 
 
 Next, you created a struct for handling todos:
 
-```go title=handler.go
-type TodoHandler struct {
-	logger log.Logger
-}
-```
+<CodeBlock language="go" title="handler.go" snippet="todo handler">{Handler}</CodeBlock>
 
 This is a simple structure that holds a `log.Logger` reference.
 
@@ -130,11 +109,7 @@ This is a simple structure that holds a `log.Logger` reference.
 
 Next, you created a function called `GetInput()` that returns the input instance to use:
 
-```go title=handler.go
-func (t TodoHandler) GetInput() interface{} {
-	return &Todo{}
-}
-```
+<CodeBlock language="go" title="handler.go" snippet="get input">{Handler}</CodeBlock>
 
 This is required because your `TodoHandler` must implement the `GetInput()` method of the `apiserver.HandlerWithInput` interface.
 
@@ -142,15 +117,7 @@ This is required because your `TodoHandler` must implement the `GetInput()` meth
 
 Next, you created a function called `NewTodoHandler()`:
 
-```go title=handler.go
-func NewTodoHandler(ctx context.Context, config cfg.Config, logger log.Logger) (*TodoHandler, error) {
-	handler := &TodoHandler{
-		logger: logger,
-	}
-
-	return handler, nil
-}
-```
+<CodeBlock language="go" title="handler.go" snippet="new todo handler">{Handler}</CodeBlock>
 
 The `config` and `logger` argument types come from gosoline. This function initializes a new `TodoHandler` and assigns it the `logger`. Then, it returns the handler with no error.
 
@@ -158,35 +125,9 @@ The `config` and `logger` argument types come from gosoline. This function initi
 
 Finally, you created a `Handle()` function that accepts a `context.Context` and an `apiserver.Request` (also from gosoline) and handles that request:
 
-```go
-func (t TodoHandler) Handle(
-	ctx context.Context,
-	request *apiserver.Request,
-) (*apiserver.Response, error) {
-	// 1
-	todo := request.Body.(*Todo)
+<CodeBlock language="go" title="handler.go" snippet="handle">{Handler}</CodeBlock>
 
-	// 2
-	todo.CreatedAt = time.Now()
-
-	// 3
-	t.logger.Info("got todo with id %d", todo.Id)
-
-	// 4
-	return apiserver.NewJsonResponse(todo), nil
-}
-```
-
-Here, you've implemented a request handler in the following steps:
-
-1. Initialize a `Todo` struct from the request body.
-2. Set the `CreatedAt` to now.
-3. Log the request using the `TodoHandler` struct's `logger`.
-4. Return a Json response object with information from the `Todo` struct.
-
-With gosoline, you can handle requests and responses in just a few lines of code.
-
-`handler.go` contains most of the heavy lifting for your web service. However, you still need a main entry point to your service, where you'll make use of the logic in `handler.go`. This, you'll add in `main.go`.
+Here, you handle requests and responses in just a few lines of code. `handler.go` does most of the heavy lifting for your web service. However, you still need a main entry point to your service, where you'll make use of the logic in `handler.go`. This, you'll add in `main.go`.
 
 ## Implement main.go
 
@@ -206,19 +147,7 @@ Now, you'll walkthrough this file in detail to learn how it works.
 
 In `main.go`, you declared the package and imported some dependencies:
 
-```go title=main.go
-package main
-
-import (
-	"context"
-	"fmt"
-
-	"github.com/justtrackio/gosoline/pkg/apiserver"
-	"github.com/justtrackio/gosoline/pkg/application"
-	"github.com/justtrackio/gosoline/pkg/cfg"
-	"github.com/justtrackio/gosoline/pkg/log"
-)
-```
+<CodeBlock language="go" title="main.go" snippet="imports">{Main}</CodeBlock>
 
 Here, you declared the package as `main`. Then, you imported the `context` and `time` modules along with three gosoline dependencies:
 
@@ -231,43 +160,9 @@ Here, you declared the package as `main`. Then, you imported the `context` and `
 
 Next, you created your `main()` function as the entry point to your service:
 
-```go title=main.go
-func main() {
-	// 1
-	definer := func(ctx context.Context, config cfg.Config, logger log.Logger) (*apiserver.Definitions, error) {
-		// 2
-		def := &apiserver.Definitions{}
+<CodeBlock language="go" title="main.go" snippet="main">{Main}</CodeBlock>
 
-		// 3
-		var err error
-		var handler apiserver.HandlerWithInput
-
-		// 4
-		if handler, err = NewTodoHandler(ctx, config, logger); err != nil {
-		return nil, fmt.Errorf("can not create trip handler: %w", err)
-		}
-
-		// 5
-		def.GET("/todo", apiserver.CreateQueryHandler(handler))
-
-		// 6
-		return def, nil
-	}
-
-	// 7
-	application.RunApiServer(definer)
-}
-```
-
-`main()` puts together all the data structures and logic from `handler.go` into a single, coherent function. To better understand this code, you can break it down like this:
-
-1. Initialize `definer`, an API server factory that defines your HTTP route.
-2. Initialize `def`, a reference to the `apiserver.Definitions`, which you'll use to create a GET route.
-3. Instantiate two new variables for handling errors and request input data.
-4. Create a handler (`NewTodoHandler`) that handles the request input data. If there is an error, return an error message. If there is no error, assign this `NewTodoHandler` to the `handler` variable from the last step. 
-5. Create a GET route for the endpoint `/todo`, using the `handler`.
-6. Return the response from `handler`.
-7. Run an API server application based on the logic from the previous steps.
+`main()` puts together all the data structures and logic from `handler.go` into a single, coherent function.
 
 Now, you've implemented your server's main entry point and handler logic. Next, you'll configure your server.
 

--- a/docs/docs/quickstart/api-server/src/create-an-api-server/handler.go
+++ b/docs/docs/quickstart/api-server/src/create-an-api-server/handler.go
@@ -1,3 +1,4 @@
+// snippet-start: imports
 package main
 
 import (
@@ -8,21 +9,29 @@ import (
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/log"
 )
+// snippet-end: imports
 
+// snippet-start: todo struct
 type Todo struct {
 	Id        int    `form:"id"`
 	Text      string `form:"text"`
 	CreatedAt time.Time
 }
+// snippet-end: todo struct
 
+// snippet-start: todo handler
 type TodoHandler struct {
 	logger log.Logger
 }
+// snippet-end: todo handler
 
+// snippet-start: get input
 func (t TodoHandler) GetInput() interface{} {
 	return &Todo{}
 }
+// snippet-end: get input
 
+// snippet-start: new todo handler
 func NewTodoHandler(ctx context.Context, config cfg.Config, logger log.Logger) (*TodoHandler, error) {
 	handler := &TodoHandler{
 		logger: logger,
@@ -30,12 +39,20 @@ func NewTodoHandler(ctx context.Context, config cfg.Config, logger log.Logger) (
 
 	return handler, nil
 }
+// snippet-end: new todo handler
 
+// snippet-start: handle
 func (t TodoHandler) Handle(ctx context.Context, request *apiserver.Request) (*apiserver.Response, error) {
+	// Initialize a Todo struct from the request body
 	todo := request.Body.(*Todo)
+
+	// Set its CreatedAt to now
 	todo.CreatedAt = time.Now()
 
+	// Log the request using the TodoHandler struct's logger
 	t.logger.Info("got todo with id %d", todo.Id)
 
+	// Return a Json response object with information from the Todo struct
 	return apiserver.NewJsonResponse(todo), nil
 }
+// snippet-end: handle

--- a/docs/docs/quickstart/api-server/src/create-an-api-server/handler.go
+++ b/docs/docs/quickstart/api-server/src/create-an-api-server/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/log"
 )
+
 // snippet-end: imports
 
 // snippet-start: todo struct
@@ -17,18 +18,21 @@ type Todo struct {
 	Text      string `form:"text"`
 	CreatedAt time.Time
 }
+
 // snippet-end: todo struct
 
 // snippet-start: todo handler
 type TodoHandler struct {
 	logger log.Logger
 }
+
 // snippet-end: todo handler
 
 // snippet-start: get input
 func (t TodoHandler) GetInput() interface{} {
 	return &Todo{}
 }
+
 // snippet-end: get input
 
 // snippet-start: new todo handler
@@ -39,6 +43,7 @@ func NewTodoHandler(ctx context.Context, config cfg.Config, logger log.Logger) (
 
 	return handler, nil
 }
+
 // snippet-end: new todo handler
 
 // snippet-start: handle
@@ -55,4 +60,5 @@ func (t TodoHandler) Handle(ctx context.Context, request *apiserver.Request) (*a
 	// Return a Json response object with information from the Todo struct
 	return apiserver.NewJsonResponse(todo), nil
 }
+
 // snippet-end: handle

--- a/docs/docs/quickstart/api-server/src/create-an-api-server/main.go
+++ b/docs/docs/quickstart/api-server/src/create-an-api-server/main.go
@@ -1,3 +1,4 @@
+// snippet-start: imports
 package main
 
 import (
@@ -9,22 +10,34 @@ import (
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/log"
 )
+// snippet-end: imports
 
+// snippet-start: main
 func main() {
+	// Initialize an API server factory that defines your HTTP route
 	definer := func(ctx context.Context, config cfg.Config, logger log.Logger) (*apiserver.Definitions, error) {
+		// Initialize a reference to apiserver.Definitions, which you use to create a GET route
 		def := &apiserver.Definitions{}
 
+		// Instantiate two new variables for handling errors and request input data
 		var err error
 		var handler apiserver.HandlerWithInput
 
+		// Create a handler (`NewTodoHandler`) that handles the request input data. 
+		// If there is an error, return an error message. 
+		// If there is no error, assign this `NewTodoHandler` to the `handler` variable from the last step.
 		if handler, err = NewTodoHandler(ctx, config, logger); err != nil {
 			return nil, fmt.Errorf("can not create trip handler: %w", err)
 		}
 
+		// Create a GET route for the endpoint /todo, using the handler
 		def.GET("/todo", apiserver.CreateQueryHandler(handler))
 
+		// Return the response from handler
 		return def, nil
 	}
 
+	// Run an API server application based on the logic from the previous steps
 	application.RunApiServer(definer)
 }
+// snippet-end: main

--- a/docs/docs/quickstart/api-server/src/create-an-api-server/main.go
+++ b/docs/docs/quickstart/api-server/src/create-an-api-server/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/log"
 )
+
 // snippet-end: imports
 
 // snippet-start: main
@@ -23,8 +24,8 @@ func main() {
 		var err error
 		var handler apiserver.HandlerWithInput
 
-		// Create a handler (`NewTodoHandler`) that handles the request input data. 
-		// If there is an error, return an error message. 
+		// Create a handler (`NewTodoHandler`) that handles the request input data.
+		// If there is an error, return an error message.
 		// If there is no error, assign this `NewTodoHandler` to the `handler` variable from the last step.
 		if handler, err = NewTodoHandler(ctx, config, logger); err != nil {
 			return nil, fmt.Errorf("can not create trip handler: %w", err)
@@ -40,4 +41,5 @@ func main() {
 	// Run an API server application based on the logic from the previous steps
 	application.RunApiServer(definer)
 }
+
 // snippet-end: main


### PR DESCRIPTION
This adds a new MDX `CodeBlock` component that supports snippets.

Example usage (more detailed instructions included in the README):

```yaml
port: 80
host: example.com

# snippet-start: example
struct_example:
  port: 80
  host: example.com
  timeout: 5s
  threshold: 100
# snippet-end: example

```

```go
package main

import (
	"github.com/justtrackio/gosoline/pkg/cfg"
)

// snippet-start: main
func main() {
	config := cfg.New()

	// snippet-start: configure options
	options := []cfg.Option{
		cfg.WithConfigSetting("host", "localhost"),
		cfg.WithConfigSetting("port", "80"),
	}
	// snippet-end: configure options

	if err := config.Option(options...); err != nil {
		panic(err)
	}
}
// snippet-end: main

```

```mdx
import { CodeBlock } from '../components.jsx';

<CodeBlock showLineNumbers language="yaml" snippet="example">{ConfigDist}</CodeBlock>
<CodeBlock showLineNumbers language="go" snippet="main">{Main}</CodeBlock>
<CodeBlock showLineNumbers language="go" snippet="configure options">{Main}</CodeBlock>
```

<img width="751" alt="Screenshot 2023-11-13 at 10 32 03" src="https://github.com/justtrackio/gosoline/assets/8672090/03df8c51-e43f-43b8-9595-e2f9e08f8ee9">
