### PR TITLE
guard: make it context aware and the audit logs configurable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,11 +61,11 @@ require (
 	github.com/lib/pq v1.10.4
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/ory/dockertest/v3 v3.10.0
-	github.com/ory/ladon v1.2.0
 	github.com/oschwald/geoip2-golang v1.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/segmentio/kafka-go v0.4.31
+	github.com/selm0/ladon v0.0.0-20231114080549-31144de4b38d
 	github.com/sha1sum/aws_signing_client v0.0.0-20170514202702-9088e4c7b34b
 	github.com/spf13/cast v1.4.1
 	github.com/stretchr/testify v1.8.3

--- a/go.sum
+++ b/go.sum
@@ -1201,6 +1201,8 @@ github.com/segmentio/go-snakecase v1.2.0 h1:4cTmEjPGi03WmyAHWBjX53viTpBkn/z+4DO+
 github.com/segmentio/go-snakecase v1.2.0/go.mod h1:jk1miR5MS7Na32PZUykG89Arm+1BUSYhuGR6b7+hJto=
 github.com/segmentio/kafka-go v0.4.31 h1:+ImsrkJRju9j1D9U44rvRGRlpsI9GnwD8s9WTFagNLQ=
 github.com/segmentio/kafka-go v0.4.31/go.mod h1:m1lXeqJtIFYZayv0shM/tjrAFljvWLTprxBHd+3PnaU=
+github.com/selm0/ladon v0.0.0-20231114080549-31144de4b38d h1:XTgDC26Uamoxj2cN8CDXhY46UuArsrBPiihU8JXSX1s=
+github.com/selm0/ladon v0.0.0-20231114080549-31144de4b38d/go.mod h1:Ewe06WTqFRY14E3RiRb7kmiHWUuB90CJuMrJljFQm24=
 github.com/sha1sum/aws_signing_client v0.0.0-20170514202702-9088e4c7b34b h1:WdIIYKhAP6TUEJmCubGJAEjmW65Sxhaoi/FhZ09Ax7o=
 github.com/sha1sum/aws_signing_client v0.0.0-20170514202702-9088e4c7b34b/go.mod h1:hPj3jKAamv0ryZvssbqkCeOWYFmy9itWMSOD7tDsE3E=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=

--- a/pkg/guard/guard_test.go
+++ b/pkg/guard/guard_test.go
@@ -1,12 +1,13 @@
 package guard_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/justtrackio/gosoline/pkg/guard"
-	"github.com/ory/ladon"
+	"github.com/selm0/ladon"
 	"github.com/stretchr/testify/require"
 
 	"github.com/justtrackio/gosoline/pkg/guard/mocks"
@@ -28,11 +29,13 @@ func TestLadonGuard_GetPolicies(t *testing.T) {
 		ID: "200",
 	}
 
-	manager.On("GetAll", int64(100), int64(0)).Return(ladon.Policies{pol1}, nil).Once()
-	manager.On("GetAll", int64(100), int64(100)).Return(ladon.Policies{pol2}, nil).Once()
-	manager.On("GetAll", int64(100), int64(200)).Return(ladon.Policies{}, nil).Once()
+	ctx := context.Background()
 
-	pols, err := g.GetPolicies()
+	manager.On("GetAll", ctx, int64(100), int64(0)).Return(ladon.Policies{pol1}, nil).Once()
+	manager.On("GetAll", ctx, int64(100), int64(100)).Return(ladon.Policies{pol2}, nil).Once()
+	manager.On("GetAll", ctx, int64(100), int64(200)).Return(ladon.Policies{}, nil).Once()
+
+	pols, err := g.GetPolicies(context.Background())
 	require.NoError(t, err)
 
 	expected := ladon.Policies{pol1, pol2}

--- a/pkg/guard/mocks/AuditLogger.go
+++ b/pkg/guard/mocks/AuditLogger.go
@@ -3,7 +3,10 @@
 package mocks
 
 import (
-	ladon "github.com/ory/ladon"
+	context "context"
+
+	ladon "github.com/selm0/ladon"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -20,9 +23,9 @@ func (_m *AuditLogger) EXPECT() *AuditLogger_Expecter {
 	return &AuditLogger_Expecter{mock: &_m.Mock}
 }
 
-// LogGrantedAccessRequest provides a mock function with given fields: request, pool, deciders
-func (_m *AuditLogger) LogGrantedAccessRequest(request *ladon.Request, pool ladon.Policies, deciders ladon.Policies) {
-	_m.Called(request, pool, deciders)
+// LogGrantedAccessRequest provides a mock function with given fields: ctx, request, pool, deciders
+func (_m *AuditLogger) LogGrantedAccessRequest(ctx context.Context, request *ladon.Request, pool ladon.Policies, deciders ladon.Policies) {
+	_m.Called(ctx, request, pool, deciders)
 }
 
 // AuditLogger_LogGrantedAccessRequest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LogGrantedAccessRequest'
@@ -31,16 +34,17 @@ type AuditLogger_LogGrantedAccessRequest_Call struct {
 }
 
 // LogGrantedAccessRequest is a helper method to define mock.On call
+//   - ctx context.Context
 //   - request *ladon.Request
 //   - pool ladon.Policies
 //   - deciders ladon.Policies
-func (_e *AuditLogger_Expecter) LogGrantedAccessRequest(request interface{}, pool interface{}, deciders interface{}) *AuditLogger_LogGrantedAccessRequest_Call {
-	return &AuditLogger_LogGrantedAccessRequest_Call{Call: _e.mock.On("LogGrantedAccessRequest", request, pool, deciders)}
+func (_e *AuditLogger_Expecter) LogGrantedAccessRequest(ctx interface{}, request interface{}, pool interface{}, deciders interface{}) *AuditLogger_LogGrantedAccessRequest_Call {
+	return &AuditLogger_LogGrantedAccessRequest_Call{Call: _e.mock.On("LogGrantedAccessRequest", ctx, request, pool, deciders)}
 }
 
-func (_c *AuditLogger_LogGrantedAccessRequest_Call) Run(run func(request *ladon.Request, pool ladon.Policies, deciders ladon.Policies)) *AuditLogger_LogGrantedAccessRequest_Call {
+func (_c *AuditLogger_LogGrantedAccessRequest_Call) Run(run func(ctx context.Context, request *ladon.Request, pool ladon.Policies, deciders ladon.Policies)) *AuditLogger_LogGrantedAccessRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*ladon.Request), args[1].(ladon.Policies), args[2].(ladon.Policies))
+		run(args[0].(context.Context), args[1].(*ladon.Request), args[2].(ladon.Policies), args[3].(ladon.Policies))
 	})
 	return _c
 }
@@ -50,14 +54,14 @@ func (_c *AuditLogger_LogGrantedAccessRequest_Call) Return() *AuditLogger_LogGra
 	return _c
 }
 
-func (_c *AuditLogger_LogGrantedAccessRequest_Call) RunAndReturn(run func(*ladon.Request, ladon.Policies, ladon.Policies)) *AuditLogger_LogGrantedAccessRequest_Call {
+func (_c *AuditLogger_LogGrantedAccessRequest_Call) RunAndReturn(run func(context.Context, *ladon.Request, ladon.Policies, ladon.Policies)) *AuditLogger_LogGrantedAccessRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// LogRejectedAccessRequest provides a mock function with given fields: request, pool, deciders
-func (_m *AuditLogger) LogRejectedAccessRequest(request *ladon.Request, pool ladon.Policies, deciders ladon.Policies) {
-	_m.Called(request, pool, deciders)
+// LogRejectedAccessRequest provides a mock function with given fields: ctx, request, pool, deciders
+func (_m *AuditLogger) LogRejectedAccessRequest(ctx context.Context, request *ladon.Request, pool ladon.Policies, deciders ladon.Policies) {
+	_m.Called(ctx, request, pool, deciders)
 }
 
 // AuditLogger_LogRejectedAccessRequest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LogRejectedAccessRequest'
@@ -66,16 +70,17 @@ type AuditLogger_LogRejectedAccessRequest_Call struct {
 }
 
 // LogRejectedAccessRequest is a helper method to define mock.On call
+//   - ctx context.Context
 //   - request *ladon.Request
 //   - pool ladon.Policies
 //   - deciders ladon.Policies
-func (_e *AuditLogger_Expecter) LogRejectedAccessRequest(request interface{}, pool interface{}, deciders interface{}) *AuditLogger_LogRejectedAccessRequest_Call {
-	return &AuditLogger_LogRejectedAccessRequest_Call{Call: _e.mock.On("LogRejectedAccessRequest", request, pool, deciders)}
+func (_e *AuditLogger_Expecter) LogRejectedAccessRequest(ctx interface{}, request interface{}, pool interface{}, deciders interface{}) *AuditLogger_LogRejectedAccessRequest_Call {
+	return &AuditLogger_LogRejectedAccessRequest_Call{Call: _e.mock.On("LogRejectedAccessRequest", ctx, request, pool, deciders)}
 }
 
-func (_c *AuditLogger_LogRejectedAccessRequest_Call) Run(run func(request *ladon.Request, pool ladon.Policies, deciders ladon.Policies)) *AuditLogger_LogRejectedAccessRequest_Call {
+func (_c *AuditLogger_LogRejectedAccessRequest_Call) Run(run func(ctx context.Context, request *ladon.Request, pool ladon.Policies, deciders ladon.Policies)) *AuditLogger_LogRejectedAccessRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*ladon.Request), args[1].(ladon.Policies), args[2].(ladon.Policies))
+		run(args[0].(context.Context), args[1].(*ladon.Request), args[2].(ladon.Policies), args[3].(ladon.Policies))
 	})
 	return _c
 }
@@ -85,7 +90,7 @@ func (_c *AuditLogger_LogRejectedAccessRequest_Call) Return() *AuditLogger_LogRe
 	return _c
 }
 
-func (_c *AuditLogger_LogRejectedAccessRequest_Call) RunAndReturn(run func(*ladon.Request, ladon.Policies, ladon.Policies)) *AuditLogger_LogRejectedAccessRequest_Call {
+func (_c *AuditLogger_LogRejectedAccessRequest_Call) RunAndReturn(run func(context.Context, *ladon.Request, ladon.Policies, ladon.Policies)) *AuditLogger_LogRejectedAccessRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/guard/mocks/Guard.go
+++ b/pkg/guard/mocks/Guard.go
@@ -3,7 +3,10 @@
 package mocks
 
 import (
-	ladon "github.com/ory/ladon"
+	context "context"
+
+	ladon "github.com/selm0/ladon"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -20,13 +23,13 @@ func (_m *Guard) EXPECT() *Guard_Expecter {
 	return &Guard_Expecter{mock: &_m.Mock}
 }
 
-// CreatePolicy provides a mock function with given fields: pol
-func (_m *Guard) CreatePolicy(pol ladon.Policy) error {
-	ret := _m.Called(pol)
+// CreatePolicy provides a mock function with given fields: ctx, pol
+func (_m *Guard) CreatePolicy(ctx context.Context, pol ladon.Policy) error {
+	ret := _m.Called(ctx, pol)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(ladon.Policy) error); ok {
-		r0 = rf(pol)
+	if rf, ok := ret.Get(0).(func(context.Context, ladon.Policy) error); ok {
+		r0 = rf(ctx, pol)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -40,14 +43,15 @@ type Guard_CreatePolicy_Call struct {
 }
 
 // CreatePolicy is a helper method to define mock.On call
+//   - ctx context.Context
 //   - pol ladon.Policy
-func (_e *Guard_Expecter) CreatePolicy(pol interface{}) *Guard_CreatePolicy_Call {
-	return &Guard_CreatePolicy_Call{Call: _e.mock.On("CreatePolicy", pol)}
+func (_e *Guard_Expecter) CreatePolicy(ctx interface{}, pol interface{}) *Guard_CreatePolicy_Call {
+	return &Guard_CreatePolicy_Call{Call: _e.mock.On("CreatePolicy", ctx, pol)}
 }
 
-func (_c *Guard_CreatePolicy_Call) Run(run func(pol ladon.Policy)) *Guard_CreatePolicy_Call {
+func (_c *Guard_CreatePolicy_Call) Run(run func(ctx context.Context, pol ladon.Policy)) *Guard_CreatePolicy_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(ladon.Policy))
+		run(args[0].(context.Context), args[1].(ladon.Policy))
 	})
 	return _c
 }
@@ -57,18 +61,18 @@ func (_c *Guard_CreatePolicy_Call) Return(_a0 error) *Guard_CreatePolicy_Call {
 	return _c
 }
 
-func (_c *Guard_CreatePolicy_Call) RunAndReturn(run func(ladon.Policy) error) *Guard_CreatePolicy_Call {
+func (_c *Guard_CreatePolicy_Call) RunAndReturn(run func(context.Context, ladon.Policy) error) *Guard_CreatePolicy_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// DeletePolicy provides a mock function with given fields: pol
-func (_m *Guard) DeletePolicy(pol ladon.Policy) error {
-	ret := _m.Called(pol)
+// DeletePolicy provides a mock function with given fields: ctx, pol
+func (_m *Guard) DeletePolicy(ctx context.Context, pol ladon.Policy) error {
+	ret := _m.Called(ctx, pol)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(ladon.Policy) error); ok {
-		r0 = rf(pol)
+	if rf, ok := ret.Get(0).(func(context.Context, ladon.Policy) error); ok {
+		r0 = rf(ctx, pol)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -82,14 +86,15 @@ type Guard_DeletePolicy_Call struct {
 }
 
 // DeletePolicy is a helper method to define mock.On call
+//   - ctx context.Context
 //   - pol ladon.Policy
-func (_e *Guard_Expecter) DeletePolicy(pol interface{}) *Guard_DeletePolicy_Call {
-	return &Guard_DeletePolicy_Call{Call: _e.mock.On("DeletePolicy", pol)}
+func (_e *Guard_Expecter) DeletePolicy(ctx interface{}, pol interface{}) *Guard_DeletePolicy_Call {
+	return &Guard_DeletePolicy_Call{Call: _e.mock.On("DeletePolicy", ctx, pol)}
 }
 
-func (_c *Guard_DeletePolicy_Call) Run(run func(pol ladon.Policy)) *Guard_DeletePolicy_Call {
+func (_c *Guard_DeletePolicy_Call) Run(run func(ctx context.Context, pol ladon.Policy)) *Guard_DeletePolicy_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(ladon.Policy))
+		run(args[0].(context.Context), args[1].(ladon.Policy))
 	})
 	return _c
 }
@@ -99,30 +104,30 @@ func (_c *Guard_DeletePolicy_Call) Return(_a0 error) *Guard_DeletePolicy_Call {
 	return _c
 }
 
-func (_c *Guard_DeletePolicy_Call) RunAndReturn(run func(ladon.Policy) error) *Guard_DeletePolicy_Call {
+func (_c *Guard_DeletePolicy_Call) RunAndReturn(run func(context.Context, ladon.Policy) error) *Guard_DeletePolicy_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetPolicies provides a mock function with given fields:
-func (_m *Guard) GetPolicies() (ladon.Policies, error) {
-	ret := _m.Called()
+// GetPolicies provides a mock function with given fields: ctx
+func (_m *Guard) GetPolicies(ctx context.Context) (ladon.Policies, error) {
+	ret := _m.Called(ctx)
 
 	var r0 ladon.Policies
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (ladon.Policies, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(context.Context) (ladon.Policies, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func() ladon.Policies); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) ladon.Policies); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(ladon.Policies)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -136,13 +141,14 @@ type Guard_GetPolicies_Call struct {
 }
 
 // GetPolicies is a helper method to define mock.On call
-func (_e *Guard_Expecter) GetPolicies() *Guard_GetPolicies_Call {
-	return &Guard_GetPolicies_Call{Call: _e.mock.On("GetPolicies")}
+//   - ctx context.Context
+func (_e *Guard_Expecter) GetPolicies(ctx interface{}) *Guard_GetPolicies_Call {
+	return &Guard_GetPolicies_Call{Call: _e.mock.On("GetPolicies", ctx)}
 }
 
-func (_c *Guard_GetPolicies_Call) Run(run func()) *Guard_GetPolicies_Call {
+func (_c *Guard_GetPolicies_Call) Run(run func(ctx context.Context)) *Guard_GetPolicies_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -152,30 +158,30 @@ func (_c *Guard_GetPolicies_Call) Return(_a0 ladon.Policies, _a1 error) *Guard_G
 	return _c
 }
 
-func (_c *Guard_GetPolicies_Call) RunAndReturn(run func() (ladon.Policies, error)) *Guard_GetPolicies_Call {
+func (_c *Guard_GetPolicies_Call) RunAndReturn(run func(context.Context) (ladon.Policies, error)) *Guard_GetPolicies_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetPoliciesBySubject provides a mock function with given fields: subject
-func (_m *Guard) GetPoliciesBySubject(subject string) (ladon.Policies, error) {
-	ret := _m.Called(subject)
+// GetPoliciesBySubject provides a mock function with given fields: ctx, subject
+func (_m *Guard) GetPoliciesBySubject(ctx context.Context, subject string) (ladon.Policies, error) {
+	ret := _m.Called(ctx, subject)
 
 	var r0 ladon.Policies
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (ladon.Policies, error)); ok {
-		return rf(subject)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (ladon.Policies, error)); ok {
+		return rf(ctx, subject)
 	}
-	if rf, ok := ret.Get(0).(func(string) ladon.Policies); ok {
-		r0 = rf(subject)
+	if rf, ok := ret.Get(0).(func(context.Context, string) ladon.Policies); ok {
+		r0 = rf(ctx, subject)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(ladon.Policies)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(subject)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, subject)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -189,14 +195,15 @@ type Guard_GetPoliciesBySubject_Call struct {
 }
 
 // GetPoliciesBySubject is a helper method to define mock.On call
+//   - ctx context.Context
 //   - subject string
-func (_e *Guard_Expecter) GetPoliciesBySubject(subject interface{}) *Guard_GetPoliciesBySubject_Call {
-	return &Guard_GetPoliciesBySubject_Call{Call: _e.mock.On("GetPoliciesBySubject", subject)}
+func (_e *Guard_Expecter) GetPoliciesBySubject(ctx interface{}, subject interface{}) *Guard_GetPoliciesBySubject_Call {
+	return &Guard_GetPoliciesBySubject_Call{Call: _e.mock.On("GetPoliciesBySubject", ctx, subject)}
 }
 
-func (_c *Guard_GetPoliciesBySubject_Call) Run(run func(subject string)) *Guard_GetPoliciesBySubject_Call {
+func (_c *Guard_GetPoliciesBySubject_Call) Run(run func(ctx context.Context, subject string)) *Guard_GetPoliciesBySubject_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -206,30 +213,30 @@ func (_c *Guard_GetPoliciesBySubject_Call) Return(_a0 ladon.Policies, _a1 error)
 	return _c
 }
 
-func (_c *Guard_GetPoliciesBySubject_Call) RunAndReturn(run func(string) (ladon.Policies, error)) *Guard_GetPoliciesBySubject_Call {
+func (_c *Guard_GetPoliciesBySubject_Call) RunAndReturn(run func(context.Context, string) (ladon.Policies, error)) *Guard_GetPoliciesBySubject_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetPolicy provides a mock function with given fields: id
-func (_m *Guard) GetPolicy(id string) (ladon.Policy, error) {
-	ret := _m.Called(id)
+// GetPolicy provides a mock function with given fields: ctx, id
+func (_m *Guard) GetPolicy(ctx context.Context, id string) (ladon.Policy, error) {
+	ret := _m.Called(ctx, id)
 
 	var r0 ladon.Policy
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (ladon.Policy, error)); ok {
-		return rf(id)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (ladon.Policy, error)); ok {
+		return rf(ctx, id)
 	}
-	if rf, ok := ret.Get(0).(func(string) ladon.Policy); ok {
-		r0 = rf(id)
+	if rf, ok := ret.Get(0).(func(context.Context, string) ladon.Policy); ok {
+		r0 = rf(ctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(ladon.Policy)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(id)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -243,14 +250,15 @@ type Guard_GetPolicy_Call struct {
 }
 
 // GetPolicy is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *Guard_Expecter) GetPolicy(id interface{}) *Guard_GetPolicy_Call {
-	return &Guard_GetPolicy_Call{Call: _e.mock.On("GetPolicy", id)}
+func (_e *Guard_Expecter) GetPolicy(ctx interface{}, id interface{}) *Guard_GetPolicy_Call {
+	return &Guard_GetPolicy_Call{Call: _e.mock.On("GetPolicy", ctx, id)}
 }
 
-func (_c *Guard_GetPolicy_Call) Run(run func(id string)) *Guard_GetPolicy_Call {
+func (_c *Guard_GetPolicy_Call) Run(run func(ctx context.Context, id string)) *Guard_GetPolicy_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -260,18 +268,18 @@ func (_c *Guard_GetPolicy_Call) Return(_a0 ladon.Policy, _a1 error) *Guard_GetPo
 	return _c
 }
 
-func (_c *Guard_GetPolicy_Call) RunAndReturn(run func(string) (ladon.Policy, error)) *Guard_GetPolicy_Call {
+func (_c *Guard_GetPolicy_Call) RunAndReturn(run func(context.Context, string) (ladon.Policy, error)) *Guard_GetPolicy_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// IsAllowed provides a mock function with given fields: request
-func (_m *Guard) IsAllowed(request *ladon.Request) error {
-	ret := _m.Called(request)
+// IsAllowed provides a mock function with given fields: ctx, request
+func (_m *Guard) IsAllowed(ctx context.Context, request *ladon.Request) error {
+	ret := _m.Called(ctx, request)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*ladon.Request) error); ok {
-		r0 = rf(request)
+	if rf, ok := ret.Get(0).(func(context.Context, *ladon.Request) error); ok {
+		r0 = rf(ctx, request)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -285,14 +293,15 @@ type Guard_IsAllowed_Call struct {
 }
 
 // IsAllowed is a helper method to define mock.On call
+//   - ctx context.Context
 //   - request *ladon.Request
-func (_e *Guard_Expecter) IsAllowed(request interface{}) *Guard_IsAllowed_Call {
-	return &Guard_IsAllowed_Call{Call: _e.mock.On("IsAllowed", request)}
+func (_e *Guard_Expecter) IsAllowed(ctx interface{}, request interface{}) *Guard_IsAllowed_Call {
+	return &Guard_IsAllowed_Call{Call: _e.mock.On("IsAllowed", ctx, request)}
 }
 
-func (_c *Guard_IsAllowed_Call) Run(run func(request *ladon.Request)) *Guard_IsAllowed_Call {
+func (_c *Guard_IsAllowed_Call) Run(run func(ctx context.Context, request *ladon.Request)) *Guard_IsAllowed_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*ladon.Request))
+		run(args[0].(context.Context), args[1].(*ladon.Request))
 	})
 	return _c
 }
@@ -302,18 +311,18 @@ func (_c *Guard_IsAllowed_Call) Return(_a0 error) *Guard_IsAllowed_Call {
 	return _c
 }
 
-func (_c *Guard_IsAllowed_Call) RunAndReturn(run func(*ladon.Request) error) *Guard_IsAllowed_Call {
+func (_c *Guard_IsAllowed_Call) RunAndReturn(run func(context.Context, *ladon.Request) error) *Guard_IsAllowed_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// UpdatePolicy provides a mock function with given fields: pol
-func (_m *Guard) UpdatePolicy(pol ladon.Policy) error {
-	ret := _m.Called(pol)
+// UpdatePolicy provides a mock function with given fields: ctx, pol
+func (_m *Guard) UpdatePolicy(ctx context.Context, pol ladon.Policy) error {
+	ret := _m.Called(ctx, pol)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(ladon.Policy) error); ok {
-		r0 = rf(pol)
+	if rf, ok := ret.Get(0).(func(context.Context, ladon.Policy) error); ok {
+		r0 = rf(ctx, pol)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -327,14 +336,15 @@ type Guard_UpdatePolicy_Call struct {
 }
 
 // UpdatePolicy is a helper method to define mock.On call
+//   - ctx context.Context
 //   - pol ladon.Policy
-func (_e *Guard_Expecter) UpdatePolicy(pol interface{}) *Guard_UpdatePolicy_Call {
-	return &Guard_UpdatePolicy_Call{Call: _e.mock.On("UpdatePolicy", pol)}
+func (_e *Guard_Expecter) UpdatePolicy(ctx interface{}, pol interface{}) *Guard_UpdatePolicy_Call {
+	return &Guard_UpdatePolicy_Call{Call: _e.mock.On("UpdatePolicy", ctx, pol)}
 }
 
-func (_c *Guard_UpdatePolicy_Call) Run(run func(pol ladon.Policy)) *Guard_UpdatePolicy_Call {
+func (_c *Guard_UpdatePolicy_Call) Run(run func(ctx context.Context, pol ladon.Policy)) *Guard_UpdatePolicy_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(ladon.Policy))
+		run(args[0].(context.Context), args[1].(ladon.Policy))
 	})
 	return _c
 }
@@ -344,7 +354,7 @@ func (_c *Guard_UpdatePolicy_Call) Return(_a0 error) *Guard_UpdatePolicy_Call {
 	return _c
 }
 
-func (_c *Guard_UpdatePolicy_Call) RunAndReturn(run func(ladon.Policy) error) *Guard_UpdatePolicy_Call {
+func (_c *Guard_UpdatePolicy_Call) RunAndReturn(run func(context.Context, ladon.Policy) error) *Guard_UpdatePolicy_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/guard/mocks/Manager.go
+++ b/pkg/guard/mocks/Manager.go
@@ -3,7 +3,10 @@
 package mocks
 
 import (
-	ladon "github.com/ory/ladon"
+	context "context"
+
+	ladon "github.com/selm0/ladon"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -20,13 +23,13 @@ func (_m *Manager) EXPECT() *Manager_Expecter {
 	return &Manager_Expecter{mock: &_m.Mock}
 }
 
-// Create provides a mock function with given fields: policy
-func (_m *Manager) Create(policy ladon.Policy) error {
-	ret := _m.Called(policy)
+// Create provides a mock function with given fields: ctx, policy
+func (_m *Manager) Create(ctx context.Context, policy ladon.Policy) error {
+	ret := _m.Called(ctx, policy)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(ladon.Policy) error); ok {
-		r0 = rf(policy)
+	if rf, ok := ret.Get(0).(func(context.Context, ladon.Policy) error); ok {
+		r0 = rf(ctx, policy)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -40,14 +43,15 @@ type Manager_Create_Call struct {
 }
 
 // Create is a helper method to define mock.On call
+//   - ctx context.Context
 //   - policy ladon.Policy
-func (_e *Manager_Expecter) Create(policy interface{}) *Manager_Create_Call {
-	return &Manager_Create_Call{Call: _e.mock.On("Create", policy)}
+func (_e *Manager_Expecter) Create(ctx interface{}, policy interface{}) *Manager_Create_Call {
+	return &Manager_Create_Call{Call: _e.mock.On("Create", ctx, policy)}
 }
 
-func (_c *Manager_Create_Call) Run(run func(policy ladon.Policy)) *Manager_Create_Call {
+func (_c *Manager_Create_Call) Run(run func(ctx context.Context, policy ladon.Policy)) *Manager_Create_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(ladon.Policy))
+		run(args[0].(context.Context), args[1].(ladon.Policy))
 	})
 	return _c
 }
@@ -57,18 +61,18 @@ func (_c *Manager_Create_Call) Return(_a0 error) *Manager_Create_Call {
 	return _c
 }
 
-func (_c *Manager_Create_Call) RunAndReturn(run func(ladon.Policy) error) *Manager_Create_Call {
+func (_c *Manager_Create_Call) RunAndReturn(run func(context.Context, ladon.Policy) error) *Manager_Create_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// Delete provides a mock function with given fields: id
-func (_m *Manager) Delete(id string) error {
-	ret := _m.Called(id)
+// Delete provides a mock function with given fields: ctx, id
+func (_m *Manager) Delete(ctx context.Context, id string) error {
+	ret := _m.Called(ctx, id)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(id)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -82,14 +86,15 @@ type Manager_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *Manager_Expecter) Delete(id interface{}) *Manager_Delete_Call {
-	return &Manager_Delete_Call{Call: _e.mock.On("Delete", id)}
+func (_e *Manager_Expecter) Delete(ctx interface{}, id interface{}) *Manager_Delete_Call {
+	return &Manager_Delete_Call{Call: _e.mock.On("Delete", ctx, id)}
 }
 
-func (_c *Manager_Delete_Call) Run(run func(id string)) *Manager_Delete_Call {
+func (_c *Manager_Delete_Call) Run(run func(ctx context.Context, id string)) *Manager_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -99,30 +104,30 @@ func (_c *Manager_Delete_Call) Return(_a0 error) *Manager_Delete_Call {
 	return _c
 }
 
-func (_c *Manager_Delete_Call) RunAndReturn(run func(string) error) *Manager_Delete_Call {
+func (_c *Manager_Delete_Call) RunAndReturn(run func(context.Context, string) error) *Manager_Delete_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// FindPoliciesForResource provides a mock function with given fields: resource
-func (_m *Manager) FindPoliciesForResource(resource string) (ladon.Policies, error) {
-	ret := _m.Called(resource)
+// FindPoliciesForResource provides a mock function with given fields: ctx, resource
+func (_m *Manager) FindPoliciesForResource(ctx context.Context, resource string) (ladon.Policies, error) {
+	ret := _m.Called(ctx, resource)
 
 	var r0 ladon.Policies
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (ladon.Policies, error)); ok {
-		return rf(resource)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (ladon.Policies, error)); ok {
+		return rf(ctx, resource)
 	}
-	if rf, ok := ret.Get(0).(func(string) ladon.Policies); ok {
-		r0 = rf(resource)
+	if rf, ok := ret.Get(0).(func(context.Context, string) ladon.Policies); ok {
+		r0 = rf(ctx, resource)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(ladon.Policies)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(resource)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, resource)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -136,14 +141,15 @@ type Manager_FindPoliciesForResource_Call struct {
 }
 
 // FindPoliciesForResource is a helper method to define mock.On call
+//   - ctx context.Context
 //   - resource string
-func (_e *Manager_Expecter) FindPoliciesForResource(resource interface{}) *Manager_FindPoliciesForResource_Call {
-	return &Manager_FindPoliciesForResource_Call{Call: _e.mock.On("FindPoliciesForResource", resource)}
+func (_e *Manager_Expecter) FindPoliciesForResource(ctx interface{}, resource interface{}) *Manager_FindPoliciesForResource_Call {
+	return &Manager_FindPoliciesForResource_Call{Call: _e.mock.On("FindPoliciesForResource", ctx, resource)}
 }
 
-func (_c *Manager_FindPoliciesForResource_Call) Run(run func(resource string)) *Manager_FindPoliciesForResource_Call {
+func (_c *Manager_FindPoliciesForResource_Call) Run(run func(ctx context.Context, resource string)) *Manager_FindPoliciesForResource_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -153,30 +159,30 @@ func (_c *Manager_FindPoliciesForResource_Call) Return(_a0 ladon.Policies, _a1 e
 	return _c
 }
 
-func (_c *Manager_FindPoliciesForResource_Call) RunAndReturn(run func(string) (ladon.Policies, error)) *Manager_FindPoliciesForResource_Call {
+func (_c *Manager_FindPoliciesForResource_Call) RunAndReturn(run func(context.Context, string) (ladon.Policies, error)) *Manager_FindPoliciesForResource_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// FindPoliciesForSubject provides a mock function with given fields: subject
-func (_m *Manager) FindPoliciesForSubject(subject string) (ladon.Policies, error) {
-	ret := _m.Called(subject)
+// FindPoliciesForSubject provides a mock function with given fields: ctx, subject
+func (_m *Manager) FindPoliciesForSubject(ctx context.Context, subject string) (ladon.Policies, error) {
+	ret := _m.Called(ctx, subject)
 
 	var r0 ladon.Policies
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (ladon.Policies, error)); ok {
-		return rf(subject)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (ladon.Policies, error)); ok {
+		return rf(ctx, subject)
 	}
-	if rf, ok := ret.Get(0).(func(string) ladon.Policies); ok {
-		r0 = rf(subject)
+	if rf, ok := ret.Get(0).(func(context.Context, string) ladon.Policies); ok {
+		r0 = rf(ctx, subject)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(ladon.Policies)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(subject)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, subject)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -190,14 +196,15 @@ type Manager_FindPoliciesForSubject_Call struct {
 }
 
 // FindPoliciesForSubject is a helper method to define mock.On call
+//   - ctx context.Context
 //   - subject string
-func (_e *Manager_Expecter) FindPoliciesForSubject(subject interface{}) *Manager_FindPoliciesForSubject_Call {
-	return &Manager_FindPoliciesForSubject_Call{Call: _e.mock.On("FindPoliciesForSubject", subject)}
+func (_e *Manager_Expecter) FindPoliciesForSubject(ctx interface{}, subject interface{}) *Manager_FindPoliciesForSubject_Call {
+	return &Manager_FindPoliciesForSubject_Call{Call: _e.mock.On("FindPoliciesForSubject", ctx, subject)}
 }
 
-func (_c *Manager_FindPoliciesForSubject_Call) Run(run func(subject string)) *Manager_FindPoliciesForSubject_Call {
+func (_c *Manager_FindPoliciesForSubject_Call) Run(run func(ctx context.Context, subject string)) *Manager_FindPoliciesForSubject_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -207,30 +214,30 @@ func (_c *Manager_FindPoliciesForSubject_Call) Return(_a0 ladon.Policies, _a1 er
 	return _c
 }
 
-func (_c *Manager_FindPoliciesForSubject_Call) RunAndReturn(run func(string) (ladon.Policies, error)) *Manager_FindPoliciesForSubject_Call {
+func (_c *Manager_FindPoliciesForSubject_Call) RunAndReturn(run func(context.Context, string) (ladon.Policies, error)) *Manager_FindPoliciesForSubject_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// FindRequestCandidates provides a mock function with given fields: r
-func (_m *Manager) FindRequestCandidates(r *ladon.Request) (ladon.Policies, error) {
-	ret := _m.Called(r)
+// FindRequestCandidates provides a mock function with given fields: ctx, r
+func (_m *Manager) FindRequestCandidates(ctx context.Context, r *ladon.Request) (ladon.Policies, error) {
+	ret := _m.Called(ctx, r)
 
 	var r0 ladon.Policies
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ladon.Request) (ladon.Policies, error)); ok {
-		return rf(r)
+	if rf, ok := ret.Get(0).(func(context.Context, *ladon.Request) (ladon.Policies, error)); ok {
+		return rf(ctx, r)
 	}
-	if rf, ok := ret.Get(0).(func(*ladon.Request) ladon.Policies); ok {
-		r0 = rf(r)
+	if rf, ok := ret.Get(0).(func(context.Context, *ladon.Request) ladon.Policies); ok {
+		r0 = rf(ctx, r)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(ladon.Policies)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*ladon.Request) error); ok {
-		r1 = rf(r)
+	if rf, ok := ret.Get(1).(func(context.Context, *ladon.Request) error); ok {
+		r1 = rf(ctx, r)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -244,14 +251,15 @@ type Manager_FindRequestCandidates_Call struct {
 }
 
 // FindRequestCandidates is a helper method to define mock.On call
+//   - ctx context.Context
 //   - r *ladon.Request
-func (_e *Manager_Expecter) FindRequestCandidates(r interface{}) *Manager_FindRequestCandidates_Call {
-	return &Manager_FindRequestCandidates_Call{Call: _e.mock.On("FindRequestCandidates", r)}
+func (_e *Manager_Expecter) FindRequestCandidates(ctx interface{}, r interface{}) *Manager_FindRequestCandidates_Call {
+	return &Manager_FindRequestCandidates_Call{Call: _e.mock.On("FindRequestCandidates", ctx, r)}
 }
 
-func (_c *Manager_FindRequestCandidates_Call) Run(run func(r *ladon.Request)) *Manager_FindRequestCandidates_Call {
+func (_c *Manager_FindRequestCandidates_Call) Run(run func(ctx context.Context, r *ladon.Request)) *Manager_FindRequestCandidates_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*ladon.Request))
+		run(args[0].(context.Context), args[1].(*ladon.Request))
 	})
 	return _c
 }
@@ -261,30 +269,30 @@ func (_c *Manager_FindRequestCandidates_Call) Return(_a0 ladon.Policies, _a1 err
 	return _c
 }
 
-func (_c *Manager_FindRequestCandidates_Call) RunAndReturn(run func(*ladon.Request) (ladon.Policies, error)) *Manager_FindRequestCandidates_Call {
+func (_c *Manager_FindRequestCandidates_Call) RunAndReturn(run func(context.Context, *ladon.Request) (ladon.Policies, error)) *Manager_FindRequestCandidates_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// Get provides a mock function with given fields: id
-func (_m *Manager) Get(id string) (ladon.Policy, error) {
-	ret := _m.Called(id)
+// Get provides a mock function with given fields: ctx, id
+func (_m *Manager) Get(ctx context.Context, id string) (ladon.Policy, error) {
+	ret := _m.Called(ctx, id)
 
 	var r0 ladon.Policy
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (ladon.Policy, error)); ok {
-		return rf(id)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (ladon.Policy, error)); ok {
+		return rf(ctx, id)
 	}
-	if rf, ok := ret.Get(0).(func(string) ladon.Policy); ok {
-		r0 = rf(id)
+	if rf, ok := ret.Get(0).(func(context.Context, string) ladon.Policy); ok {
+		r0 = rf(ctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(ladon.Policy)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(id)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -298,14 +306,15 @@ type Manager_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *Manager_Expecter) Get(id interface{}) *Manager_Get_Call {
-	return &Manager_Get_Call{Call: _e.mock.On("Get", id)}
+func (_e *Manager_Expecter) Get(ctx interface{}, id interface{}) *Manager_Get_Call {
+	return &Manager_Get_Call{Call: _e.mock.On("Get", ctx, id)}
 }
 
-func (_c *Manager_Get_Call) Run(run func(id string)) *Manager_Get_Call {
+func (_c *Manager_Get_Call) Run(run func(ctx context.Context, id string)) *Manager_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -315,30 +324,30 @@ func (_c *Manager_Get_Call) Return(_a0 ladon.Policy, _a1 error) *Manager_Get_Cal
 	return _c
 }
 
-func (_c *Manager_Get_Call) RunAndReturn(run func(string) (ladon.Policy, error)) *Manager_Get_Call {
+func (_c *Manager_Get_Call) RunAndReturn(run func(context.Context, string) (ladon.Policy, error)) *Manager_Get_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetAll provides a mock function with given fields: limit, offset
-func (_m *Manager) GetAll(limit int64, offset int64) (ladon.Policies, error) {
-	ret := _m.Called(limit, offset)
+// GetAll provides a mock function with given fields: ctx, limit, offset
+func (_m *Manager) GetAll(ctx context.Context, limit int64, offset int64) (ladon.Policies, error) {
+	ret := _m.Called(ctx, limit, offset)
 
 	var r0 ladon.Policies
 	var r1 error
-	if rf, ok := ret.Get(0).(func(int64, int64) (ladon.Policies, error)); ok {
-		return rf(limit, offset)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, int64) (ladon.Policies, error)); ok {
+		return rf(ctx, limit, offset)
 	}
-	if rf, ok := ret.Get(0).(func(int64, int64) ladon.Policies); ok {
-		r0 = rf(limit, offset)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, int64) ladon.Policies); ok {
+		r0 = rf(ctx, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(ladon.Policies)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(int64, int64) error); ok {
-		r1 = rf(limit, offset)
+	if rf, ok := ret.Get(1).(func(context.Context, int64, int64) error); ok {
+		r1 = rf(ctx, limit, offset)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -352,15 +361,16 @@ type Manager_GetAll_Call struct {
 }
 
 // GetAll is a helper method to define mock.On call
+//   - ctx context.Context
 //   - limit int64
 //   - offset int64
-func (_e *Manager_Expecter) GetAll(limit interface{}, offset interface{}) *Manager_GetAll_Call {
-	return &Manager_GetAll_Call{Call: _e.mock.On("GetAll", limit, offset)}
+func (_e *Manager_Expecter) GetAll(ctx interface{}, limit interface{}, offset interface{}) *Manager_GetAll_Call {
+	return &Manager_GetAll_Call{Call: _e.mock.On("GetAll", ctx, limit, offset)}
 }
 
-func (_c *Manager_GetAll_Call) Run(run func(limit int64, offset int64)) *Manager_GetAll_Call {
+func (_c *Manager_GetAll_Call) Run(run func(ctx context.Context, limit int64, offset int64)) *Manager_GetAll_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64), args[1].(int64))
+		run(args[0].(context.Context), args[1].(int64), args[2].(int64))
 	})
 	return _c
 }
@@ -370,18 +380,18 @@ func (_c *Manager_GetAll_Call) Return(_a0 ladon.Policies, _a1 error) *Manager_Ge
 	return _c
 }
 
-func (_c *Manager_GetAll_Call) RunAndReturn(run func(int64, int64) (ladon.Policies, error)) *Manager_GetAll_Call {
+func (_c *Manager_GetAll_Call) RunAndReturn(run func(context.Context, int64, int64) (ladon.Policies, error)) *Manager_GetAll_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// Update provides a mock function with given fields: policy
-func (_m *Manager) Update(policy ladon.Policy) error {
-	ret := _m.Called(policy)
+// Update provides a mock function with given fields: ctx, policy
+func (_m *Manager) Update(ctx context.Context, policy ladon.Policy) error {
+	ret := _m.Called(ctx, policy)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(ladon.Policy) error); ok {
-		r0 = rf(policy)
+	if rf, ok := ret.Get(0).(func(context.Context, ladon.Policy) error); ok {
+		r0 = rf(ctx, policy)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -395,14 +405,15 @@ type Manager_Update_Call struct {
 }
 
 // Update is a helper method to define mock.On call
+//   - ctx context.Context
 //   - policy ladon.Policy
-func (_e *Manager_Expecter) Update(policy interface{}) *Manager_Update_Call {
-	return &Manager_Update_Call{Call: _e.mock.On("Update", policy)}
+func (_e *Manager_Expecter) Update(ctx interface{}, policy interface{}) *Manager_Update_Call {
+	return &Manager_Update_Call{Call: _e.mock.On("Update", ctx, policy)}
 }
 
-func (_c *Manager_Update_Call) Run(run func(policy ladon.Policy)) *Manager_Update_Call {
+func (_c *Manager_Update_Call) Run(run func(ctx context.Context, policy ladon.Policy)) *Manager_Update_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(ladon.Policy))
+		run(args[0].(context.Context), args[1].(ladon.Policy))
 	})
 	return _c
 }
@@ -412,7 +423,7 @@ func (_c *Manager_Update_Call) Return(_a0 error) *Manager_Update_Call {
 	return _c
 }
 
-func (_c *Manager_Update_Call) RunAndReturn(run func(ladon.Policy) error) *Manager_Update_Call {
+func (_c *Manager_Update_Call) RunAndReturn(run func(context.Context, ladon.Policy) error) *Manager_Update_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/share/create.go
+++ b/pkg/share/create.go
@@ -61,7 +61,7 @@ func (s shareCreateHandler) Handle(ctx context.Context, req *apiserver.Request) 
 	policy := BuildSharePolicy(s.uuidProvider.NewV4(), entity, shareInput.GetOwnerId(), shareInput.GetActions())
 
 	guard := s.transformer.GetGuard()
-	err = guard.CreatePolicy(policy)
+	err = guard.CreatePolicy(ctx, policy)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/share/handler.go
+++ b/pkg/share/handler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/justtrackio/gosoline/pkg/db-repo"
 	"github.com/justtrackio/gosoline/pkg/guard"
 	"github.com/justtrackio/gosoline/pkg/log"
-	"github.com/ory/ladon"
+	"github.com/selm0/ladon"
 )
 
 type Shareable interface {

--- a/pkg/share/policy_builder.go
+++ b/pkg/share/policy_builder.go
@@ -3,7 +3,7 @@ package share
 import (
 	"fmt"
 
-	"github.com/ory/ladon"
+	"github.com/selm0/ladon"
 )
 
 func BuildSharePolicy(uuid string, entity Shareable, ownerId uint, actions []string) ladon.Policy {

--- a/pkg/share/repository.go
+++ b/pkg/share/repository.go
@@ -9,7 +9,7 @@ import (
 	"github.com/justtrackio/gosoline/pkg/db-repo"
 	"github.com/justtrackio/gosoline/pkg/guard"
 	"github.com/justtrackio/gosoline/pkg/log"
-	"github.com/ory/ladon"
+	"github.com/selm0/ladon"
 )
 
 type WithPolicy interface {
@@ -78,7 +78,7 @@ func (r sqlRepository) Delete(ctx context.Context, value db_repo.ModelBased) err
 		return err
 	}
 
-	err = r.guard.DeletePolicy(&ladon.DefaultPolicy{ID: s.GetPolicyId()})
+	err = r.guard.DeletePolicy(ctx, &ladon.DefaultPolicy{ID: s.GetPolicyId()})
 	if err != nil {
 		return err
 	}

--- a/pkg/share/shareable_repository.go
+++ b/pkg/share/shareable_repository.go
@@ -8,7 +8,7 @@ import (
 	"github.com/justtrackio/gosoline/pkg/db-repo"
 	"github.com/justtrackio/gosoline/pkg/guard"
 	"github.com/justtrackio/gosoline/pkg/log"
-	"github.com/ory/ladon"
+	"github.com/selm0/ladon"
 )
 
 type shareRepository struct {
@@ -54,13 +54,13 @@ func (r shareRepository) Update(ctx context.Context, value db_repo.ModelBased) e
 	}
 
 	for _, share := range shares {
-		oldPolicy, err := r.guard.GetPolicy(share.PolicyId)
+		oldPolicy, err := r.guard.GetPolicy(ctx, share.PolicyId)
 		if err != nil {
 			return fmt.Errorf("can not get policy by id: %w", err)
 		}
 
 		updatedPolicy := BuildSharePolicy(share.PolicyId, entity, share.OwnerId, oldPolicy.GetActions())
-		err = r.guard.UpdatePolicy(updatedPolicy)
+		err = r.guard.UpdatePolicy(ctx, updatedPolicy)
 		if err != nil {
 			return fmt.Errorf("can not update policy: %w", err)
 		}
@@ -86,7 +86,7 @@ func (r shareRepository) Delete(ctx context.Context, value db_repo.ModelBased) e
 			return fmt.Errorf("can not delete share of entity: %w", err)
 		}
 
-		err = r.guard.DeletePolicy(&ladon.DefaultPolicy{ID: share.PolicyId})
+		err = r.guard.DeletePolicy(ctx, &ladon.DefaultPolicy{ID: share.PolicyId})
 		if err != nil {
 			return fmt.Errorf("can not delete policy of share: %w", err)
 		}

--- a/test/guard/guard_test.go
+++ b/test/guard/guard_test.go
@@ -3,13 +3,14 @@
 package guard_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/justtrackio/gosoline/pkg/fixtures"
 	"github.com/justtrackio/gosoline/pkg/guard"
 	"github.com/justtrackio/gosoline/pkg/test/suite"
-	"github.com/ory/ladon"
+	"github.com/selm0/ladon"
 )
 
 type GuardTestSuite struct {
@@ -48,31 +49,35 @@ func (s *GuardTestSuite) TestCrud() {
 		Actions:     []string{"<.+>"},
 	}
 
-	err := s.guard.CreatePolicy(&pol)
+	ctx := context.Background()
+
+	err := s.guard.CreatePolicy(ctx, &pol)
 	if !s.NoError(err) {
 		return
 	}
 
 	pol.Description = "allow everything"
 
-	err = s.guard.UpdatePolicy(&pol)
+	err = s.guard.UpdatePolicy(ctx, &pol)
 	if !s.NoError(err) {
 		return
 	}
 
-	err = s.guard.DeletePolicy(&pol)
+	err = s.guard.DeletePolicy(ctx, &pol)
 	s.NoError(err)
 }
 
 func (s *GuardTestSuite) TestGetPolicies() {
-	policies, err := s.guard.GetPolicies()
+	ctx := context.Background()
+
+	policies, err := s.guard.GetPolicies(ctx)
 	if !s.NoError(err) {
 		return
 	}
 
 	s.Len(policies, 2)
 
-	policies, err = s.guard.GetPoliciesBySubject("r:1")
+	policies, err = s.guard.GetPoliciesBySubject(ctx, "r:1")
 	if !s.NoError(err) {
 		return
 	}
@@ -87,10 +92,12 @@ func (s *GuardTestSuite) TestIsAllowed() {
 		Subject:  "r:1",
 	}
 
-	err := s.guard.IsAllowed(&req)
+	ctx := context.Background()
+
+	err := s.guard.IsAllowed(ctx, &req)
 	s.NoError(err)
 
-	err = s.guard.IsAllowed(&ladon.Request{})
+	err = s.guard.IsAllowed(ctx, &ladon.Request{})
 	s.Error(err, "Request was denied by default")
 }
 


### PR DESCRIPTION
If you want to provide additional contextual information, you need to pass on the context to the logger in your guard audit. Hence we switched to a fork which supports `context.Context` as a parameter.
Additionally you can now configure the audit logger and enable / disable both grant and rejection logs. By default, grants are disabled / rejections are enabled. You can adjust this like the following:
```yaml
guard:
  audit:
    log_grants: false
    log_rejections: true
```