### PR TITLE
guard: unify guard tables;

### DIFF
--- a/test/guard/fixtures_test.go
+++ b/test/guard/fixtures_test.go
@@ -8,31 +8,9 @@ import (
 
 func buildPolicies() []interface{} {
 	return []interface{}{
-		fixtures.MysqlPlainFixtureValues{"a97b104f-4d93-4c15-a97a-4e3173e75cde", "global - read and write access", "allow", "{}"},
-		fixtures.MysqlPlainFixtureValues{"18a1de65-62eb-4af6-aab4-593d05ed30be", "entity - read and write access", "allow", "{}"},
-		fixtures.MysqlPlainFixtureValues{"4ab80e96-22ea-469e-96d1-12b232bd4660", "global - read access", "allow", "{}"},
-	}
-}
-
-func buildSubjects() []interface{} {
-	return []interface{}{
-		fixtures.MysqlPlainFixtureValues{"a97b104f-4d93-4c15-a97a-4e3173e75cde", "r:1"},
-		fixtures.MysqlPlainFixtureValues{"18a1de65-62eb-4af6-aab4-593d05ed30be", "r:2"},
-	}
-}
-
-func buildResources() []interface{} {
-	return []interface{}{
-		fixtures.MysqlPlainFixtureValues{"a97b104f-4d93-4c15-a97a-4e3173e75cde", "gsl:<.+>"},
-		fixtures.MysqlPlainFixtureValues{"18a1de65-62eb-4af6-aab4-593d05ed30be", "gsl:e:1:<.+>"},
-	}
-}
-
-func buildActions() []interface{} {
-	return []interface{}{
-		fixtures.MysqlPlainFixtureValues{"a97b104f-4d93-4c15-a97a-4e3173e75cde", "<.+>"},
-		fixtures.MysqlPlainFixtureValues{"18a1de65-62eb-4af6-aab4-593d05ed30be", "<.+>"},
-		fixtures.MysqlPlainFixtureValues{"ab80e96-22ea-469e-96d1-12b232bd4660", "read"},
+		fixtures.MysqlPlainFixtureValues{"a97b104f-4d93-4c15-a97a-4e3173e75cde", `{"id": "a97b104f-4d93-4c15-a97a-4e3173e75cde", "effect": "allow", "actions": ["<.+>"], "subjects": ["r:1"], "resources": ["gsl:<.+>"], "conditions": {}, "description": "global - read and write access"}`},
+		fixtures.MysqlPlainFixtureValues{"18a1de65-62eb-4af6-aab4-593d05ed30be", `{"id": "18a1de65-62eb-4af6-aab4-593d05ed30be", "effect": "allow", "actions": ["<.+>"], "subjects": ["r:2"], "resources": ["gsl:e:1:<.+>"], "conditions": {}, "description": "entity - read and write access"}`},
+		fixtures.MysqlPlainFixtureValues{"4ab80e96-22ea-469e-96d1-12b232bd4660", `{"id": "4ab80e96-22ea-469e-96d1-12b232bd4660", "effect": "allow", "actions": ["read"], "subjects": [], "resources": [], "conditions": {}, "description": "global - read access"}`},
 	}
 }
 
@@ -42,35 +20,8 @@ var fixtureSets = []*fixtures.FixtureSet{
 		Purge:   false,
 		Writer: fixtures.MysqlPlainFixtureWriterFactory(&fixtures.MysqlPlainMetaData{
 			TableName: "guard_policies",
-			Columns:   []string{"id", "description", "effect", "conditions"},
+			Columns:   []string{"id", "policy"},
 		}),
 		Fixtures: buildPolicies(),
-	},
-	{
-		Enabled: true,
-		Purge:   false,
-		Writer: fixtures.MysqlPlainFixtureWriterFactory(&fixtures.MysqlPlainMetaData{
-			TableName: "guard_subjects",
-			Columns:   []string{"id", "name"},
-		}),
-		Fixtures: buildSubjects(),
-	},
-	{
-		Enabled: true,
-		Purge:   false,
-		Writer: fixtures.MysqlPlainFixtureWriterFactory(&fixtures.MysqlPlainMetaData{
-			TableName: "guard_resources",
-			Columns:   []string{"id", "name"},
-		}),
-		Fixtures: buildResources(),
-	},
-	{
-		Enabled: true,
-		Purge:   false,
-		Writer: fixtures.MysqlPlainFixtureWriterFactory(&fixtures.MysqlPlainMetaData{
-			TableName: "guard_actions",
-			Columns:   []string{"id", "name"},
-		}),
-		Fixtures: buildActions(),
 	},
 }

--- a/test/guard/guard_test.go
+++ b/test/guard/guard_test.go
@@ -75,7 +75,7 @@ func (s *GuardTestSuite) TestGetPolicies() {
 		return
 	}
 
-	s.Len(policies, 2)
+	s.Len(policies, 3)
 
 	policies, err = s.guard.GetPoliciesBySubject(ctx, "r:1")
 	if !s.NoError(err) {

--- a/test/guard/migrations/01_add_guard_policy.up.sql
+++ b/test/guard/migrations/01_add_guard_policy.up.sql
@@ -1,35 +1,8 @@
 create table guard_policies
 (
-	id varchar(255) not null,
-	description varchar(255) not null,
-	effect varchar(255) not null,
-    conditions text not null,
-	updated_at datetime not null,
-	created_at datetime not null,
-	constraint guard_policies_pk
-		primary key (id)
-);
-
-create table guard_subjects
-(
-	id VARCHAR(255) not null,
-	name VARCHAR(255) not null,
-	constraint table_name_pk
-		primary key (id, name)
-);
-
-create table guard_resources
-(
-	id VARCHAR(255) not null,
-	name VARCHAR(255) not null,
-	constraint table_name_pk
-		primary key (id, name)
-);
-
-create table guard_actions
-(
-	id VARCHAR(255) not null,
-	name VARCHAR(255) not null,
-	constraint table_name_pk
-		primary key (id, name)
+    id         varchar(255) not null
+        primary key,
+    policy     json         not null,
+    updated_at datetime     not null,
+    created_at datetime     not null
 );


### PR DESCRIPTION
Increases guard table transparency by unifying guard tables. The original library uses JSON policies, the changes allows us to switch to JSON representation of the policy instead of the fully-denormalized way