### PR TITLE
http: add disable_cookies config flag;

### DIFF
--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -71,6 +71,7 @@ type client struct {
 }
 
 type Settings struct {
+	DisableCookies         bool                   `cfg:"disable_cookies" default:"false"`
 	FollowRedirects        bool                   `cfg:"follow_redirects" default:"true"`
 	RequestTimeout         time.Duration          `cfg:"request_timeout" default:"30s"`
 	RetryCount             int                    `cfg:"retry_count" default:"5"`
@@ -92,7 +93,13 @@ func newHttpClient(config cfg.Config, logger log.Logger, name string) Client {
 	metricWriter := metric.NewWriter()
 	settings := UnmarshalClientSettings(config, name)
 
-	httpClient := resty.New()
+	var httpClient *resty.Client
+	if settings.DisableCookies {
+		httpClient = resty.NewWithClient(&http.Client{})
+	} else {
+		httpClient = resty.New()
+	}
+
 	if settings.FollowRedirects {
 		httpClient.SetRedirectPolicy(resty.FlexibleRedirectPolicy(10))
 	} else {


### PR DESCRIPTION
Adds a configuration flag `disable_cookies` to the http client.

after this change you should be able to configure a http client without cookies. It shouldn't have any breaking changes, the default option is with cookies enabled.

usage example:

```
http_client:
  default:
    request_timeout: 1s
    retry_count: 3
    follow_redirects: false
    disable_cookies: true
```