### PR TITLE
log: Split logger fields into local and global fields and made them mutable

### DIFF
--- a/docs/docs/how-to/logging/src/complex-logger/main.go
+++ b/docs/docs/how-to/logging/src/complex-logger/main.go
@@ -17,7 +17,7 @@ func main() {
 	handler := log.NewHandlerIoWriter(log.LevelDebug, []string{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
 	logger := log.NewLoggerWithInterfaces(clock.NewRealClock(), []log.Handler{handler})
 
-	if err := logger.Option(log.WithContextFieldsResolver(log.ContextLoggerFieldsResolver)); err != nil {
+	if err := logger.Option(log.WithContextFieldsResolver(log.ContextFieldsResolver)); err != nil {
 		panic(err)
 	}
 
@@ -35,7 +35,7 @@ func main() {
 	loggerWithFields.Error("it happens: %w", fmt.Errorf("should not happen"))
 
 	// 6
-	ctx = log.AppendLoggerContextField(ctx, map[string]interface{}{
+	ctx = log.AppendContextFields(ctx, map[string]interface{}{
 		"id": 1337,
 	})
 	contextAwareLogger := logger.WithContext(ctx)

--- a/docs/docs/quickstart/api-server/create-a-money-exchange-app.mdx
+++ b/docs/docs/quickstart/api-server/create-a-money-exchange-app.mdx
@@ -144,7 +144,7 @@ You'll use this later to create a new `euroHandler`.
 Then, you implemented `euroHandler.Handle()` for handling HTTP requests:
 
 ```go title=handler.go
-func (h *euroHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, error error) {
+func (h *euroHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, err error) {
     // 1
 	currency := request.Params.ByName("currency")
 	amountString := request.Params.ByName("amount")
@@ -213,7 +213,7 @@ The logic here is very similar to the logic for `euroHandler`.
 Finally, you implemented `euroAtDateHandler.Handle()` for handling HTTP requests:
 
 ```go title=handler.go
-func (h *euroAtDateHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, error error) {
+func (h *euroAtDateHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, err error) {
     // 1
 	currency := request.Params.ByName("currency")
 	dateString := request.Params.ByName("date")

--- a/docs/docs/quickstart/api-server/src/create-a-money-exchange-app/handler.go
+++ b/docs/docs/quickstart/api-server/src/create-a-money-exchange-app/handler.go
@@ -30,7 +30,7 @@ func NewEuroHandler(ctx context.Context, config cfg.Config, logger log.Logger) (
 	}, nil
 }
 
-func (h *euroHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, error error) {
+func (h *euroHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, err error) {
 	currency := request.Params.ByName("currency")
 	amountString := request.Params.ByName("amount")
 	amount, err := strconv.ParseFloat(amountString, 64)
@@ -67,7 +67,7 @@ func NewEuroAtDateHandler(ctx context.Context, config cfg.Config, logger log.Log
 	}, nil
 }
 
-func (h *euroAtDateHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, error error) {
+func (h *euroAtDateHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, err error) {
 	currency := request.Params.ByName("currency")
 	dateString := request.Params.ByName("date")
 	date, err := time.Parse(time.RFC3339, dateString)

--- a/docs/docs/quickstart/testing/src/integration-test-api/handler.go
+++ b/docs/docs/quickstart/testing/src/integration-test-api/handler.go
@@ -32,7 +32,7 @@ func NewEuroHandler(ctx context.Context, config cfg.Config, logger log.Logger) (
 	}, nil
 }
 
-func (h *euroHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, error error) {
+func (h *euroHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, err error) {
 	currency := request.Params.ByName("currency")
 	amountString := request.Params.ByName("amount")
 	amount, err := strconv.ParseFloat(amountString, 64)
@@ -69,7 +69,7 @@ func NewEuroAtDateHandler(ctx context.Context, config cfg.Config, logger log.Log
 	}, nil
 }
 
-func (h *euroAtDateHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, error error) {
+func (h *euroAtDateHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, err error) {
 	currency := request.Params.ByName("currency")
 	dateString := request.Params.ByName("date")
 	date, err := time.Parse(time.RFC3339, dateString)

--- a/docs/docs/reference/package-log.mdx
+++ b/docs/docs/reference/package-log.mdx
@@ -75,7 +75,7 @@ logger.Error("Message")
 #### Usage
 
 ```go
-if err := logger.Option(log.WithContextFieldsResolver(log.ContextLoggerFieldsResolver)); err != nil {
+if err := logger.Option(log.WithContextFieldsResolver(log.ContextFieldsResolver)); err != nil {
 	panic(err)
 }
 ```

--- a/docs/docs/reference/src/log/usage.go
+++ b/docs/docs/reference/src/log/usage.go
@@ -13,7 +13,7 @@ func Usage() {
 	handler := log.NewHandlerIoWriter(log.LevelDebug, []string{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
 	logger := log.NewLoggerWithInterfaces(clock.NewRealClock(), []log.Handler{handler})
 
-	if err := logger.Option(log.WithContextFieldsResolver(log.ContextLoggerFieldsResolver)); err != nil {
+	if err := logger.Option(log.WithContextFieldsResolver(log.ContextFieldsResolver)); err != nil {
 		panic(err)
 	}
 
@@ -27,7 +27,7 @@ func Usage() {
 	loggerWithFields.Error("it happens: %w", fmt.Errorf("should not happen"))
 
 	ctx := context.Background()
-	ctx = log.AppendLoggerContextField(ctx, map[string]interface{}{
+	ctx = log.AppendContextFields(ctx, map[string]interface{}{
 		"id": 1337,
 	})
 

--- a/examples/apiserver/simple-handlers/handlers.go
+++ b/examples/apiserver/simple-handlers/handlers.go
@@ -11,7 +11,7 @@ import (
 
 type JsonResponseFromMapHandler struct{}
 
-func (h *JsonResponseFromMapHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, error error) {
+func (h *JsonResponseFromMapHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, err error) {
 	m := map[string]string{
 		"status": "success",
 	}
@@ -21,7 +21,7 @@ func (h *JsonResponseFromMapHandler) Handle(requestContext context.Context, requ
 
 type JsonResponseFromStructHandler struct{}
 
-func (h *JsonResponseFromStructHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, error error) {
+func (h *JsonResponseFromStructHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, err error) {
 	obj := myTestStruct{
 		Status: "success",
 	}
@@ -40,7 +40,7 @@ func (h *JsonInputHandler) GetInput() interface{} {
 	return &inputEntity{}
 }
 
-func (h *JsonInputHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, error error) {
+func (h *JsonInputHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, err error) {
 	input := request.Body.(*inputEntity)
 	output := fmt.Sprintf("Thank you for submitting your message '%s', we will handle it with care!", input.Message)
 
@@ -51,7 +51,7 @@ func (h *JsonInputHandler) Handle(requestContext context.Context, request *apise
 
 type AdminAuthenticatedHandler struct{}
 
-func (h *AdminAuthenticatedHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, error error) {
+func (h *AdminAuthenticatedHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, err error) {
 	m := map[string]bool{
 		"authenticated": true,
 	}
@@ -118,7 +118,7 @@ func (h *MyEntityHandler) List(ctx context.Context, qb *db_repo.QueryBuilder, ap
 	return res, err
 }
 
-func (h *MyEntityHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, error error) {
+func (h *MyEntityHandler) Handle(requestContext context.Context, request *apiserver.Request) (response *apiserver.Response, err error) {
 	m := map[string]bool{
 		"authenticated": true,
 	}

--- a/pkg/apiserver/handler.go
+++ b/pkg/apiserver/handler.go
@@ -119,7 +119,7 @@ func (r *Response) WithContentType(contentType string) *Response {
 
 //go:generate mockery --name HandlerWithoutInput
 type HandlerWithoutInput interface {
-	Handle(requestContext context.Context, request *Request) (response *Response, error error)
+	Handle(requestContext context.Context, request *Request) (response *Response, err error)
 }
 
 //go:generate mockery --name HandlerWithInput
@@ -137,7 +137,7 @@ type HandlerWithMultipleBindings interface {
 //go:generate mockery --name HandlerWithStream
 type HandlerWithStream interface {
 	GetInput() interface{}
-	Handle(ginContext *gin.Context, requestContext context.Context, request *Request) (error error)
+	Handle(ginContext *gin.Context, requestContext context.Context, request *Request) (err error)
 }
 
 func CreateHandler(handler HandlerWithoutInput) gin.HandlerFunc {

--- a/pkg/apiserver/middleware_logger.go
+++ b/pkg/apiserver/middleware_logger.go
@@ -31,6 +31,8 @@ func LoggingMiddleware(logger log.Logger, settings LoggingSettings) gin.HandlerF
 			}
 		}
 
+		ginCtx.Request = ginCtx.Request.WithContext(log.InitContext(ginCtx.Request.Context()))
+
 		ginCtx.Next()
 
 		req := ginCtx.Request

--- a/pkg/apiserver/mocks/HandlerWithInput.go
+++ b/pkg/apiserver/mocks/HandlerWithInput.go
@@ -111,8 +111,8 @@ func (_c *HandlerWithInput_Handle_Call) Run(run func(requestContext context.Cont
 	return _c
 }
 
-func (_c *HandlerWithInput_Handle_Call) Return(response *apiserver.Response, error error) *HandlerWithInput_Handle_Call {
-	_c.Call.Return(response, error)
+func (_c *HandlerWithInput_Handle_Call) Return(response *apiserver.Response, err error) *HandlerWithInput_Handle_Call {
+	_c.Call.Return(response, err)
 	return _c
 }
 

--- a/pkg/apiserver/mocks/HandlerWithMultipleBindings.go
+++ b/pkg/apiserver/mocks/HandlerWithMultipleBindings.go
@@ -155,8 +155,8 @@ func (_c *HandlerWithMultipleBindings_Handle_Call) Run(run func(requestContext c
 	return _c
 }
 
-func (_c *HandlerWithMultipleBindings_Handle_Call) Return(response *apiserver.Response, error error) *HandlerWithMultipleBindings_Handle_Call {
-	_c.Call.Return(response, error)
+func (_c *HandlerWithMultipleBindings_Handle_Call) Return(response *apiserver.Response, err error) *HandlerWithMultipleBindings_Handle_Call {
+	_c.Call.Return(response, err)
 	return _c
 }
 

--- a/pkg/apiserver/mocks/HandlerWithStream.go
+++ b/pkg/apiserver/mocks/HandlerWithStream.go
@@ -102,8 +102,8 @@ func (_c *HandlerWithStream_Handle_Call) Run(run func(ginContext *gin.Context, r
 	return _c
 }
 
-func (_c *HandlerWithStream_Handle_Call) Return(error error) *HandlerWithStream_Handle_Call {
-	_c.Call.Return(error)
+func (_c *HandlerWithStream_Handle_Call) Return(err error) *HandlerWithStream_Handle_Call {
+	_c.Call.Return(err)
 	return _c
 }
 

--- a/pkg/apiserver/mocks/HandlerWithoutInput.go
+++ b/pkg/apiserver/mocks/HandlerWithoutInput.go
@@ -68,8 +68,8 @@ func (_c *HandlerWithoutInput_Handle_Call) Run(run func(requestContext context.C
 	return _c
 }
 
-func (_c *HandlerWithoutInput_Handle_Call) Return(response *apiserver.Response, error error) *HandlerWithoutInput_Handle_Call {
-	_c.Call.Return(response, error)
+func (_c *HandlerWithoutInput_Handle_Call) Return(response *apiserver.Response, err error) *HandlerWithoutInput_Handle_Call {
+	_c.Call.Return(response, err)
 	return _c
 }
 

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -47,7 +47,7 @@ func Default(options ...Option) kernel.Kernel {
 		WithLoggerGroupTag,
 		WithLoggerApplicationTag,
 		WithLoggerContextFieldsMessageEncoder,
-		WithLoggerContextFieldsResolver(log.ContextLoggerFieldsResolver),
+		WithLoggerContextFieldsResolver(log.ContextFieldsResolver),
 		WithLoggerHandlersFromConfig,
 		WithLoggerMetricHandler,
 		WithLoggerSentryHandler(log.SentryContextConfigProvider, log.SentryContextEcsMetadataProvider),

--- a/pkg/application/error.go
+++ b/pkg/application/error.go
@@ -10,7 +10,7 @@ import (
 
 type ErrorHandler func(msg string, args ...interface{})
 
-func WithDefaultErrorHandler(handler ErrorHandler) {
+func withDefaultErrorHandler(handler ErrorHandler) {
 	defaultErrorHandler = handler
 }
 
@@ -25,4 +25,8 @@ var defaultErrorHandler = func(msg string, args ...interface{}) {
 
 	logger.Error(msg, args...)
 	os.Exit(1)
+}
+
+func callDefaultErrorHandler(msg string, args ...interface{}) {
+	defaultErrorHandler(msg, args...)
 }

--- a/pkg/application/options.go
+++ b/pkg/application/options.go
@@ -195,7 +195,7 @@ func WithLoggerContextFieldsMessageEncoder(app *App) {
 	})
 }
 
-func WithLoggerContextFieldsResolver(resolver ...log.ContextFieldsResolver) Option {
+func WithLoggerContextFieldsResolver(resolver ...log.ContextFieldsResolverFunction) Option {
 	return func(app *App) {
 		app.addLoggerOption(func(config cfg.GosoConf, logger log.GosoLogger) error {
 			return logger.Option(log.WithContextFieldsResolver(resolver...))

--- a/pkg/cloud/aws/kinesis/record_writer.go
+++ b/pkg/cloud/aws/kinesis/record_writer.go
@@ -112,7 +112,7 @@ func (w *recordWriter) PutRecords(ctx context.Context, records []*Record) error 
 		return nil
 	}
 
-	ctx = log.AppendLoggerContextField(ctx, log.Fields{
+	ctx = log.AppendContextFields(ctx, log.Fields{
 		"stream_name":              w.settings.StreamName,
 		"kinesis_write_request_id": w.uuidGen.NewV4(),
 	})

--- a/pkg/cloud/aws/kinesis/record_writer_test.go
+++ b/pkg/cloud/aws/kinesis/record_writer_test.go
@@ -24,7 +24,7 @@ func TestRecordWriterPutRecords(t *testing.T) {
 	mw := metricMocks.NewWriterMockedAll()
 	testClock := clock.NewFakeClock(clock.WithNonBlockingSleep)
 
-	ctx := log.AppendLoggerContextField(context.Background(), map[string]interface{}{
+	ctx := log.AppendContextFields(context.Background(), map[string]interface{}{
 		"kinesis_write_request_id": "79db3180-99a9-4157-91c3-a591b9a8f01c",
 		"stream_name":              "streamName",
 	})

--- a/pkg/lambda/lambda.go
+++ b/pkg/lambda/lambda.go
@@ -51,7 +51,7 @@ func Start(handlerFactory HandlerFactory, configOptions ...cfg.Option) {
 
 	loggerOptions := []log.Option{
 		log.WithHandlers(handlers...),
-		log.WithContextFieldsResolver(log.ContextLoggerFieldsResolver),
+		log.WithContextFieldsResolver(log.ContextFieldsResolver),
 	}
 
 	if err = logger.Option(loggerOptions...); err != nil {

--- a/pkg/log/context.go
+++ b/pkg/log/context.go
@@ -1,49 +1,242 @@
 package log
 
-import "context"
+import (
+	"context"
+	"sync"
 
-type key int
+	"github.com/justtrackio/gosoline/pkg/funk"
+)
+
+type (
+	key    int
+	fields struct {
+		lck  *sync.RWMutex
+		data map[string]any
+	}
+	contextFields struct {
+		localFields  fields
+		globalFields fields
+	}
+)
 
 const contextFieldsKey key = 0
 
-type ContextFieldsResolver func(ctx context.Context) map[string]interface{}
+type ContextFieldsResolverFunction func(ctx context.Context) map[string]any
 
-// NewLoggerContext returns a new Context carrying fields
-func NewLoggerContext(ctx context.Context, fields map[string]interface{}) context.Context {
-	return context.WithValue(ctx, contextFieldsKey, fields)
+func newContext(ctx context.Context, localFields fields, globalFields fields) context.Context {
+	return context.WithValue(ctx, contextFieldsKey, contextFields{
+		localFields:  localFields,
+		globalFields: globalFields,
+	})
 }
 
-// AppendLoggerContextField appends the fields to the existing context fields, if there are no contextFields in the context
-// then the value is initialized with the given fields.
-// If there is a duplicate key then the newest value is the one that will be used.
-func AppendLoggerContextField(ctx context.Context, fields map[string]interface{}) context.Context {
-	contextFields := ContextLoggerFieldsResolver(ctx)
-	contextFieldsLength := len(contextFields)
-
-	if contextFieldsLength == 0 {
-		return NewLoggerContext(ctx, fields)
-	}
-
-	newFields := make(map[string]interface{}, contextFieldsLength+len(fields))
-
-	for k, v := range contextFields {
-		newFields[k] = v
-	}
-
-	for k, v := range fields {
-		newFields[k] = v
-	}
-
-	return NewLoggerContext(ctx, newFields)
+// InitContext returns a new context capable of carrying (mutable) local and global logger fields.
+//
+// ---------------------------------------------------------------------------------------------------------------------
+//
+// A note about local and global context fields:
+//   - A local field is private to the current application. It will NOT be attached to stream.Messages or transferred in
+//     some other way to another service. Thus, it is somewhat cheaper to add local fields to a context as they will only
+//     not affect any downstream applications or increase message size.
+//   - A global field is the inverse of a local field. It will be forwarded with a message and thus "infect" other services.
+//     For some fields this might be desirable, for example, to record the identity of the user of an event. You should
+//     however be careful when adding many global fields as they will increase the size of any encoded message.
+//
+// When logging messages, global fields overwrite local fields if they share the same name.
+//
+// ---------------------------------------------------------------------------------------------------------------------
+//
+// A note about mutability:
+// After using any of the methods returning a new context from this file (InitContext, AppendContextFields,
+// MutateContextFields, AppendGlobalContextFields, MutateGlobalContextFields), the returned context will be mutable.
+// This means that you can add context fields using MutateContextFields or MutateGlobalContextFields to the existing
+// context (even though a new context is returned, it will be the same context if the context was already mutable). This
+// allows for the following pattern:
+//
+//	func caller(ctx context.Context, logger log.Logger, input int) {
+//		ctx = log.InitContext(ctx)
+//
+//		if result, err := callee(ctx, input); err == nil {
+//			logger.WithContext(ctx).Info("Computed result %d", result)
+//		} else {
+//			logger.WithContext(ctx).Error("Failed to compute result: %w", err)
+//		}
+//	}
+//
+//	func callee(ctx context.Context, input int) (int, error) {
+//		_ = log.MutateContextFields(ctx, map[string]any{
+//			"input_value": input,
+//		})
+//
+//		if input < 10 {
+//			return 0, fmt.Errorf("input must not be smaller than 10")
+//		}
+//
+//		return input - 10, nil
+//	}
+//
+// After the callee returns, we add the (now mutated) context to the logger and will see the original input value in the
+// logged fields even though it was for example not included in the error we got back.
+func InitContext(ctx context.Context) context.Context {
+	return appendContextFields(ctx, nil, true, true)
 }
 
-// ContextLoggerFieldsResolver extracts the ContextFields from ctx, if not present returns empty ContextFields
-func ContextLoggerFieldsResolver(ctx context.Context) map[string]interface{} {
-	contextFields, ok := ctx.Value(contextFieldsKey).(map[string]interface{})
+// AppendContextFields appends the fields to the existing local context, creating a new context containing the
+// merged fields.
+//
+// Any existing fields with the same key as any new field provided will be overwritten.
+//
+// This method breaks mutation links for the local context only. If you mutate global fields on the returned context and
+// the original context was already mutable, it will see these changes as well. Example:
+//
+//	func mutateFields() {
+//		ctx := log.InitContext(context.Background())
+//		localCtx := log.AppendContextFields(ctx, map[string]any{
+//			"field": "value",
+//		})
+//
+//		// mutations of local fields are only propagated to the local context
+//		localCtx = log.MutateContextFields(localCtx, map[string]any{
+//			"field": "new_value",
+//		})
+//		localFields := log.LocalOnlyContextFieldsResolver(localCtx)
+//		print(localFields["field"]) // "new_value"
+//		// the parent context wasn't changed
+//		localFields = log.LocalOnlyContextFieldsResolver(ctx)
+//		print(len(localFields)) // 0
+//
+//		// mutations of global fields are still propagated to the original context
+//		localCtx = log.MutateGlobalContextFields(localCtx, map[string]any{
+//			"other_field": "other_value",
+//		})
+//		globalFields := log.GlobalContextFieldsResolver(ctx)
+//		print(globalFields["other_field"]) // "other_value"
+//	}
+func AppendContextFields(ctx context.Context, newFields map[string]any) context.Context {
+	return appendContextFields(ctx, newFields, true, false)
+}
+
+// MutateContextFields is similar to AppendContextFields, but it mutates the fields from the context
+// if the context already contains fields which can be mutated. Otherwise, it initializes a new context able to carry
+// fields in the future.
+func MutateContextFields(ctx context.Context, newFields map[string]any) context.Context {
+	return appendContextFields(ctx, newFields, true, true)
+}
+
+// AppendGlobalContextFields is similar to AppendContextFields, but appends to global fields instead.
+func AppendGlobalContextFields(ctx context.Context, newFields map[string]any) context.Context {
+	return appendContextFields(ctx, newFields, false, false)
+}
+
+// MutateGlobalContextFields is similar to MutateContextFields, but mutates to global fields instead.
+func MutateGlobalContextFields(ctx context.Context, newFields map[string]any) context.Context {
+	return appendContextFields(ctx, newFields, false, true)
+}
+
+func appendContextFields(ctx context.Context, newFields map[string]any, local bool, mutate bool) context.Context {
+	value, ok := ctx.Value(contextFieldsKey).(contextFields)
+	if !ok {
+		localFields := fields{
+			lck:  &sync.RWMutex{},
+			data: make(map[string]any),
+		}
+		globalFields := fields{
+			lck:  &sync.RWMutex{},
+			data: make(map[string]any),
+		}
+
+		updateFields := &globalFields
+		if local {
+			updateFields = &localFields
+		}
+
+		// make a copy of the input data as we don't know if it will be mutated later on
+		updateFields.data = funk.MergeMaps(newFields)
+
+		return newContext(ctx, localFields, globalFields)
+	}
+
+	updateFields := value.globalFields
+	if local {
+		updateFields = value.localFields
+	}
+
+	if mutate {
+		updateFields.lck.Lock()
+		defer updateFields.lck.Unlock()
+
+		for k, v := range newFields {
+			updateFields.data[k] = v
+		}
+
+		return ctx
+	}
+
+	updateFields.lck.RLock()
+	defer updateFields.lck.RUnlock()
+
+	updatedFields := fields{
+		lck:  &sync.RWMutex{},
+		data: funk.MergeMaps(updateFields.data, newFields),
+	}
+
+	if local {
+		value.localFields = updatedFields
+	} else {
+		value.globalFields = updatedFields
+	}
+
+	return newContext(ctx, value.localFields, value.globalFields)
+}
+
+// LocalOnlyContextFieldsResolver extracts the local fields from a context and, if not present, it returns an empty map.
+//
+// Warning: Besides very specific circumstances this method is most likely not what you want. Consider using
+// GlobalContextFieldsResolver or ContextFieldsResolver instead. Outside of tests there shouldn't normally be a need to
+// ignore any configured global fields from a context.
+func LocalOnlyContextFieldsResolver(ctx context.Context) map[string]any {
+	return contextFieldsResolver(ctx, true, false)
+}
+
+// GlobalContextFieldsResolver extracts the global fields from a context and, if not present, it returns an empty map.
+func GlobalContextFieldsResolver(ctx context.Context) map[string]any {
+	return contextFieldsResolver(ctx, false, true)
+}
+
+// ContextFieldsResolver extracts the local and global fields from a context and, if not present, it returns an empty map.
+//
+// Global fields overwrite local fields of the same name.
+func ContextFieldsResolver(ctx context.Context) map[string]any {
+	return contextFieldsResolver(ctx, true, true)
+}
+
+func contextFieldsResolver(ctx context.Context, local bool, global bool) map[string]any {
+	value, ok := ctx.Value(contextFieldsKey).(contextFields)
 
 	if !ok {
-		return map[string]interface{}{}
+		return map[string]any{}
 	}
 
-	return contextFields
+	var fields []map[string]any
+
+	if local {
+		// be careful about the locking in this method. We always have to lock the local fields first before locking the
+		// global fields (if we lock both in a method). Otherwise, we have an opportunity for a deadlock.
+		value.localFields.lck.RLock()
+		defer value.localFields.lck.RUnlock()
+
+		fields = append(fields, value.localFields.data)
+	}
+
+	// need to append the global data second to ensure we honor our comment about
+	// global fields taking precedence over local fields
+	if global {
+		value.globalFields.lck.RLock()
+		defer value.globalFields.lck.RUnlock()
+
+		fields = append(fields, value.globalFields.data)
+	}
+
+	// make a copy of the data to ensure we can mutate the maps in another goroutine
+	return funk.MergeMaps(fields...)
 }

--- a/pkg/log/context_test.go
+++ b/pkg/log/context_test.go
@@ -1,0 +1,84 @@
+package log_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitIdempotent(t *testing.T) {
+	baseCtx := context.Background()
+	ctx1 := log.InitContext(baseCtx)
+	assert.NotEqual(t, baseCtx, ctx1)
+
+	ctx2 := log.InitContext(ctx1)
+	assert.Equal(t, ctx1, ctx2)
+}
+
+func TestCanMutateCorrectGlobalFields(t *testing.T) {
+	ctx := log.InitContext(context.Background())
+	localCtx := log.AppendContextFields(ctx, map[string]any{
+		"field": "value",
+	})
+
+	// mutations of local fields are only propagated to the local context
+	localCtx = log.MutateContextFields(localCtx, map[string]any{
+		"field": "new_value",
+	})
+	localFields := log.LocalOnlyContextFieldsResolver(localCtx)
+	assert.Equal(t, "new_value", localFields["field"])
+	// the parent context wasn't changed
+	localFields = log.LocalOnlyContextFieldsResolver(ctx)
+	assert.Equal(t, 0, len(localFields))
+
+	// mutations of global fields are still propagated to the original context
+	_ = log.MutateGlobalContextFields(localCtx, map[string]any{
+		"other_field": "other_value",
+	})
+	globalFields := log.GlobalContextFieldsResolver(ctx)
+	assert.Equal(t, "other_value", globalFields["other_field"])
+}
+
+func TestCanMutateCorrectLocalFields(t *testing.T) {
+	ctx := log.InitContext(context.Background())
+	globalCtx := log.AppendGlobalContextFields(ctx, map[string]any{
+		"field": "value",
+	})
+
+	// mutations of global fields are only propagated to the global context
+	globalCtx = log.MutateGlobalContextFields(globalCtx, map[string]any{
+		"field": "new_value",
+	})
+	globalFields := log.GlobalContextFieldsResolver(globalCtx)
+	assert.Equal(t, "new_value", globalFields["field"])
+	// the parent context wasn't changed
+	globalFields = log.GlobalContextFieldsResolver(ctx)
+	assert.Equal(t, 0, len(globalFields))
+
+	// mutations of local fields are still propagated to the original context
+	_ = log.MutateContextFields(globalCtx, map[string]any{
+		"other_field": "other_value",
+	})
+	localFields := log.LocalOnlyContextFieldsResolver(ctx)
+	assert.Equal(t, "other_value", localFields["other_field"])
+}
+
+func TestMergeLoggerFieldsCorrectly(t *testing.T) {
+	ctx := log.InitContext(context.Background())
+	log.MutateContextFields(ctx, map[string]any{
+		"field":       "local value",
+		"local field": "local",
+	})
+	log.MutateGlobalContextFields(ctx, map[string]any{
+		"field":        "global value",
+		"global field": "global",
+	})
+	merged := log.ContextFieldsResolver(ctx)
+	assert.Equal(t, map[string]any{
+		"field":        "global value",
+		"local field":  "local",
+		"global field": "global",
+	}, merged)
+}

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -84,7 +84,7 @@ type HandlerSettings struct {
 type gosoLogger struct {
 	clock        clock.Clock
 	data         Data
-	ctxResolvers []ContextFieldsResolver
+	ctxResolvers []ContextFieldsResolverFunction
 	handlers     []Handler
 }
 

--- a/pkg/log/logger_message_encode_handler.go
+++ b/pkg/log/logger_message_encode_handler.go
@@ -28,7 +28,7 @@ func NewMessageWithLoggingFieldsEncoderWithInterfaces(logger Logger) *MessageWit
 }
 
 func (m MessageWithLoggingFieldsEncoder) Encode(ctx context.Context, _ interface{}, attributes map[string]string) (context.Context, map[string]string, error) {
-	fields := ContextLoggerFieldsResolver(ctx)
+	fields := GlobalContextFieldsResolver(ctx)
 
 	if len(fields) == 0 {
 		return ctx, attributes, nil
@@ -69,7 +69,7 @@ func (m MessageWithLoggingFieldsEncoder) Decode(ctx context.Context, _ interface
 		return ctx, attributes, nil
 	}
 
-	ctx = AppendLoggerContextField(ctx, fields)
+	ctx = AppendGlobalContextFields(ctx, fields)
 	delete(attributes, MessageAttributeLoggerContext)
 
 	return ctx, attributes, nil

--- a/pkg/log/logger_message_encode_handler_test.go
+++ b/pkg/log/logger_message_encode_handler_test.go
@@ -40,7 +40,7 @@ func (s *LoggerMessageEncodeHandlerTestSuite) TestEncodeSuccess() {
 	s.logger.On("Warn", "omitting logger context field %s of type %T during message encoding", "fieldC", mock.Anything)
 
 	ctx := context.Background()
-	ctx = log.AppendLoggerContextField(ctx, map[string]interface{}{
+	ctx = log.AppendGlobalContextFields(ctx, map[string]interface{}{
 		"fieldA": "text",
 		"fieldB": "1",
 		"fieldC": struct{}{},
@@ -91,7 +91,7 @@ func (s *LoggerMessageEncodeHandlerTestSuite) TestDecodeSuccess() {
 	s.NoError(err)
 	s.NotContains(attributes, log.MessageAttributeLoggerContext)
 
-	fields := log.ContextLoggerFieldsResolver(ctx)
+	fields := log.GlobalContextFieldsResolver(ctx)
 	s.Contains(fields, "fieldA")
 	s.Equal("text", fields["fieldA"])
 	s.Contains(fields, "fieldB")

--- a/pkg/log/options.go
+++ b/pkg/log/options.go
@@ -2,7 +2,7 @@ package log
 
 type Option func(logger *gosoLogger) error
 
-func WithContextFieldsResolver(resolvers ...ContextFieldsResolver) Option {
+func WithContextFieldsResolver(resolvers ...ContextFieldsResolverFunction) Option {
 	return func(logger *gosoLogger) error {
 		logger.ctxResolvers = append(logger.ctxResolvers, resolvers...)
 

--- a/pkg/stream/consumer.go
+++ b/pkg/stream/consumer.go
@@ -142,6 +142,8 @@ func (c *Consumer) process(ctx context.Context, msg *Message) bool {
 	ctx, span := c.tracer.StartSpanFromContext(ctx, c.id)
 	defer span.Finish()
 
+	ctx = log.InitContext(ctx)
+
 	if ack, err = c.callback.Consume(ctx, model, attributes); err != nil {
 		c.handleError(ctx, err, "an error occurred during the consume operation")
 	}

--- a/pkg/stream/consumer_base.go
+++ b/pkg/stream/consumer_base.go
@@ -320,7 +320,7 @@ func (c *baseConsumer) recover(ctx context.Context, msg *Message) {
 		return
 	}
 
-	c.handleError(ctx, err, "a panic occured during the consume operation")
+	c.handleError(ctx, err, "a panic occurred during the consume operation")
 
 	if msg == nil {
 		return
@@ -336,7 +336,7 @@ func (c *baseConsumer) retry(ctx context.Context, msg *Message) {
 
 	retryMsg, retryId := c.buildRetryMessage(msg)
 
-	ctx = log.AppendLoggerContextField(ctx, log.Fields{
+	ctx = log.AppendGlobalContextFields(ctx, log.Fields{
 		"retry_id": retryId,
 	})
 

--- a/pkg/stream/consumer_test.go
+++ b/pkg/stream/consumer_test.go
@@ -135,16 +135,15 @@ func (s *ConsumerTestSuite) TestRun() {
 
 	consumed := make([]*string, 0)
 
-	ack := true
 	s.input.
-		On("Ack", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*stream.Message"), ack).
+		On("Ack", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*stream.Message"), true).
 		Return(nil).
 		Times(3)
 
-	s.callback.On("Consume", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*string"), map[string]string{}).
+	s.callback.On("Consume", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*string"), map[string]string{}).
 		Run(func(args mock.Arguments) {
 			consumed = append(consumed, args[1].(*string))
-		}).Return(ack, nil)
+		}).Return(true, nil)
 
 	s.callback.On("GetModel", mock.AnythingOfType("map[string]string")).
 		Return(func(_ map[string]string) interface{} {
@@ -220,7 +219,7 @@ func (s *ConsumerTestSuite) TestRun_CallbackRunPanic() {
 		Once()
 
 	s.callback.
-		On("Consume", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*string"), map[string]string{}).
+		On("Consume", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*string"), map[string]string{}).
 		Run(func(args mock.Arguments) {
 			ptr := args.Get(1).(*string)
 			consumed = append(consumed, ptr)
@@ -298,24 +297,23 @@ func (s *ConsumerTestSuite) TestRun_AggregateMessage() {
 
 	expectedAttributes1 := map[string]string{"attr1": "a"}
 
-	ack := true
 	s.input.
-		On("Ack", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*stream.Message"), ack).
+		On("Ack", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*stream.Message"), true).
 		Return(nil).
 		Once()
-	s.callback.On("Consume", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*string"), expectedAttributes1).
+	s.callback.On("Consume", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*string"), expectedAttributes1).
 		Run(func(args mock.Arguments) {
 			ptr := args.Get(1).(*string)
 			consumed = append(consumed, *ptr)
 		}).
-		Return(ack, nil)
+		Return(true, nil)
 
 	expectedModelAttributes1 := map[string]string{"attr1": "a", "encoding": "application/json"}
 	s.callback.On("GetModel", expectedModelAttributes1).
 		Return(mdl.Box(""))
 
 	expectedAttributes2 := map[string]string{"attr1": "b"}
-	s.callback.On("Consume", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*string"), expectedAttributes2).
+	s.callback.On("Consume", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*string"), expectedAttributes2).
 		Run(func(args mock.Arguments) {
 			ptr := args.Get(1).(*string)
 			consumed = append(consumed, *ptr)
@@ -371,14 +369,14 @@ func (s *ConsumerTestSuite) TestRunWithRetry() {
 		Once()
 
 	s.callback.
-		On("Consume", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*string"), map[string]string{}).
+		On("Consume", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*string"), map[string]string{}).
 		Run(func(args mock.Arguments) {
 			consumed = append(consumed, *args[1].(*string))
 		}).
 		Return(false, nil).
 		Once()
 	s.callback.
-		On("Consume", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*string"), map[string]string{}).
+		On("Consume", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*string"), map[string]string{}).
 		Run(func(args mock.Arguments) {
 			consumed = append(consumed, *args[1].(*string))
 			s.kernelCancel()


### PR DESCRIPTION
This commit introduces a distinction between local and global logger fields in a context (there used to be only global fields in the past). Global fields are forwarded to downstream services when using the stream framework while local fields are kept local to the current application. This can be useful to establish fields shared for the duration of a single request between different services without affecting downstream services.
Additionally, this commit introduces the notation of mutating these fields. If a context already contains fields, a callee can thus change fields in a context, allowing the caller to also log these fields. Support was added for the stream and apiserver frameworks already - when handling a message or a request, we are now able to log the returned error in case of a failure with the fields attached to the context by the consumer callback or api handler.

This commit is a breaking change. The following changes have been performed:

- `log.NewLoggerContext` has been removed from the public API
- `log.AppendLoggerContextField` is now called `log.AppendGlobalLoggerContextField`
- `log.ContextLoggerFieldsResolver` is now called `log.MergedContextLoggerFieldsResolver`