### PR TITLE
apiserver: enable request body logging via settings

### DIFF
--- a/pkg/apiserver/health_check.go
+++ b/pkg/apiserver/health_check.go
@@ -50,7 +50,7 @@ func NewApiHealthCheck() kernel.ModuleFactory {
 func NewApiHealthCheckWithInterfaces(logger log.Logger, router *gin.Engine, healthChecker kernel.HealthChecker, settings *ApiHealthCheckSettings) *ApiHealthCheck {
 	logger = logger.WithChannel("health-check")
 
-	router.Use(LoggingMiddleware(logger))
+	router.Use(LoggingMiddleware(logger, LoggingSettings{}))
 	router.GET(settings.Path, buildHealthCheckHandler(logger, healthChecker))
 
 	server := &http.Server{

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -36,6 +36,8 @@ type Settings struct {
 	Compression CompressionSettings `cfg:"compression"`
 	// Timeout settings.
 	Timeout TimeoutSettings `cfg:"timeout"`
+	// Logging settings
+	Logging LoggingSettings `cfg:"logging"`
 }
 
 // TimeoutSettings configures IO timeouts.
@@ -47,6 +49,11 @@ type TimeoutSettings struct {
 	Write time.Duration `cfg:"write" default:"60s" validate:"min=1000000000"`
 	// Idle timeout is the maximum amount of time to wait for the next request when keep-alives are enabled
 	Idle time.Duration `cfg:"idle" default:"60s" validate:"min=1000000000"`
+}
+
+type LoggingSettings struct {
+	RequestBody       bool `cfg:"request_body"`
+	RequestBodyBase64 bool `cfg:"request_body_base64"`
 }
 
 type ApiServer struct {
@@ -86,7 +93,7 @@ func New(definer Definer) kernel.ModuleFactory {
 
 		router := gin.New()
 		router.Use(metricMiddleware)
-		router.Use(LoggingMiddleware(logger))
+		router.Use(LoggingMiddleware(logger, settings.Logging))
 		router.Use(compressionMiddlewares...)
 		router.Use(RecoveryWithSentry(logger))
 		router.Use(location.Default())


### PR DESCRIPTION
Enables to log the request body for incoming http requests via configuration:

```yaml
api:
  port: 8080
  logging:
    request_body: true
    request_body_base64: true
``` 

If needed the body can be encoded in base64 if `request_body_base64` is set to true.