### PR TITLE
lambda: changed logger initialization to get handlers from config

### DIFF
--- a/pkg/lambda/error.go
+++ b/pkg/lambda/error.go
@@ -1,0 +1,28 @@
+package lambda
+
+import (
+	"os"
+
+	"github.com/justtrackio/gosoline/pkg/clock"
+	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/justtrackio/gosoline/pkg/metric"
+)
+
+type ErrorHandler func(msg string, args ...interface{})
+
+func WithDefaultErrorHandler(handler ErrorHandler) {
+	defaultErrorHandler = handler
+}
+
+var defaultErrorHandler = func(msg string, args ...interface{}) {
+	writerHandler := log.NewHandlerIoWriter(log.LevelInfo, []string{}, log.FormatterJson, "2006-01-02T15:04:05.999Z07:00", os.Stdout)
+	metricHandler := metric.NewLoggerHandler()
+
+	logger := log.NewLoggerWithInterfaces(clock.Provider, []log.Handler{
+		writerHandler,
+		metricHandler,
+	})
+
+	logger.Error(msg, args...)
+	os.Exit(1)
+}

--- a/pkg/lambda/lambda.go
+++ b/pkg/lambda/lambda.go
@@ -28,9 +28,7 @@ func Start(handlerFactory HandlerFactory, configOptions ...cfg.Option) {
 	mergedConfigOptions := append([]cfg.Option{
 		cfg.WithEnvKeyReplacer(cfg.DefaultEnvKeyReplacer),
 		cfg.WithSanitizers(cfg.TimeSanitizer),
-		cfg.WithErrorHandlers(func(msg string, args ...interface{}) {
-			defaultErrorHandler(msg, args...)
-		}),
+		cfg.WithErrorHandlers(defaultErrorHandler),
 	}, configOptions...)
 
 	if err = config.Option(mergedConfigOptions...); err != nil {


### PR DESCRIPTION
This change enables the option to set up the handlers of the logger via configuration.