### PR TITLE
ddb: use 1 capacity if no capacity setting was provided

### DIFF
--- a/pkg/cloud/aws/kinesis/kinesis.go
+++ b/pkg/cloud/aws/kinesis/kinesis.go
@@ -44,7 +44,7 @@ func CreateKinesisStream(ctx context.Context, config cfg.Config, logger log.Logg
 	}
 
 	if !dx.ShouldAutoCreate(config) {
-		return nil, fmt.Errorf("kinesis stream does not exist and auto create is disabled")
+		return nil, fmt.Errorf("kinesis stream %s does not exist and auto create is disabled", streamName)
 	}
 
 	logger.Info("trying to create kinesis stream: %s", streamName)

--- a/pkg/ddb/metadata_factory.go
+++ b/pkg/ddb/metadata_factory.go
@@ -198,7 +198,7 @@ func (f *MetadataFactory) getGlobalSecondaryIndices(settings []GlobalSettings) (
 		}
 
 		name := gs.Name
-		if len(name) == 0 {
+		if name == "" {
 			name = fmt.Sprintf("global-%s", *globalFields.HashKey)
 		}
 

--- a/pkg/ddb/naming.go
+++ b/pkg/ddb/naming.go
@@ -19,7 +19,7 @@ func TableName(config cfg.Config, settings *Settings) string {
 }
 
 func GetTableNamingSettings(config cfg.Config, clientName string) *TableNamingSettings {
-	if len(clientName) == 0 {
+	if clientName == "" {
 		clientName = "default"
 	}
 

--- a/pkg/ddb/settings.go
+++ b/pkg/ddb/settings.go
@@ -49,14 +49,16 @@ type SimpleSettings struct {
 }
 
 func sanitizeSettings(settings *Settings) {
-	if len(settings.ClientName) == 0 {
+	if settings.ClientName == "" {
 		settings.ClientName = "default"
 	}
 
 	settings.Main.ReadCapacityUnits = int64(math.Max(1, float64(settings.Main.ReadCapacityUnits)))
 	settings.Main.WriteCapacityUnits = int64(math.Max(1, float64(settings.Main.WriteCapacityUnits)))
 
-	for _, global := range settings.Global {
+	for i := range settings.Global {
+		// work on a reference to ensure our update is correctly propagated
+		global := &settings.Global[i]
 		global.ReadCapacityUnits = int64(math.Max(1, float64(global.ReadCapacityUnits)))
 		global.WriteCapacityUnits = int64(math.Max(1, float64(global.WriteCapacityUnits)))
 	}

--- a/pkg/tracing/tracer_aws.go
+++ b/pkg/tracing/tracer_aws.go
@@ -80,8 +80,7 @@ func NewAwsTracerWithInterfaces(logger log.Logger, appId cfg.AppId, settings *XR
 		return nil, fmt.Errorf("can not configure xray tracer: %w", err)
 	}
 
-	xrayLogger := newXrayLogger(logger)
-	xray.SetLogger(xrayLogger)
+	setGlobalXRayLogger(logger)
 
 	return &awsTracer{
 		AppId:   appId,


### PR DESCRIPTION
When creating a ddb table for an integration test, we would ensure there was at least 1 capacity set for read and write capacity. We also tried the same for GSIs, but we only updated a local variable and not the actual setting. This PR fixes the issue.

Additionally, we now report the name of a kinesis stream we failed to find, making debugging easier.