### PR TITLE
ipread: added kernel module to pull database updates from s3

### DIFF
--- a/docs/docs/reference/package-cloud_aws.mdx
+++ b/docs/docs/reference/package-cloud_aws.mdx
@@ -79,3 +79,53 @@ cloud:
                       max_interval: 10s
 ```
 These are the default values which are used if you don't provide any config by yourself.
+
+### Full reference
+```yaml
+cloud:
+  aws:
+    credentials:
+      access_key_id: "*******************"
+      secret_access_key: "****************************************"
+      session_token: "********************************************************************"
+    defaults:
+      region: "eu-central-1"
+      endpoint: ""
+    cloudwatch:
+      clients:
+        default:
+          endpoint: "http://localhost:4566"
+          region: "eu-central-1"
+          http_client:
+            timeout: 0s
+          backoff:
+            cancel_delay: 1s
+            initial_interval: 50ms
+            max_attempts: 10
+            max_elapsed_time: 15m0s
+            max_interval: 10s
+    dynamodb:
+      clients:
+        default:
+          naming:
+            pattern: "{env}-{group}-{modelId}"
+
+    kinesis:
+      clients:
+        default:
+          credentials:
+            access_key_id: "*******************"
+            secret_access_key: "****************************************"
+            session_token: "********************************************************************"
+    s3:
+      clients:
+        default:
+          usePathStyle: false
+          credentials:
+            endpoint: "https://s3.eu-central-1.amazonaws.com"
+    sqs:
+      clients:
+        default:
+          naming:
+            pattern: "{env}-{group}-{queueId}"
+```

--- a/pkg/cloud/aws/awsv2.go
+++ b/pkg/cloud/aws/awsv2.go
@@ -37,11 +37,12 @@ type ClientHttpSettings struct {
 }
 
 type ClientSettings struct {
-	Region     string             `cfg:"region" default:"eu-central-1"`
-	Endpoint   string             `cfg:"endpoint" default:"http://localhost:4566"`
-	AssumeRole string             `cfg:"assume_role"`
-	HttpClient ClientHttpSettings `cfg:"http_client"`
-	Backoff    exec.BackoffSettings
+	Region      string             `cfg:"region" default:"eu-central-1"`
+	Endpoint    string             `cfg:"endpoint" default:"http://localhost:4566"`
+	AssumeRole  string             `cfg:"assume_role"`
+	Credentials Credentials        `cfg:"credentials"`
+	HttpClient  ClientHttpSettings `cfg:"http_client"`
+	Backoff     exec.BackoffSettings
 }
 
 func (s *ClientSettings) SetBackoff(backoff exec.BackoffSettings) {
@@ -150,6 +151,7 @@ func DefaultClientConfig(ctx context.Context, config cfg.Config, logger log.Logg
 func WithEndpoint(url string) func(options *awsCfg.LoadOptions) error {
 	return func(o *awsCfg.LoadOptions) error {
 		o.EndpointResolverWithOptions = EndpointResolver(url)
+
 		return nil
 	}
 }

--- a/pkg/cloud/aws/credentials.go
+++ b/pkg/cloud/aws/credentials.go
@@ -13,11 +13,15 @@ import (
 )
 
 func GetCredentialsProvider(ctx context.Context, config cfg.Config, settings ClientSettings) (aws.CredentialsProvider, error) {
+	if settings.Credentials.AccessKeyID != "" {
+		return credentials.NewStaticCredentialsProvider(settings.Credentials.AccessKeyID, settings.Credentials.SecretAccessKey, settings.Credentials.SessionToken), nil
+	}
+
 	if len(settings.AssumeRole) > 0 {
 		return GetAssumeRoleCredentialsProvider(ctx, settings.AssumeRole)
 	}
 
-	if creds := UnmarshalCredentials(config); creds != nil {
+	if creds := UnmarshalDefaultCredentials(config); creds != nil {
 		return credentials.NewStaticCredentialsProvider(creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken), nil
 	}
 
@@ -37,7 +41,7 @@ func GetAssumeRoleCredentialsProvider(ctx context.Context, roleArn string) (aws.
 	return stscreds.NewAssumeRoleProvider(stsClient, roleArn), nil
 }
 
-func UnmarshalCredentials(config cfg.Config) *Credentials {
+func UnmarshalDefaultCredentials(config cfg.Config) *Credentials {
 	if !config.HasPrefix("cloud.aws.credentials") {
 		return nil
 	}

--- a/pkg/cloud/aws/kinesis/naming.go
+++ b/pkg/cloud/aws/kinesis/naming.go
@@ -19,13 +19,14 @@ type StreamNamingSettings struct {
 }
 
 func GetStreamName(config cfg.Config, settings StreamNameSettingsAware) (Stream, error) {
-	if len(settings.GetClientName()) == 0 {
+	if settings.GetClientName() == "" {
 		return "", fmt.Errorf("the client name shouldn't be empty")
 	}
 
 	namingKey := fmt.Sprintf("%s.naming", aws.GetClientConfigKey("kinesis", settings.GetClientName()))
+	defaultKey := fmt.Sprintf("%s.naming", aws.GetClientConfigKey("kinesis", "default"))
 	namingSettings := &StreamNamingSettings{}
-	config.UnmarshalKey(namingKey, namingSettings)
+	config.UnmarshalKey(namingKey, namingSettings, cfg.UnmarshalWithDefaultsFromKey(defaultKey, "."))
 
 	appId := settings.GetAppId()
 	name := namingSettings.Pattern

--- a/pkg/ipread/provider.go
+++ b/pkg/ipread/provider.go
@@ -1,6 +1,7 @@
 package ipread
 
 import (
+	"context"
 	"net"
 
 	"github.com/justtrackio/gosoline/pkg/cfg"
@@ -10,9 +11,11 @@ import (
 
 type Provider interface {
 	City(ipAddress net.IP) (*geoip2.City, error)
+	Refresh(ctx context.Context) error
+	Close() error
 }
 
-type ProviderFactory func(config cfg.Config, logger log.Logger, name string) (Provider, error)
+type ProviderFactory func(ctx context.Context, config cfg.Config, logger log.Logger, name string) (Provider, error)
 
 var providers = map[string]ProviderFactory{
 	"maxmind": NewMaxmindProvider,

--- a/pkg/ipread/provider_maxmind.go
+++ b/pkg/ipread/provider_maxmind.go
@@ -1,20 +1,259 @@
 package ipread
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
 	"fmt"
+	"io"
+	"net"
+	urlPkg "net/url"
+	"os"
+	"path"
+	"strings"
+	"sync"
 
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/hashicorp/go-multierror"
 	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/clock"
+	gosoS3 "github.com/justtrackio/gosoline/pkg/cloud/aws/s3"
 	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/justtrackio/gosoline/pkg/mdl"
 	"github.com/oschwald/geoip2-golang"
 )
 
-func NewMaxmindProvider(config cfg.Config, _ log.Logger, name string) (Provider, error) {
-	key := fmt.Sprintf("ipread.%s.maxmind.database", name)
-	database := config.GetString(key)
-	geoIpReader, err := geoip2.Open(database)
-	if err != nil {
-		return nil, fmt.Errorf("could not open geo db: %w", err)
+type databaseLoader func(ctx context.Context) (io.ReadCloser, error)
+
+type MaxmindSettings struct {
+	Database     string `cfg:"database"`
+	S3ClientName string `cfg:"s3_client_name"`
+}
+
+type maxmindProvider struct {
+	lck         sync.RWMutex
+	clk         clock.Clock
+	logger      log.Logger
+	reader      *geoip2.Reader
+	loader      func(ctx context.Context) (io.ReadCloser, error)
+	currentFile string
+	name        string
+	settings    *MaxmindSettings
+}
+
+func NewMaxmindProvider(ctx context.Context, config cfg.Config, logger log.Logger, name string) (Provider, error) {
+	logger = logger.WithFields(map[string]interface{}{
+		"provider_name": name,
+	})
+
+	key := fmt.Sprintf("ipread.%s", name)
+	settings := &MaxmindSettings{}
+	config.UnmarshalKey(key, settings)
+
+	var err error
+	var loader databaseLoader
+
+	if loader, err = getDatabaseLoader(ctx, config, logger, settings); err != nil {
+		return nil, fmt.Errorf("can not get database loader: %w", err)
 	}
 
-	return geoIpReader, nil
+	provider := &maxmindProvider{
+		clk:      clock.NewRealClock(),
+		logger:   logger,
+		loader:   loader,
+		name:     name,
+		settings: settings,
+	}
+
+	return provider, nil
+}
+
+func (p *maxmindProvider) City(ipAddress net.IP) (*geoip2.City, error) {
+	if p.reader == nil {
+		return nil, fmt.Errorf("maxmind geo ip reader is not initialized yet. do you have the refresh mode enabled?")
+	}
+
+	p.lck.RLock()
+	defer p.lck.RUnlock()
+
+	return p.reader.City(ipAddress)
+}
+
+func (p *maxmindProvider) Refresh(ctx context.Context) (err error) {
+	var file *os.File
+	var read io.Reader
+	var source io.ReadCloser
+	var written int64
+	var ipreader *geoip2.Reader
+
+	oldFile := p.currentFile
+	p.logger.Info("refreshing maxmind provider %s with database file %s", p.name, p.settings.Database)
+
+	if source, err = p.loader(ctx); err != nil {
+		return fmt.Errorf("can no read database bytes: %w", err)
+	}
+
+	defer func() {
+		if closeErr := source.Close(); closeErr != nil {
+			err = multierror.Append(err, fmt.Errorf("can not close source reader: %w", closeErr))
+		}
+	}()
+
+	if strings.HasSuffix(p.settings.Database, ".tar.gz") {
+		if read, err = readCompressedDatabase(source); err != nil {
+			return fmt.Errorf("can not read compressed database: %w", err)
+		}
+	} else {
+		read = source
+	}
+
+	if file, err = os.CreateTemp("", "ipread_database"); err != nil {
+		return fmt.Errorf("can not create temporary file: %w", err)
+	}
+	p.currentFile = file.Name()
+
+	clk := clock.NewRealClock()
+	start := clk.Now()
+
+	if written, err = io.Copy(file, read); err != nil {
+		return fmt.Errorf("can not write database file: %w", err)
+	}
+
+	duration := clk.Since(start)
+	p.logger.Info("reading of %s with size %d bytes took %s", p.settings.Database, written, duration)
+
+	if ipreader, err = geoip2.Open(p.currentFile); err != nil {
+		return fmt.Errorf("can not open database file %s: %w", p.currentFile, err)
+	}
+
+	p.lck.Lock()
+	p.reader = ipreader
+	p.lck.Unlock()
+
+	return p.removeDatabaseFile(oldFile)
+}
+
+func (p *maxmindProvider) Close() error {
+	return p.removeDatabaseFile(p.currentFile)
+}
+
+func (p *maxmindProvider) removeDatabaseFile(file string) error {
+	if file == "" {
+		return nil
+	}
+
+	if err := os.Remove(file); err != nil {
+		return fmt.Errorf("can not remove old database file %s: %w", file, err)
+	}
+
+	p.logger.Info("removed old database file %s", file)
+
+	return nil
+}
+
+func getDatabaseLoader(ctx context.Context, config cfg.Config, logger log.Logger, settings *MaxmindSettings) (databaseLoader, error) {
+	var err error
+	var url *urlPkg.URL
+
+	if url, err = urlPkg.Parse(settings.Database); err != nil {
+		return nil, fmt.Errorf("can not parse database url: %w", err)
+	}
+
+	switch url.Scheme {
+	case "", "file":
+		return readDatabaseLoaderLocal(settings)
+	case "s3":
+		return readDatabaseLoaderS3(ctx, config, logger, settings)
+	default:
+		return nil, fmt.Errorf("no database handler found for scheme %s", url.Scheme)
+	}
+}
+
+func readDatabaseLoaderLocal(settings *MaxmindSettings) (databaseLoader, error) {
+	return func(ctx context.Context) (io.ReadCloser, error) {
+		var err error
+		var file io.ReadCloser
+
+		if file, err = os.Open(settings.Database); err != nil {
+			return nil, fmt.Errorf("can not open local file %s: %w", settings.Database, err)
+		}
+
+		return file, err
+	}, nil
+}
+
+func readDatabaseLoaderS3(ctx context.Context, config cfg.Config, logger log.Logger, settings *MaxmindSettings) (databaseLoader, error) {
+	var err error
+	var client *s3.Client
+
+	if client, err = gosoS3.ProvideClient(ctx, config, logger, settings.S3ClientName); err != nil {
+		return nil, fmt.Errorf("can not get s3 client: %w", err)
+	}
+
+	return func(ctx context.Context) (io.ReadCloser, error) {
+		var err error
+		var url *urlPkg.URL
+		var output *s3.GetObjectOutput
+
+		if url, err = urlPkg.Parse(settings.Database); err != nil {
+			return nil, fmt.Errorf("can not parse database url: %w", err)
+		}
+
+		bucket := url.Host
+		key := strings.TrimLeft(url.Path, "/")
+
+		input := &s3.GetObjectInput{
+			Bucket: mdl.Box(bucket),
+			Key:    mdl.Box(key),
+		}
+
+		if output, err = client.GetObject(ctx, input); err != nil {
+			return nil, fmt.Errorf("can not get database from bucket %s and key %s: %w", bucket, key, err)
+		}
+
+		return output.Body, err
+	}, nil
+}
+
+func readCompressedDatabase(input io.Reader) (io.Reader, error) {
+	var err error
+	var uncompressedStream *gzip.Reader
+	var tarReader *tar.Reader
+	var header *tar.Header
+
+	if uncompressedStream, err = gzip.NewReader(input); err != nil {
+		return nil, fmt.Errorf("can not decompress input: %w", err)
+	}
+
+	tarReader = tar.NewReader(uncompressedStream)
+
+	for {
+		header, err = tarReader.Next()
+
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("extractTarGz: Next() failed: %w", err)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			continue
+		case tar.TypeReg:
+			ext := path.Ext(header.Name)
+
+			if ext != ".mmdb" {
+				continue
+			}
+
+			return tarReader, nil
+
+		default:
+			return nil, fmt.Errorf("unexpected type: %s in %s", string(header.Typeflag), header.Name)
+		}
+	}
+
+	return nil, fmt.Errorf("no maxmind database file found in the archive")
 }

--- a/pkg/ipread/provider_memory.go
+++ b/pkg/ipread/provider_memory.go
@@ -1,6 +1,7 @@
 package ipread
 
 import (
+	"context"
 	"net"
 
 	"github.com/justtrackio/gosoline/pkg/cfg"
@@ -32,7 +33,7 @@ func ProvideMemoryProvider(name string) *memoryProvider {
 	return memoryProviderContainer[name]
 }
 
-func NewMemoryProvider(_ cfg.Config, _ log.Logger, name string) (Provider, error) {
+func NewMemoryProvider(_ context.Context, _ cfg.Config, _ log.Logger, name string) (Provider, error) {
 	return ProvideMemoryProvider(name), nil
 }
 
@@ -44,6 +45,14 @@ func (p memoryProvider) City(ipAddress net.IP) (*geoip2.City, error) {
 	}
 
 	return p.records[ipString], nil
+}
+
+func (p memoryProvider) Refresh(ctx context.Context) error {
+	return nil
+}
+
+func (p memoryProvider) Close() error {
+	return nil
 }
 
 func (p memoryProvider) AddRecord(ipString string, record MemoryRecord) {

--- a/pkg/ipread/refresh_module.go
+++ b/pkg/ipread/refresh_module.go
@@ -1,0 +1,97 @@
+package ipread
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/kernel"
+	"github.com/justtrackio/gosoline/pkg/log"
+)
+
+type RefreshModule struct {
+	kernel.BackgroundModule
+	kernel.ServiceStage
+	kernel.HealthCheckedModule
+	logger   log.Logger
+	provider Provider
+	healthy  *atomic.Bool
+	settings RefreshSettings
+}
+
+func RefreshModuleFactory(ctx context.Context, config cfg.Config, logger log.Logger) (map[string]kernel.ModuleFactory, error) {
+	modules := map[string]kernel.ModuleFactory{}
+	readerSettings := readAllSettings(config)
+
+	for name, settings := range readerSettings {
+		moduleName := fmt.Sprintf("ipread-refresh-%s", name)
+		modules[moduleName] = NewProviderRefreshModule(name, settings.Refresh)
+	}
+
+	return modules, nil
+}
+
+func NewProviderRefreshModule(name string, settings RefreshSettings) kernel.ModuleFactory {
+	return func(ctx context.Context, config cfg.Config, logger log.Logger) (kernel.Module, error) {
+		logger = logger.WithChannel("ipread")
+
+		var err error
+		var read *reader
+
+		if read, err = ProvideReader(ctx, config, logger, name); err != nil {
+			return nil, fmt.Errorf("can not get reader with name %s: %w", name, err)
+		}
+
+		module := &RefreshModule{
+			logger:   logger,
+			provider: read.provider,
+			healthy:  &atomic.Bool{},
+			settings: settings,
+		}
+
+		return module, nil
+	}
+}
+
+func (m *RefreshModule) IsHealthy(ctx context.Context) (bool, error) {
+	return m.healthy.Load(), nil
+}
+
+func (m *RefreshModule) Run(ctx context.Context) (err error) {
+	defer func() {
+		m.healthy.Store(false)
+
+		if closeErr := m.provider.Close(); closeErr != nil {
+			err = multierror.Append(err, fmt.Errorf("can not close ipread provider: %w", closeErr))
+		}
+
+		m.provider = nil
+	}()
+
+	if err = m.provider.Refresh(ctx); err != nil {
+		return fmt.Errorf("can not refresh provider: %w", err)
+	}
+
+	m.healthy.Store(true)
+
+	if !m.settings.Enabled {
+		return nil
+	}
+
+	ticker := time.NewTicker(m.settings.Interval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case <-ticker.C:
+			if err = m.provider.Refresh(ctx); err != nil {
+				m.logger.Error("can not refresh provider: %w", err)
+			}
+		}
+	}
+}

--- a/pkg/ipread/settings.go
+++ b/pkg/ipread/settings.go
@@ -1,0 +1,38 @@
+package ipread
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/justtrackio/gosoline/pkg/cfg"
+)
+
+type RefreshSettings struct {
+	Enabled  bool          `cfg:"enabled" default:"false"`
+	Interval time.Duration `cfg:"interval" default:"24h"`
+}
+
+type ReaderSettings struct {
+	Provider string          `cfg:"provider" default:"maxmind"`
+	Refresh  RefreshSettings `cfg:"refresh"`
+}
+
+func readSettings(config cfg.Config, name string) *ReaderSettings {
+	key := fmt.Sprintf("ipread.%s", name)
+	settings := &ReaderSettings{}
+	config.UnmarshalKey(key, settings)
+
+	return settings
+}
+
+func readAllSettings(config cfg.Config) map[string]*ReaderSettings {
+	readerSettings := make(map[string]*ReaderSettings)
+	readerMap := config.GetStringMap("ipread", map[string]interface{}{})
+
+	for name := range readerMap {
+		settings := readSettings(config, name)
+		readerSettings[name] = settings
+	}
+
+	return readerSettings
+}

--- a/pkg/test/env/container_runner.go
+++ b/pkg/test/env/container_runner.go
@@ -189,7 +189,7 @@ func (r *containerRunner) RunContainers(skeletons []*componentSkeleton) error {
 				var container *container
 
 				if container, err = r.RunContainer(skeleton, name, description); err != nil {
-					return fmt.Errorf("can not run container %s: %w", skeleton.id(), err)
+					return fmt.Errorf("can not run container %s (%s:%s): %w", skeleton.id(), description.containerConfig.Repository, description.containerConfig.Tag, err)
 				}
 
 				lck.Lock()


### PR DESCRIPTION
This release enables pulling geoip database files from s3 and automatic refresh of those.  
To load the database file from s3 and refresh it every hour, set up the following config:  
```yaml
ipread:
  default:
    provider: maxmind
    database: s3://my-bucket-with-geoip-databases/geoip_latest.tar.gz
    refresh:
      enabled: true
      interval: 1h
```

Refreshing the database is happing in a background kernel module, so you have to add following kernel module factory:
```golang
func main() {
	application.RunHttpDefaultServer(
		api.DefineRouter,
		application.WithModuleMultiFactory(ipread.RefreshModuleFactory),
	)
}
```