### PR TITLE
httpserver: fixes httpserver jwt auth

### DIFF
--- a/pkg/httpserver/auth/jwt_auth.go
+++ b/pkg/httpserver/auth/jwt_auth.go
@@ -19,8 +19,8 @@ type jwtAuthenticator struct {
 	jwtTokenHandler JwtTokenHandler
 }
 
-func NewJwtAuthHandler(config cfg.Config) gin.HandlerFunc {
-	auth := NewJWTAuthAuthenticator(config)
+func NewJwtAuthHandler(config cfg.Config, name string) gin.HandlerFunc {
+	auth := NewJWTAuthAuthenticator(config, name)
 
 	return func(ginCtx *gin.Context) {
 		valid, err := auth.IsValid(ginCtx)
@@ -38,8 +38,8 @@ func NewJwtAuthHandler(config cfg.Config) gin.HandlerFunc {
 	}
 }
 
-func NewJWTAuthAuthenticator(config cfg.Config) Authenticator {
-	jwtTokenHandler := NewJwtTokenHandler(config)
+func NewJWTAuthAuthenticator(config cfg.Config, name string) Authenticator {
+	jwtTokenHandler := NewJwtTokenHandler(config, name)
 
 	return NewJWTAuthAuthenticatorWithInterfaces(jwtTokenHandler)
 }

--- a/pkg/httpserver/auth/jwt_token_handler.go
+++ b/pkg/httpserver/auth/jwt_token_handler.go
@@ -37,9 +37,10 @@ type JwtClaims struct {
 	jwt.StandardClaims
 }
 
-func NewJwtTokenHandler(config cfg.Config) JwtTokenHandler {
+func NewJwtTokenHandler(config cfg.Config, name string) JwtTokenHandler {
+	key := fmt.Sprintf("httpserver.%s.auth.jwt", name)
 	settings := &JwtTokenHandlerSettings{}
-	config.UnmarshalKey("api.auth.jwt", settings)
+	config.UnmarshalKey(key, settings)
 
 	return NewJwtTokenHandlerWithInterfaces(*settings)
 }


### PR DESCRIPTION
This release fixes an issue with configuring JWT auth handlers on http servers.  
The signature updates from:

```golang
func NewJWTAuthAuthenticator(config cfg.Config) Authenticator
```
to
```golang
func NewJWTAuthAuthenticator(config cfg.Config, name string) Authenticator
```

The name corresponds to the httpserver in the config. With this one can configure different JWT auth handlers for each http server.
```yaml
httpserver:
  default:
    auth:
      jwt:
        signingSecret: 4812bd82-2e5b-4c8a-8559-eee08b03fea9
        issuer: justtrack
```    
