### PR TITLE
httpserver: fixes integration testsuite

### DIFF
--- a/pkg/cfg/config_strings_test.go
+++ b/pkg/cfg/config_strings_test.go
@@ -32,7 +32,7 @@ type TestSettings struct {
 	OkayIDontKnowANameForThis map[Encoding][]map[Encoding][]Compression `cfg:"name_this"`
 }
 
-type ApiSettings struct {
+type HttpServerSettings struct {
 	Port string `cfg:"port"`
 	Mode string `cfg:"mode"`
 }
@@ -108,10 +108,10 @@ func TestConfigStringConversionTest(t *testing.T) {
 	err := config.Option(cfg.WithConfigFile("./testdata/config.strings.test.yml", "yml"))
 	assert.NoError(t, err)
 
-	settings := &ApiSettings{}
-	config.UnmarshalKey("api", settings)
+	settings := &HttpServerSettings{}
+	config.UnmarshalKey("httpserver.default", settings)
 
-	assert.Equal(t, &ApiSettings{
+	assert.Equal(t, &HttpServerSettings{
 		Port: "80",
 		Mode: "release",
 	}, settings)

--- a/pkg/cfg/testdata/config.strings.test.yml
+++ b/pkg/cfg/testdata/config.strings.test.yml
@@ -31,6 +31,7 @@ test:
       - html: []
         json: [gzip, gzip]
 
-api:
-  port: 80
-  mode: release
+httpserver:
+  default:
+    port: 80
+    mode: release

--- a/pkg/test/suite/testcase_httpserver.go
+++ b/pkg/test/suite/testcase_httpserver.go
@@ -97,8 +97,10 @@ func runTestCaseHttpserver(suite TestingSuite, testCase func(suite TestingSuite,
 		}
 
 		suiteOptions.addAppOption(application.WithConfigMap(map[string]interface{}{
-			"api": map[string]interface{}{
-				"port": 0,
+			"httpserver": map[string]interface{}{
+				"default": map[string]interface{}{
+					"port": 0,
+				},
 			},
 		}))
 
@@ -106,6 +108,7 @@ func runTestCaseHttpserver(suite TestingSuite, testCase func(suite TestingSuite,
 			port, err := server.GetPort()
 			if err != nil {
 				assert.FailNow(t, err.Error(), "can not get port of server")
+
 				return
 			}
 


### PR DESCRIPTION
Fixes an issue with httpserver based integration tests in which the http port wasn't randomized.