### PR TITLE
test: component repository and image tags are configurable now

### DIFF
--- a/docs/docs/quickstart/http-server/src/create-a-money-exchange-app/handler.go
+++ b/docs/docs/quickstart/http-server/src/create-a-money-exchange-app/handler.go
@@ -49,7 +49,6 @@ func (h *euroHandler) Handle(requestContext context.Context, request *httpserver
 
 	// Parse a float value from amountString.
 	amount, err := strconv.ParseFloat(amountString, 64)
-
 	// Send a 400 Bad Request response if amountString can't be parsed into a valid float.
 	if err != nil {
 		h.logger.Error("cannot parse amount %s: %w", amountString, err)
@@ -57,9 +56,8 @@ func (h *euroHandler) Handle(requestContext context.Context, request *httpserver
 		return httpserver.NewStatusResponse(http.StatusBadRequest), nil
 	}
 
-	// Convert the amount from the the source currency to euros.
+	// Convert the amount from the source currency to euros.
 	result, err := h.currencyService.ToEur(requestContext, amount, currency)
-
 	// Send a 500 Internal Server Error if the server can't convert the amount.
 	if err != nil {
 		h.logger.Error("cannot convert amount %f with currency %s: %w", amount, currency, err)
@@ -99,7 +97,6 @@ func (h *euroAtDateHandler) Handle(requestContext context.Context, request *http
 	currency := request.Params.ByName("currency")
 	dateString := request.Params.ByName("date")
 	date, err := time.Parse(time.RFC3339, dateString)
-
 	// Send a 500 Internal Server Error if the service can't parse the params or convert the currency.
 	if err != nil {
 		h.logger.Error("cannot parse date %s: %w", dateString, err)

--- a/docs/docs/reference/package-test.mdx
+++ b/docs/docs/reference/package-test.mdx
@@ -38,3 +38,31 @@ This is the starting point for a gosoline integration test. This performs the fo
 2. Applies each of the `extraOptions`.
 3. Creates a kernel with whatever modules or APIs were declared in the `SetupSuite` and `SetupApiDefinitions`.
 4. Runs the tests.
+
+## Configuration
+Test components are docker container like wiremock or localstack which support you in your integration tests to mock
+your applications infrastructure.
+
+#### image configuration
+The used image for a component can be configured on a global and on a per component level. The following configuration
+snipped shows a config for two wiremock components. **mockA** gets the image configuration from the global level which is
+configured via the key `test.defaults.images.wiremock` and **mockB** has local configuration. With this, **mockA** gets
+tag `3.4.0` and **mockB** gets `3.3.0`.
+
+```yaml
+test:
+  defaults:
+    images:
+      wiremock:
+        repository: wiremock/wiremock
+        tag: 3.4.0
+  components:
+    wiremock:
+      mockA:
+        expire_after: 5m
+      mockB:
+        image:
+          repository: wiremock/wiremock
+          tag: 3.3.0
+        expire_after: 5m
+```

--- a/pkg/stream/retry_noop.go
+++ b/pkg/stream/retry_noop.go
@@ -11,8 +11,7 @@ func init() {
 	retryHandlers["noop"] = NewRetryHandlerNoop
 }
 
-type RetryHandlerNoop struct {
-}
+type RetryHandlerNoop struct{}
 
 func NewRetryHandlerNoop(context.Context, cfg.Config, log.Logger, string) (Input, RetryHandler, error) {
 	return NewNoopInput(), NewRetryHandlerNoopWithInterfaces(), nil

--- a/pkg/stream/testdata/encoding_test.pb.go
+++ b/pkg/stream/testdata/encoding_test.pb.go
@@ -7,10 +7,11 @@
 package testdata
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -99,10 +100,13 @@ func file_encoding_test_proto_rawDescGZIP() []byte {
 	return file_encoding_test_proto_rawDescData
 }
 
-var file_encoding_test_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_encoding_test_proto_goTypes = []interface{}{
-	(*TestEncodingMessage)(nil), // 0: TestEncodingMessage
-}
+var (
+	file_encoding_test_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+	file_encoding_test_proto_goTypes  = []interface{}{
+		(*TestEncodingMessage)(nil), // 0: TestEncodingMessage
+	}
+)
+
 var file_encoding_test_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/pkg/stream/testdata/message_builder_test.pb.go
+++ b/pkg/stream/testdata/message_builder_test.pb.go
@@ -7,10 +7,11 @@
 package testdata
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -101,10 +102,13 @@ func file_message_builder_test_proto_rawDescGZIP() []byte {
 	return file_message_builder_test_proto_rawDescData
 }
 
-var file_message_builder_test_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_message_builder_test_proto_goTypes = []interface{}{
-	(*TestMessage)(nil), // 0: TestMessage
-}
+var (
+	file_message_builder_test_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+	file_message_builder_test_proto_goTypes  = []interface{}{
+		(*TestMessage)(nil), // 0: TestMessage
+	}
+)
+
 var file_message_builder_test_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/pkg/test/env/components.go
+++ b/pkg/test/env/components.go
@@ -60,14 +60,20 @@ func (c *ComponentBaseSettings) SetType(typ string) {
 	c.Type = typ
 }
 
+type ContainerImageSettings struct {
+	Repository string `cfg:"repository"`
+	Tag        string `cfg:"tag"`
+}
+
 type ContainerBindingSettings struct {
 	Host string `cfg:"host" default:"127.0.0.1"`
 	Port int    `cfg:"port" default:"0"`
 }
 
 type ComponentContainerSettings struct {
-	ExpireAfter time.Duration   `cfg:"expire_after" default:"60s"`
-	Tmpfs       []TmpfsSettings `cfg:"tmpfs"`
+	Image       ContainerImageSettings `cfg:"image"`
+	ExpireAfter time.Duration          `cfg:"expire_after" default:"60s"`
+	Tmpfs       []TmpfsSettings        `cfg:"tmpfs"`
 }
 
 type TmpfsSettings struct {

--- a/pkg/test/env/components_config_manager.go
+++ b/pkg/test/env/components_config_manager.go
@@ -45,16 +45,7 @@ func (m *ComponentsConfigManager) GetAllSettings() ([]ComponentBaseSettingsAware
 
 		for name := range components {
 			settings := factory.GetSettingsSchema()
-
-			key := fmt.Sprintf("test.components.%s.%s", typ, name)
-
-			defaults := []cfg.UnmarshalDefaults{
-				cfg.UnmarshalWithDefaultForKey("type", typ),
-				cfg.UnmarshalWithDefaultForKey("name", name),
-			}
-
-			m.config.UnmarshalKey(key, settings, defaults...)
-
+			UnmarshalSettings(m.config, settings, typ, name)
 			allSettings = append(allSettings, settings)
 		}
 	}
@@ -132,4 +123,17 @@ func (m *ComponentsConfigManager) Add(settings interface{}) error {
 	}
 
 	return nil
+}
+
+func UnmarshalSettings(config cfg.Config, settings interface{}, typ string, name string) {
+	key := fmt.Sprintf("test.components.%s.%s", typ, name)
+	defaultKey := fmt.Sprintf("test.defaults.images.%s", typ)
+
+	defaults := []cfg.UnmarshalDefaults{
+		cfg.UnmarshalWithDefaultForKey("type", typ),
+		cfg.UnmarshalWithDefaultForKey("name", name),
+		cfg.UnmarshalWithDefaultsFromKey(defaultKey, "image"),
+	}
+
+	config.UnmarshalKey(key, settings, defaults...)
 }

--- a/pkg/test/env/config.default.yml
+++ b/pkg/test/env/config.default.yml
@@ -1,0 +1,21 @@
+test:
+  defaults:
+    images:
+      ddb:
+        repository: "amazon/dynamodb-local"
+        tag: "2.2.1"
+      localstack:
+        repository: "localstack/localstack"
+        tag: "3.1"
+      mysql:
+        repository: "mysql/mysql-server"
+        tag: "8.0"
+      redis:
+        repository: "redis"
+        tag: "7-alpine"
+      s3:
+        repository: "minio/minio"
+        tag: "RELEASE.2024-02-17T01-15-57Z"
+      wiremock:
+        repository: "wiremock/wiremock"
+        tag: "3.4.1"

--- a/pkg/test/env/container_runner.go
+++ b/pkg/test/env/container_runner.go
@@ -262,7 +262,7 @@ func (r *containerRunner) createExternalContainer(containerName, skeletonTyp str
 }
 
 func (r *containerRunner) runNewContainer(containerName string, skeleton *componentSkeleton, name string, config *containerConfig) (*container, error) {
-	r.logger.Debug("run container %s %s", skeleton.typ, containerName)
+	r.logger.Debug("run container %s %s:%s %s", skeleton.typ, config.Repository, config.Tag, containerName)
 
 	bindings := make(map[docker.Port][]docker.PortBinding)
 

--- a/pkg/test/env/factory_ddb.go
+++ b/pkg/test/env/factory_ddb.go
@@ -39,8 +39,7 @@ func (f *ddbFactory) Detect(config cfg.Config, manager *ComponentsConfigManager)
 	}
 
 	settings := &ddbSettings{}
-	config.UnmarshalDefaults(settings)
-
+	UnmarshalSettings(config, settings, componentDdb, "default")
 	settings.Type = componentDdb
 
 	if err := manager.Add(settings); err != nil {
@@ -75,8 +74,8 @@ func (f *ddbFactory) configureContainer(settings interface{}) *containerConfig {
 	s := settings.(*ddbSettings)
 
 	return &containerConfig{
-		Repository: "amazon/dynamodb-local",
-		Tag:        "1.21.0",
+		Repository: s.Image.Repository,
+		Tag:        s.Image.Tag,
 		PortBindings: portBindings{
 			"8000/tcp": s.Port,
 		},

--- a/pkg/test/env/factory_mysql.go
+++ b/pkg/test/env/factory_mysql.go
@@ -31,7 +31,6 @@ type mysqlSettings struct {
 	ComponentContainerSettings
 	ContainerBindingSettings
 	UseExternalContainer bool             `cfg:"use_external_container" default:"false"`
-	Version              string           `cfg:"version" default:"8.0"`
 	Credentials          mysqlCredentials `cfg:"credentials"`
 }
 
@@ -60,7 +59,7 @@ func (f mysqlFactory) Detect(config cfg.Config, manager *ComponentsConfigManager
 		}
 
 		settings := &mysqlSettings{}
-		config.UnmarshalDefaults(settings)
+		UnmarshalSettings(config, settings, componentMySql, "default")
 
 		settings.Type = componentMySql
 		settings.Name = name
@@ -125,9 +124,9 @@ func (f mysqlFactory) configureContainer(settings interface{}) *containerConfig 
 	}
 
 	return &containerConfig{
-		Repository: "mysql/mysql-server",
+		Repository: s.Image.Repository,
+		Tag:        s.Image.Tag,
 		Tmpfs:      s.Tmpfs,
-		Tag:        s.Version,
 		Env:        env,
 		Cmd:        []string{"--sql_mode=NO_ENGINE_SUBSTITUTION", "--log-bin-trust-function-creators=TRUE"},
 		PortBindings: portBindings{

--- a/pkg/test/env/factory_redis.go
+++ b/pkg/test/env/factory_redis.go
@@ -37,8 +37,7 @@ func (f *redisFactory) Detect(config cfg.Config, manager *ComponentsConfigManage
 	}
 
 	settings := &redisSettings{}
-	config.UnmarshalDefaults(settings)
-
+	UnmarshalSettings(config, settings, componentRedis, "default")
 	settings.Type = componentRedis
 
 	if err := manager.Add(settings); err != nil {
@@ -65,8 +64,8 @@ func (f *redisFactory) configureContainer(settings interface{}) *containerConfig
 	s := settings.(*redisSettings)
 
 	return &containerConfig{
-		Repository: "redis",
-		Tag:        "7-alpine",
+		Repository: s.Image.Repository,
+		Tag:        s.Image.Tag,
 		PortBindings: portBindings{
 			"6379/tcp": s.Port,
 		},

--- a/pkg/test/env/factory_s3.go
+++ b/pkg/test/env/factory_s3.go
@@ -38,8 +38,7 @@ func (f *s3Factory) Detect(config cfg.Config, manager *ComponentsConfigManager) 
 	}
 
 	settings := &s3Settings{}
-	config.UnmarshalDefaults(settings)
-
+	UnmarshalSettings(config, settings, componentS3, "default")
 	settings.Type = componentS3
 
 	if err := manager.Add(settings); err != nil {
@@ -68,8 +67,8 @@ func (f *s3Factory) configureContainer(settings interface{}) *containerConfig {
 	s := settings.(*s3Settings)
 
 	return &containerConfig{
-		Repository: "minio/minio",
-		Tag:        "RELEASE.2023-03-09T23-16-13Z",
+		Repository: s.Image.Repository,
+		Tag:        s.Image.Tag,
 		Cmd: []string{
 			"server",
 			"/data",

--- a/pkg/test/env/factory_wiremock.go
+++ b/pkg/test/env/factory_wiremock.go
@@ -47,8 +47,8 @@ func (f *wiremockFactory) configureContainer(settings interface{}) *containerCon
 	s := settings.(*wiremockSettings)
 
 	return &containerConfig{
-		Repository: "wiremock/wiremock",
-		Tag:        "3.3.1-alpine",
+		Repository: s.Image.Repository,
+		Tag:        s.Image.Tag,
 		PortBindings: portBindings{
 			"8080/tcp": s.Port,
 		},

--- a/test/cloud/aws/dynamodb/client_test.go
+++ b/test/cloud/aws/dynamodb/client_test.go
@@ -26,6 +26,7 @@ type ClientTestSuite struct {
 
 func (s *ClientTestSuite) SetupSuite() []suite.Option {
 	return []suite.Option{
+		suite.WithLogLevel("debug"),
 		suite.WithSharedEnvironment(),
 		suite.WithConfigFile("client_test_cfg.yml"),
 		suite.WithClockProvider(clock.NewRealClock()),

--- a/test/stream/retry_handler_sqs/testdata/data_model.pb.go
+++ b/test/stream/retry_handler_sqs/testdata/data_model.pb.go
@@ -7,10 +7,11 @@
 package testdata
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -90,10 +91,13 @@ func file_data_model_proto_rawDescGZIP() []byte {
 	return file_data_model_proto_rawDescData
 }
 
-var file_data_model_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_data_model_proto_goTypes = []interface{}{
-	(*DataModel)(nil), // 0: DataModel
-}
+var (
+	file_data_model_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+	file_data_model_proto_goTypes  = []interface{}{
+		(*DataModel)(nil), // 0: DataModel
+	}
+)
+
 var file_data_model_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type


### PR DESCRIPTION
## Configuration
Test components are docker container like wiremock or localstack which support you in your integration tests to mock
your applications infrastructure.

#### image configuration
The used image for a component can be configured on a global and on a per component level. The following configuration
snipped shows a config for two wiremock components. **mockA** gets the image configuration from the global level which is
configured via the key `test.defaults.images.wiremock` and **mockB** has local configuration. With this, **mockA** gets
tag `3.4.0` and **mockB** gets `3.3.0`.

```yaml
test:
  defaults:
    images:
      wiremock:
        repository: wiremock/wiremock
        tag: 3.4.0
  components:
    wiremock:
      mockA:
        expire_after: 5m
      mockB:
        image:
          repository: wiremock/wiremock
          tag: 3.3.0
        expire_after: 5m
```