### PR TITLE
fixtures: fix misleading message about 'fixtureSets' build tag, which…

### DIFF
--- a/pkg/fixtures/loader_noop.go
+++ b/pkg/fixtures/loader_noop.go
@@ -21,6 +21,6 @@ func NewFixtureLoader(ctx context.Context, config cfg.Config, logger log.Logger)
 }
 
 func (n *noopFixtureLoader) Load(ctx context.Context, fixtureSets []*FixtureSet) error {
-	n.logger.Info("fixtureSets loading disabled, to enable it use the 'fixtureSets' build tag")
+	n.logger.Info("fixtureSets loading disabled, to enable it use the 'fixtures' build tag")
 	return nil
 }


### PR DESCRIPTION
… should be 'fixtures' build tag