### PR TITLE
http: allow configuring the HTTP transport for a client

### DIFF
--- a/pkg/cloud/aws/kinesis/metadata_repository.go
+++ b/pkg/cloud/aws/kinesis/metadata_repository.go
@@ -177,7 +177,7 @@ func (m *metadataRepository) RegisterClient(ctx context.Context) (clientIndex in
 		return 0, 0, fmt.Errorf("failed to register client: %w", err)
 	}
 
-	qb := m.repo.QueryBuilder().WithHash(namespace)
+	qb := m.repo.QueryBuilder().WithHash(namespace).WithConsistentRead(true)
 	clients := make([]ClientRecord, 0)
 	if _, err = m.repo.Query(ctx, qb, &clients); err != nil {
 		return 0, 0, fmt.Errorf("failed to list clients: %w", err)

--- a/pkg/cloud/aws/kinesis/metadata_repository_test.go
+++ b/pkg/cloud/aws/kinesis/metadata_repository_test.go
@@ -119,6 +119,7 @@ func (s *metadataRepositoryTestSuite) mockRegisterClientPutItem(err error) {
 func (s *metadataRepositoryTestSuite) mockRegisterClientQuery(resultCount int, err error) {
 	qb := ddbMocks.NewQueryBuilder(s.T())
 	qb.EXPECT().WithHash(s.clientNamespace).Return(qb).Once()
+	qb.EXPECT().WithConsistentRead(true).Return(qb).Once()
 
 	s.repo.EXPECT().QueryBuilder().Return(qb).Once()
 	s.repo.EXPECT().Query(s.ctx, qb, &[]kinesis.ClientRecord{}).Run(func(ctx context.Context, qb ddb.QueryBuilder, result interface{}) {

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	netUrl "net/url"
+	"runtime"
 	"time"
 
 	httpHeaders "github.com/go-http-utils/headers"
@@ -79,6 +81,130 @@ type Settings struct {
 	RetryResetReaders      bool                   `cfg:"retry_reset_readers" default:"true"`
 	RetryWaitTime          time.Duration          `cfg:"retry_wait_time" default:"100ms"`
 	CircuitBreakerSettings CircuitBreakerSettings `cfg:"circuit_breaker"`
+	TransportSettings      TransportSettings      `cfg:"transport"`
+}
+
+type TransportSettings struct {
+	// TLSHandshakeTimeout specifies the maximum amount of time to
+	// wait for a TLS handshake. Zero means no timeout.
+	TLSHandshakeTimeout time.Duration `cfg:"tls_handshake_timeout" default:"10s"`
+
+	// DisableKeepAlives, if true, disables HTTP keep-alives and
+	// will only use the connection to the server for a single
+	// HTTP request.
+	//
+	// This is unrelated to the similarly named TCP keep-alives.
+	DisableKeepAlives bool `cfg:"disable_keep_alives" default:"false"`
+
+	// DisableCompression, if true, prevents the Transport from
+	// requesting compression with an "Accept-Encoding: gzip"
+	// request header when the Request contains no existing
+	// Accept-Encoding value. If the Transport requests gzip on
+	// its own and gets a gzipped response, it's transparently
+	// decoded in the Response.Body. However, if the user
+	// explicitly requested gzip it is not automatically
+	// uncompressed.
+	DisableCompression bool `cfg:"disable_compression" default:"false"`
+
+	// MaxIdleConns controls the maximum number of idle (keep-alive)
+	// connections across all hosts. Zero means no limit.
+	MaxIdleConns int `cfg:"max_idle_conns" default:"100"`
+
+	// MaxIdleConnsPerHost, if non-zero, controls the maximum idle
+	// (keep-alive) connections to keep per-host. If zero,
+	// GOMAXPROCS+1 is used.
+	MaxIdleConnsPerHost int `cfg:"max_idle_conns_per_host" default:"0"`
+
+	// MaxConnsPerHost optionally limits the total number of
+	// connections per host, including connections in the dialing,
+	// active, and idle states. On limit violation, dials will block.
+	//
+	// Zero means no limit.
+	MaxConnsPerHost int `cfg:"max_conns_per_host" default:"0"`
+
+	// IdleConnTimeout is the maximum amount of time an idle
+	// (keep-alive) connection will remain idle before closing
+	// itself.
+	// Zero means no limit.
+	IdleConnTimeout time.Duration `cfg:"idle_conn_timeout" default:"90s"`
+
+	// ResponseHeaderTimeout, if non-zero, specifies the amount of
+	// time to wait for a server's response headers after fully
+	// writing the request (including its body, if any). This
+	// time does not include the time to read the response body.
+	ResponseHeaderTimeout time.Duration `cfg:"response_header_timeout" default:"0s"`
+
+	// ExpectContinueTimeout, if non-zero, specifies the amount of
+	// time to wait for a server's first response headers after fully
+	// writing the request headers if the request has an
+	// "Expect: 100-continue" header. Zero means no timeout and
+	// causes the body to be sent immediately, without
+	// waiting for the server to approve.
+	// This time does not include the time to send the request header.
+	ExpectContinueTimeout time.Duration `cfg:"expect_continue_timeout" default:"1s"`
+
+	// MaxResponseHeaderBytes specifies a limit on how many
+	// response bytes are allowed in the server's response
+	// header.
+	//
+	// Zero means to use a default limit.
+	MaxResponseHeaderBytes int64 `cfg:"max_response_header_bytes" default:"0"`
+
+	// WriteBufferSize specifies the size of the write buffer used
+	// when writing to the transport.
+	// If zero, a default (currently 4KB) is used.
+	WriteBufferSize int `cfg:"write_buffer_size" default:"0"`
+
+	// ReadBufferSize specifies the size of the read buffer used
+	// when reading from the transport.
+	// If zero, a default (currently 4KB) is used.
+	ReadBufferSize int `cfg:"read_buffer_size" default:"0"`
+
+	DialerSettings DialerSettings `cfg:"dialer"`
+}
+
+type DialerSettings struct {
+	// KeepAlive specifies the interval between keep-alive
+	// probes for an active network connection.
+	// If zero, keep-alive probes are sent with a default value
+	// (currently 15 seconds), if supported by the protocol and operating
+	// system. Network protocols or operating systems that do
+	// not support keep-alives ignore this field.
+	// If negative, keep-alive probes are disabled.
+	KeepAlive time.Duration `cfg:"keep_alive" default:"30s"`
+
+	// Timeout is the maximum amount of time a dial will wait for
+	// a connect to complete. If Deadline is also set, it may fail
+	// earlier.
+	//
+	// The default is no timeout.
+	//
+	// When using TCP and dialing a host name with multiple IP
+	// addresses, the timeout may be divided between them.
+	//
+	// With or without a timeout, the operating system may impose
+	// its own earlier timeout. For instance, TCP timeouts are
+	// often around 3 minutes.
+	Timeout time.Duration `cfg:"timeout" default:"30s"`
+
+	// DualStack previously enabled RFC 6555 Fast Fallback
+	// support, also known as "Happy Eyeballs", in which IPv4 is
+	// tried soon if IPv6 appears to be misconfigured and
+	// hanging.
+	//
+	// Deprecated: Fast Fallback is enabled by default. To
+	// disable, set FallbackDelay to a negative value.
+	DualStack bool `cfg:"dual_stack" default:"true"`
+
+	// FallbackDelay specifies the length of time to wait before
+	// spawning a RFC 6555 Fast Fallback connection. That is, this
+	// is the amount of time to wait for IPv6 to succeed before
+	// assuming that IPv6 is misconfigured and falling back to
+	// IPv4.
+	//
+	// If zero, a default delay of 300ms is used.
+	// A negative value disables Fast Fallback support.
+	FallbackDelay time.Duration `cfg:"fallback_delay" default:"0s"`
 }
 
 func ProvideHttpClient(ctx context.Context, config cfg.Config, logger log.Logger, name string) (Client, error) {
@@ -92,12 +218,51 @@ func ProvideHttpClient(ctx context.Context, config cfg.Config, logger log.Logger
 func newHttpClient(config cfg.Config, logger log.Logger, name string) Client {
 	metricWriter := metric.NewWriter()
 	settings := UnmarshalClientSettings(config, name)
+	restyClient := newRestyClient(settings)
+	client := NewHttpClientWithInterfaces(logger, clock.Provider, metricWriter, restyClient)
 
+	if settings.CircuitBreakerSettings.Enabled {
+		client = NewCircuitBreakerClientWithInterfaces(client, logger, clock.Provider, name, settings.CircuitBreakerSettings)
+	}
+
+	return client
+}
+
+func newRestyClient(settings Settings) *resty.Client {
 	var httpClient *resty.Client
 	if settings.DisableCookies {
 		httpClient = resty.NewWithClient(&http.Client{})
 	} else {
 		httpClient = resty.New()
+	}
+
+	dialer := &net.Dialer{
+		Timeout:       settings.TransportSettings.DialerSettings.Timeout,
+		KeepAlive:     settings.TransportSettings.DialerSettings.KeepAlive,
+		DualStack:     settings.TransportSettings.DialerSettings.DualStack,
+		FallbackDelay: settings.TransportSettings.DialerSettings.FallbackDelay,
+	}
+
+	if settings.TransportSettings.MaxIdleConnsPerHost == 0 {
+		settings.TransportSettings.MaxIdleConnsPerHost = runtime.GOMAXPROCS(0) + 1
+	}
+
+	transport := &http.Transport{
+		Proxy:                  http.ProxyFromEnvironment,
+		DialContext:            dialer.DialContext,
+		ForceAttemptHTTP2:      true,
+		TLSHandshakeTimeout:    settings.TransportSettings.TLSHandshakeTimeout,
+		DisableKeepAlives:      settings.TransportSettings.DisableKeepAlives,
+		DisableCompression:     settings.TransportSettings.DisableCompression,
+		MaxIdleConns:           settings.TransportSettings.MaxIdleConns,
+		MaxIdleConnsPerHost:    settings.TransportSettings.MaxIdleConnsPerHost,
+		MaxConnsPerHost:        settings.TransportSettings.MaxConnsPerHost,
+		IdleConnTimeout:        settings.TransportSettings.IdleConnTimeout,
+		ResponseHeaderTimeout:  settings.TransportSettings.ResponseHeaderTimeout,
+		ExpectContinueTimeout:  settings.TransportSettings.ExpectContinueTimeout,
+		MaxResponseHeaderBytes: settings.TransportSettings.MaxResponseHeaderBytes,
+		WriteBufferSize:        settings.TransportSettings.WriteBufferSize,
+		ReadBufferSize:         settings.TransportSettings.ReadBufferSize,
 	}
 
 	if settings.FollowRedirects {
@@ -112,14 +277,9 @@ func newHttpClient(config cfg.Config, logger log.Logger, name string) Client {
 	httpClient.SetRetryWaitTime(settings.RetryWaitTime)
 	httpClient.SetRetryMaxWaitTime(settings.RetryMaxWaitTime)
 	httpClient.SetRetryResetReaders(settings.RetryResetReaders)
+	httpClient.SetTransport(transport)
 
-	client := NewHttpClientWithInterfaces(logger, clock.Provider, metricWriter, httpClient)
-
-	if settings.CircuitBreakerSettings.Enabled {
-		client = NewCircuitBreakerClientWithInterfaces(client, logger, clock.Provider, name, settings.CircuitBreakerSettings)
-	}
-
-	return client
+	return httpClient
 }
 
 func NewHttpClientWithInterfaces(logger log.Logger, clock clock.Clock, metricWriter metric.Writer, httpClient restyClient) Client {

--- a/pkg/mdlsub/publisher.go
+++ b/pkg/mdlsub/publisher.go
@@ -40,13 +40,13 @@ type publisher struct {
 	settings *PublisherSettings
 }
 
-func NewPublisher(ctx context.Context, config cfg.Config, logger log.Logger, name string) (*publisher, error) {
+func NewPublisher(ctx context.Context, config cfg.Config, logger log.Logger, name string) (Publisher, error) {
 	settings := readPublisherSetting(config, name)
 
 	return NewPublisherWithSettings(ctx, config, logger, settings)
 }
 
-func NewPublisherWithSettings(ctx context.Context, config cfg.Config, logger log.Logger, settings *PublisherSettings) (*publisher, error) {
+func NewPublisherWithSettings(ctx context.Context, config cfg.Config, logger log.Logger, settings *PublisherSettings) (Publisher, error) {
 	var err error
 	var producer stream.Producer
 
@@ -57,7 +57,7 @@ func NewPublisherWithSettings(ctx context.Context, config cfg.Config, logger log
 	return NewPublisherWithInterfaces(logger, producer, settings), nil
 }
 
-func NewPublisherWithInterfaces(logger log.Logger, producer stream.Producer, settings *PublisherSettings) *publisher {
+func NewPublisherWithInterfaces(logger log.Logger, producer stream.Producer, settings *PublisherSettings) Publisher {
 	return &publisher{
 		logger:   logger,
 		producer: producer,


### PR DESCRIPTION
This adds a whole bunch of settings relating to the http transport. You can configure them like this:
    
```yml
http_client:
    default:
        transport:
            tls_handshake_timeout: 10s
            disable_keep_alives: false
            disable_compression: false
            max_idle_conns: 100
            max_idle_conns_per_host: 0
            max_conns_per_host: 0
            idle_conn_timeout: 90s
            response_header_timeout: 0s
            expect_continue_timeout: 1s
            max_response_header_bytes: 0
            write_buffer_size: 0
            read_buffer_size: 0
            dialer:
                keep_alive: 30s
                timeout: 30s
                dual_stack: true
                fallback_delay: 0s

```