### PR TITLE
cloud/aws: Use the default credential constants as the last option for aws credential provider

### DIFF
--- a/pkg/cloud/aws/credentials.go
+++ b/pkg/cloud/aws/credentials.go
@@ -25,7 +25,7 @@ func GetCredentialsProvider(ctx context.Context, config cfg.Config, settings Cli
 		return credentials.NewStaticCredentialsProvider(creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken), nil
 	}
 
-	return nil, nil
+	return GetDefaultProvider(), nil
 }
 
 func GetAssumeRoleCredentialsProvider(ctx context.Context, roleArn string) (aws.CredentialsProvider, error) {

--- a/pkg/cloud/aws/credentials_default.go
+++ b/pkg/cloud/aws/credentials_default.go
@@ -4,6 +4,7 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 )
 
@@ -18,5 +19,9 @@ const (
 // tests, you get this implementation that tells the AWS SDK to use the default credentials (as if you didn't specify
 // any credentials at all).
 func GetDefaultCredentials() *credentials.Credentials {
+	return nil
+}
+
+func GetDefaultProvider() aws.CredentialsProvider {
 	return nil
 }

--- a/pkg/cloud/aws/credentials_default_test.go
+++ b/pkg/cloud/aws/credentials_default_test.go
@@ -1,0 +1,17 @@
+//go:build !integration
+// +build !integration
+
+package aws_test
+
+import (
+	gosoAws "github.com/justtrackio/gosoline/pkg/cloud/aws"
+)
+
+func (s *CredentialsTestSuite) TestNoConfiguredProvider() {
+	s.config.On("HasPrefix", "cloud.aws.credentials").Return(false)
+
+	provider, err := gosoAws.GetCredentialsProvider(s.ctx, s.config, gosoAws.ClientSettings{})
+
+	s.NoError(err)
+	s.Nil(provider, "there should be no provider returned")
+}

--- a/pkg/cloud/aws/credentials_integrationtest.go
+++ b/pkg/cloud/aws/credentials_integrationtest.go
@@ -4,6 +4,8 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	credentialsv2 "github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 )
 
@@ -24,4 +26,8 @@ func GetDefaultCredentials() *credentials.Credentials {
 			SessionToken:    DefaultToken,
 		}},
 	})
+}
+
+func GetDefaultProvider() aws.CredentialsProvider {
+	return credentialsv2.NewStaticCredentialsProvider(DefaultAccessKeyID, DefaultSecretAccessKey, DefaultToken)
 }

--- a/pkg/cloud/aws/credentials_integrationtest_test.go
+++ b/pkg/cloud/aws/credentials_integrationtest_test.go
@@ -1,0 +1,33 @@
+//go:build integration
+// +build integration
+
+package aws_test
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	gosoAws "github.com/justtrackio/gosoline/pkg/cloud/aws"
+)
+
+func (s *CredentialsTestSuite) TestNoConfiguredProvider() {
+	s.config.On("HasPrefix", "cloud.aws.credentials").Return(false)
+
+	provider, err := gosoAws.GetCredentialsProvider(s.ctx, s.config, gosoAws.ClientSettings{})
+	s.NoError(err)
+	s.IsType(credentials.StaticCredentialsProvider{}, provider, "the provider should be a static one")
+
+	expected := aws.Credentials{
+		AccessKeyID:     gosoAws.DefaultAccessKeyID,
+		SecretAccessKey: gosoAws.DefaultSecretAccessKey,
+		SessionToken:    gosoAws.DefaultToken,
+		Source:          "StaticCredentials",
+		CanExpire:       false,
+		Expires:         time.Time{},
+	}
+
+	credentials, err := provider.Retrieve(s.ctx)
+	s.NoError(err)
+	s.Equal(expected, credentials)
+}

--- a/pkg/cloud/aws/credentials_test.go
+++ b/pkg/cloud/aws/credentials_test.go
@@ -29,15 +29,6 @@ func (s *CredentialsTestSuite) SetupTest() {
 	s.config = new(mocks.Config)
 }
 
-func (s *CredentialsTestSuite) TestNoConfiguredProvider() {
-	s.config.On("HasPrefix", "cloud.aws.credentials").Return(false)
-
-	provider, err := gosoAws.GetCredentialsProvider(s.ctx, s.config, gosoAws.ClientSettings{})
-
-	s.NoError(err)
-	s.Nil(provider, "there should be no provider returned")
-}
-
 func (s *CredentialsTestSuite) TestStaticCredentialsProvider() {
 	s.config.On("HasPrefix", "cloud.aws.credentials").Return(true)
 	s.config.On("UnmarshalKey", "cloud.aws.credentials", mock.AnythingOfType("*aws.Credentials")).Run(func(args mock.Arguments) {


### PR DESCRIPTION
When running tests with localstack you previously needed to have set the AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID env vars. This collides with eg aws-sso-cli which is refusing to operate when these are set.
Without setting them the autocreate functionality of gosoline against localstack would not work.

This PR uses the previously unused const values with default authentication credentials as a fallback option when no other means of authentication are set / provided.
By default these consts are empty. When compiling with the integration tag they get set to a non empty default value which is sufficient for localstack to work with autocreation.