### PR TITLE
log/mocks: Record logged messages and make them available to the test code

### DIFF
--- a/pkg/cloud/aws/kinesis/kinsumer_test.go
+++ b/pkg/cloud/aws/kinesis/kinsumer_test.go
@@ -40,7 +40,7 @@ type kinsumerTestSuite struct {
 	suite.Suite
 
 	ctx                context.Context
-	logger             *logMocks.Logger
+	logger             *logMocks.LoggerMock
 	stream             gosoKinesis.Stream
 	kinesisClient      *mocks.Client
 	metadataRepository *mocks.MetadataRepository

--- a/pkg/currency/service_test.go
+++ b/pkg/currency/service_test.go
@@ -19,7 +19,7 @@ type serviceTestSuite struct {
 	suite.Suite
 	ctx context.Context
 
-	logger *logMocks.Logger
+	logger *logMocks.LoggerMock
 	store  *kvStoreMock.KvStore[float64]
 	clock  clock.FakeClock
 

--- a/pkg/ddb/repository_transaction_test.go
+++ b/pkg/ddb/repository_transaction_test.go
@@ -22,7 +22,7 @@ type RepositoryTransactionTestSuite struct {
 
 	ctx        context.Context
 	span       *tracingMocks.Span
-	logger     *logMocks.Logger
+	logger     *logMocks.LoggerMock
 	client     *dynamodbMocks.Client
 	tracer     *tracingMocks.Tracer
 	repository ddb.TransactionRepository

--- a/pkg/http/circuit_breaker_test.go
+++ b/pkg/http/circuit_breaker_test.go
@@ -21,7 +21,7 @@ type circuitBreakerTestSuite struct {
 	method string
 
 	ctx        context.Context
-	logger     *loggerMocks.Logger
+	logger     *loggerMocks.LoggerMock
 	clock      clock.FakeClock
 	baseClient *httpMocks.Client
 

--- a/pkg/log/mocks/factory.go
+++ b/pkg/log/mocks/factory.go
@@ -2,13 +2,71 @@ package mocks
 
 import (
 	"fmt"
+	"sync"
+	"testing"
+	"time"
 
 	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/stretchr/testify/mock"
 )
 
-func NewLoggerMock() *Logger {
-	logger := new(Logger)
+const defaultBufferSize = 100
+
+type LogRecord struct {
+	Timestamp time.Time
+	Level     string
+	Template  string
+	Arguments []any
+}
+
+func (r LogRecord) String() string {
+	return fmt.Sprintf("%s [%s] %s", r.Timestamp.Format("2006-01-02T15:04:05.999Z07:00"), r.Level, fmt.Sprintf(r.Template, r.Arguments...))
+}
+
+type LoggerMock struct {
+	Logger
+	buffer     []LogRecord
+	bufferLck  sync.Mutex
+	bufferSize int
+}
+
+func (l *LoggerMock) WithBufferSize(bufferSize int) *LoggerMock {
+	l.bufferLck.Lock()
+	defer l.bufferLck.Unlock()
+
+	l.bufferSize = bufferSize
+
+	return l
+}
+
+func (l *LoggerMock) PrintBufferedLogsOnFailure(t *testing.T) {
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+
+		logs := l.BufferedLogs()
+
+		fmt.Printf("Last %d log messages:\n", len(logs))
+		for _, msg := range logs {
+			fmt.Println(msg.String())
+		}
+	})
+}
+
+func (l *LoggerMock) BufferedLogs() []LogRecord {
+	l.bufferLck.Lock()
+	defer l.bufferLck.Unlock()
+
+	if len(l.buffer) > l.bufferSize {
+		return append([]LogRecord{}, l.buffer[len(l.buffer)-l.bufferSize:]...)
+	}
+
+	return append([]LogRecord{}, l.buffer...)
+}
+
+func NewLoggerMock() *LoggerMock {
+	logger := new(LoggerMock)
 
 	logger.On("WithChannel", mock.AnythingOfType("string")).Return(logger).Maybe()
 	logger.On("WithContext", mock.Anything).Return(logger).Maybe()
@@ -17,12 +75,12 @@ func NewLoggerMock() *Logger {
 	return logger
 }
 
-func NewLoggerMockedAll() *Logger {
+func NewLoggerMockedAll() *LoggerMock {
 	return NewLoggerMockedUntilLevel(log.PriorityError)
 }
 
-// return a logger mocked up to the given log level. All other calls will cause an error and fail the test.
-func NewLoggerMockedUntilLevel(level int) *Logger {
+// NewLoggerMockedUntilLevel returns a logger mocked up to the given log level. All other calls will cause an error and fail the test.
+func NewLoggerMockedUntilLevel(level int) *LoggerMock {
 	logger := NewLoggerMock()
 
 	mockLoggerMethod(logger, "Debug", log.LevelDebug, level >= log.PriorityDebug)
@@ -33,9 +91,9 @@ func NewLoggerMockedUntilLevel(level int) *Logger {
 	return logger
 }
 
-func mockLoggerMethod(logger *Logger, method string, level string, allowed bool) {
+func mockLoggerMethod(logger *LoggerMock, method string, level string, allowed bool) {
 	anythings := make(mock.Arguments, 0)
-	f := inspectLogFunction(level, allowed)
+	f := inspectLogFunction(logger, level, allowed)
 
 	for i := 0; i < 10; i++ {
 		anythings = append(anythings, mock.Anything)
@@ -43,10 +101,28 @@ func mockLoggerMethod(logger *Logger, method string, level string, allowed bool)
 	}
 }
 
-func inspectLogFunction(level string, allowed bool) func(args mock.Arguments) {
+func inspectLogFunction(logger *LoggerMock, level string, allowed bool) func(args mock.Arguments) {
 	return func(args mock.Arguments) {
 		if !allowed {
 			panic(fmt.Errorf("invalid log message '%s'. Logs of level %s are not allowed", args.Get(0), level))
+		}
+
+		logger.bufferLck.Lock()
+		defer logger.bufferLck.Unlock()
+
+		if logger.bufferSize == 0 {
+			logger.bufferSize = defaultBufferSize
+		}
+
+		logger.buffer = append(logger.buffer, LogRecord{
+			Timestamp: time.Now(),
+			Level:     level,
+			Template:  args.Get(0).(string),
+			Arguments: args[1:],
+		})
+		if len(logger.buffer) >= logger.bufferSize*2 {
+			copy(logger.buffer[0:logger.bufferSize], logger.buffer[logger.bufferSize:logger.bufferSize*2])
+			logger.buffer = logger.buffer[:logger.bufferSize]
 		}
 	}
 }

--- a/pkg/log/mocks/factory_test.go
+++ b/pkg/log/mocks/factory_test.go
@@ -1,0 +1,22 @@
+package mocks_test
+
+import (
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/log/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoggerMock_RecordsCorrectLogs(t *testing.T) {
+	logger := mocks.NewLoggerMockedAll().WithBufferSize(10)
+
+	for i := 0; i < 50; i++ {
+		logger.Info("%d", i)
+
+		buffered := logger.BufferedLogs()
+		assert.Len(t, buffered, min(i+1, 10))
+		for recordI, record := range buffered {
+			assert.Equal(t, i-len(buffered)+1+recordI, record.Arguments[0])
+		}
+	}
+}

--- a/pkg/stream/producer_daemon_partitioned_aggregator_test.go
+++ b/pkg/stream/producer_daemon_partitioned_aggregator_test.go
@@ -14,7 +14,7 @@ import (
 type producerDaemonPartitionedAggregatorTestSuite struct {
 	suite.Suite
 	ctx         context.Context
-	logger      *logMocks.Logger
+	logger      *logMocks.LoggerMock
 	rand        *mocks.PartitionerRand
 	aggregators []*mocks.ProducerDaemonAggregator
 	aggregator  stream.ProducerDaemonAggregator


### PR DESCRIPTION
This commit changes the `*logMocks.Logger` type to `*logMocks.LoggerMock` and implements additional functionality to access any logs produced by the code under test. `logger.PrintBufferedLogsOnFailure` now prints all logs captured during a test to stdout upon test failure. `logger.WithBufferSize` allows you to control the amount of logs captured (100 by default) and `logger.BufferedLogs` gives direct access to the log message records.

This is a breaking change - code which was using `*logMocks.Logger` now needs to change this to `*logMocks.LoggerMock`.