### PR TITLE
Fix kernel race

### DIFF
--- a/pkg/httpserver/handler_test.go
+++ b/pkg/httpserver/handler_test.go
@@ -50,7 +50,7 @@ type ProtobufHandler struct{}
 
 //go:generate protoc --go_out=.. handler_test_input.proto
 type ProtobufInput struct {
-	Text string `json:"text" binding:"required"`
+	Text string `binding:"required"`
 }
 
 func (p *ProtobufInput) EmptyMessage() proto.Message {
@@ -66,7 +66,7 @@ func (p *ProtobufInput) FromMessage(message proto.Message) error {
 
 //go:generate protoc --go_out=.. handler_test_output.proto
 type ProtobufOutput struct {
-	Text string `json:"text" binding:"required"`
+	Text string
 }
 
 func (p *ProtobufOutput) ToMessage() (proto.Message, error) {


### PR DESCRIPTION
There used to be a rare race condition in the kernel when a module
failed and returned an error. The kernel would then proceed to shut
down, but this could be started before the module was actually done and
had returned that error to the coffin it was running in. The coffin
would then receive the error for the kernel shutting down and ignore the
(slightly later received) error from the module. This would cause the
kernel to issue a success return code instead of signaling failure to
its parent process.

We now kill the coffin of the stage with the failed module with the
error returned from the module of the stage. Even if the race now
triggers, we still return the correct error. Should two modules from
different stages fail at the same time there is a small chance that one
stage still doesn't receive the correct error - but the kernel will
nonetheless correctly signal failure to its parent process.