### PR TITLE
conc: disabled task runner by default;

### DIFF
--- a/pkg/conc/task_runner/task_runner.go
+++ b/pkg/conc/task_runner/task_runner.go
@@ -18,6 +18,8 @@ import (
 //
 // Try to avoid using this module if possible. It is only meant as a last resort.
 //
+// Enable it by setting task_runner.enabled = true
+//
 //go:generate mockery --name TaskRunner
 type TaskRunner interface {
 	kernel.Module
@@ -25,10 +27,11 @@ type TaskRunner interface {
 }
 
 type Settings struct {
-	Enabled bool `cfg:"enabled" default:"true"`
+	Enabled bool `cfg:"enabled" default:"false"`
 }
 
 type taskRunner struct {
+	kernel.BackgroundModule
 	lck          sync.Mutex
 	done         bool
 	pendingTasks chan kernel.Module


### PR DESCRIPTION
When having the task runner enabled, it adds a foreground module to the app. So every application, which adds additional ones, will have troubles shutting down for themselves, as there is always a second foreground module for which the kernel is waiting.

This change disables the task runner by default, so you have to be aware about the implications.