### PR TITLE
small db improvement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/aws/smithy-go v1.13.5
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712
 	github.com/elastic/go-elasticsearch/v7 v7.2.1-0.20190714143206-f1e755531ff4
 	github.com/elliotchance/redismock/v8 v8.11.0
 	github.com/fatih/color v1.13.0
@@ -45,7 +44,7 @@ require (
 	github.com/go-playground/validator/v10 v10.14.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/go-resty/resty/v2 v2.7.1-0.20230308051516-1578007c3c8d
-	github.com/go-sql-driver/mysql v1.8.0
+	github.com/go-sql-driver/mysql v1.8.1
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang-migrate/migrate/v4 v4.16.0
 	github.com/google/go-querystring v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,6 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712 h1:aaQcKT9WumO6JEJcRyTqFVq4XUZiUcKR2/GI31TOcz8=
-github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elastic/go-elasticsearch/v7 v7.2.1-0.20190714143206-f1e755531ff4 h1:TfN8NpHqvtY2/V2Yqpy0mTj8afjV7oEWq3JKGv12Iuk=
 github.com/elastic/go-elasticsearch/v7 v7.2.1-0.20190714143206-f1e755531ff4/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-sysinfo v1.11.2 h1:mcm4OSYVMyws6+n2HIVMGkln5HOpo5Ie1ZmbbNn0jg4=
@@ -367,6 +365,8 @@ github.com/go-resty/resty/v2 v2.7.1-0.20230308051516-1578007c3c8d/go.mod h1:GBD5
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.8.0 h1:UtktXaU2Nb64z/pLiGIxY4431SJ4/dR5cjMmlVHgnT4=
 github.com/go-sql-driver/mysql v1.8.0/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
+github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
+github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -639,7 +639,6 @@ func (c *config) unmarshalMap(key string, output interface{}, defaults []Unmarsh
 
 		c.unmarshalStruct(keyIndex, item, defaults)
 		err = m.Set(name, item)
-
 		if err != nil {
 			c.err("can not unmarshal key %s: %w", key, err)
 

--- a/pkg/cloud/aws/kinesis/kinesis.go
+++ b/pkg/cloud/aws/kinesis/kinesis.go
@@ -52,7 +52,6 @@ func CreateKinesisStream(ctx context.Context, config cfg.Config, logger log.Logg
 		ShardCount: aws.Int32(1),
 		StreamName: aws.String(streamName),
 	})
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kinesis stream %s: %w", streamName, err)
 	}

--- a/pkg/cloud/aws/sns/topic.go
+++ b/pkg/cloud/aws/sns/topic.go
@@ -226,7 +226,6 @@ func (t *snsTopic) SubscribeSqs(ctx context.Context, queueArn string, attributes
 	}
 
 	_, err = t.client.Subscribe(ctx, input)
-
 	if err != nil {
 		return fmt.Errorf("could not subscribe to topic arn %s for sqs queue arn %s: %w", t.topicArn, queueArn, err)
 	}

--- a/pkg/db-repo/repository.go
+++ b/pkg/db-repo/repository.go
@@ -152,7 +152,6 @@ func (r *repository) Create(ctx context.Context, value ModelBased) error {
 	}
 
 	err = r.refreshAssociations(value, Create)
-
 	if err != nil {
 		logger.Error("could not update associations of model type %v: %w", modelId, err)
 		return err
@@ -210,7 +209,6 @@ func (r *repository) Update(ctx context.Context, value ModelBased) error {
 	}
 
 	err = r.refreshAssociations(value, Update)
-
 	if err != nil {
 		logger.Error("could not update associations of model type %s with id %d: %w", modelId, *value.GetId(), err)
 		return err
@@ -239,7 +237,6 @@ func (r *repository) Delete(ctx context.Context, value ModelBased) error {
 	}
 
 	err = r.orm.Delete(value).Error
-
 	if err != nil {
 		logger.Error("could not delete model of type %s with id %d: %w", modelId, *value.GetId(), err)
 	}

--- a/pkg/db/driver_cratedb.go
+++ b/pkg/db/driver_cratedb.go
@@ -8,22 +8,23 @@ import (
 	"github.com/golang-migrate/migrate/v4/database"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/jackc/pgx/v4/stdlib"
+	"github.com/justtrackio/gosoline/pkg/log"
 )
 
 const DriverNameCrateDb = "cratedb"
 
 func init() {
 	sql.Register(DriverNameCrateDb, stdlib.GetDefaultDriver())
-	connectionFactories[DriverNameCrateDb] = NewCrateDbDriverFactory()
+	connectionFactories[DriverNameCrateDb] = NewCrateDbDriver
 }
 
-type crateDbDriverFactory struct{}
+type crateDbDriver struct{}
 
-func NewCrateDbDriverFactory() *crateDbDriverFactory {
-	return &crateDbDriverFactory{}
+func NewCrateDbDriver(logger log.Logger) (Driver, error) {
+	return &crateDbDriver{}, nil
 }
 
-func (c crateDbDriverFactory) GetDSN(settings Settings) string {
+func (c crateDbDriver) GetDSN(settings Settings) string {
 	dsn := url.URL{
 		Scheme: "postgres",
 		Host:   fmt.Sprintf("%s:%d", settings.Uri.Host, settings.Uri.Port),
@@ -34,7 +35,7 @@ func (c crateDbDriverFactory) GetDSN(settings Settings) string {
 	return dsn.String()
 }
 
-func (c crateDbDriverFactory) GetMigrationDriver(db *sql.DB, database string, migrationsTable string) (database.Driver, error) {
+func (c crateDbDriver) GetMigrationDriver(db *sql.DB, database string, migrationsTable string) (database.Driver, error) {
 	return postgres.WithInstance(db, &postgres.Config{
 		MigrationsTable: migrationsTable,
 		DatabaseName:    database,

--- a/pkg/db/driver_factory.go
+++ b/pkg/db/driver_factory.go
@@ -5,21 +5,31 @@ import (
 	"fmt"
 
 	"github.com/golang-migrate/migrate/v4/database"
+	"github.com/justtrackio/gosoline/pkg/log"
 )
 
-type DriverFactory interface {
+type DriverFactory func(logger log.Logger) (Driver, error)
+
+type Driver interface {
 	GetDSN(settings Settings) string
 	GetMigrationDriver(db *sql.DB, database string, migrationsTable string) (database.Driver, error)
 }
 
 var connectionFactories = map[string]DriverFactory{}
 
-func GetDriverFactory(driverName string) (DriverFactory, error) {
-	factory, exists := connectionFactories[driverName]
+func GetDriver(logger log.Logger, driverName string) (Driver, error) {
+	var ok bool
+	var err error
+	var factory DriverFactory
+	var driver Driver
 
-	if !exists {
+	if factory, ok = connectionFactories[driverName]; !ok {
 		return nil, fmt.Errorf("no driver factory defined for %s", driverName)
 	}
 
-	return factory, nil
+	if driver, err = factory(logger); err != nil {
+		return nil, fmt.Errorf("failed to get driver for %s: %w", driverName, err)
+	}
+
+	return driver, nil
 }

--- a/pkg/db/driver_mysql_test.go
+++ b/pkg/db/driver_mysql_test.go
@@ -1,0 +1,50 @@
+package db_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/db"
+	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/justtrackio/gosoline/pkg/log/mocks"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestMysqlDriver(t *testing.T) {
+	suite.Run(t, new(MysqlDriverTestSuite))
+}
+
+type MysqlDriverTestSuite struct {
+	suite.Suite
+
+	config   cfg.GosoConf
+	logger   log.Logger
+	settings *db.Settings
+}
+
+func (s *MysqlDriverTestSuite) SetupTest() {
+	s.config = cfg.New()
+	err := s.config.Option(cfg.WithConfigMap(map[string]interface{}{
+		"app_name": "test",
+	}))
+	s.NoError(err)
+
+	s.settings = &db.Settings{}
+	s.config.UnmarshalDefaults(s.settings)
+
+	s.logger = new(mocks.Logger)
+}
+
+func (s *MysqlDriverTestSuite) TestDsn() {
+	driver, err := db.NewMysqlDriver(s.logger)
+	s.NoError(err)
+
+	dsn := driver.GetDSN(*s.settings)
+	s.Equal("tcp(localhost:3306)/?collation=utf8mb4_general_ci&multiStatements=true&parseTime=true&charset=utf8mb4&readTimeout=0s&writeTimeout=0s", dsn)
+
+	s.settings.Timeouts.ReadTimeout = time.Millisecond * 50
+	s.settings.Timeouts.WriteTimeout = time.Millisecond * 50
+	dsn = driver.GetDSN(*s.settings)
+	s.Equal("tcp(localhost:3306)/?collation=utf8mb4_general_ci&multiStatements=true&parseTime=true&charset=utf8mb4&readTimeout=50ms&writeTimeout=50ms", dsn)
+}

--- a/pkg/db/driver_redshift.go
+++ b/pkg/db/driver_redshift.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang-migrate/migrate/v4/database"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/golang-migrate/migrate/v4/database/redshift"
+	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/lib/pq"
 )
 
@@ -15,16 +16,16 @@ const DriverNameRedshift = "redshift"
 
 func init() {
 	sql.Register(DriverNameRedshift, &pq.Driver{})
-	connectionFactories[DriverNameRedshift] = NewRedshiftDriverFactory()
+	connectionFactories[DriverNameRedshift] = NewRedshiftDriver
 }
 
-func NewRedshiftDriverFactory() DriverFactory {
-	return &redshiftDriverFactory{}
+func NewRedshiftDriver(logger log.Logger) (Driver, error) {
+	return &redshiftDriver{}, nil
 }
 
-type redshiftDriverFactory struct{}
+type redshiftDriver struct{}
 
-func (m *redshiftDriverFactory) GetDSN(settings Settings) string {
+func (m *redshiftDriver) GetDSN(settings Settings) string {
 	dsn := url.URL{
 		Scheme: "postgres",
 		User:   url.UserPassword(settings.Uri.User, settings.Uri.Password),
@@ -38,7 +39,7 @@ func (m *redshiftDriverFactory) GetDSN(settings Settings) string {
 	return dsn.String()
 }
 
-func (m *redshiftDriverFactory) GetMigrationDriver(db *sql.DB, database string, migrationsTable string) (database.Driver, error) {
+func (m *redshiftDriver) GetMigrationDriver(db *sql.DB, database string, migrationsTable string) (database.Driver, error) {
 	return redshift.WithInstance(db, &redshift.Config{
 		MigrationsTable: migrationsTable,
 		DatabaseName:    database,

--- a/pkg/db/migrations_golang_migrate.go
+++ b/pkg/db/migrations_golang_migrate.go
@@ -15,7 +15,7 @@ func runMigrationGolangMigrate(logger log.Logger, settings Settings, db *sql.DB)
 		return nil
 	}
 
-	driverFactory, err := GetDriverFactory(settings.Driver)
+	driverFactory, err := GetDriver(logger, settings.Driver)
 	if err != nil {
 		return fmt.Errorf("could not get driver factory for %s: %w", settings.Driver, err)
 	}

--- a/pkg/db/mocks/Client.go
+++ b/pkg/db/mocks/Client.go
@@ -92,6 +92,75 @@ func (_c *Client_Exec_Call) RunAndReturn(run func(context.Context, string, ...in
 	return _c
 }
 
+// ExecMultiInTx provides a mock function with given fields: ctx, sqlers
+func (_m *Client) ExecMultiInTx(ctx context.Context, sqlers ...db.Sqler) ([]sql.Result, error) {
+	_va := make([]interface{}, len(sqlers))
+	for _i := range sqlers {
+		_va[_i] = sqlers[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 []sql.Result
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, ...db.Sqler) ([]sql.Result, error)); ok {
+		return rf(ctx, sqlers...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, ...db.Sqler) []sql.Result); ok {
+		r0 = rf(ctx, sqlers...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]sql.Result)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, ...db.Sqler) error); ok {
+		r1 = rf(ctx, sqlers...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Client_ExecMultiInTx_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExecMultiInTx'
+type Client_ExecMultiInTx_Call struct {
+	*mock.Call
+}
+
+// ExecMultiInTx is a helper method to define mock.On call
+//   - ctx context.Context
+//   - sqlers ...db.Sqler
+func (_e *Client_Expecter) ExecMultiInTx(ctx interface{}, sqlers ...interface{}) *Client_ExecMultiInTx_Call {
+	return &Client_ExecMultiInTx_Call{Call: _e.mock.On("ExecMultiInTx",
+		append([]interface{}{ctx}, sqlers...)...)}
+}
+
+func (_c *Client_ExecMultiInTx_Call) Run(run func(ctx context.Context, sqlers ...db.Sqler)) *Client_ExecMultiInTx_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]db.Sqler, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(db.Sqler)
+			}
+		}
+		run(args[0].(context.Context), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Client_ExecMultiInTx_Call) Return(results []sql.Result, err error) *Client_ExecMultiInTx_Call {
+	_c.Call.Return(results, err)
+	return _c
+}
+
+func (_c *Client_ExecMultiInTx_Call) RunAndReturn(run func(context.Context, ...db.Sqler) ([]sql.Result, error)) *Client_ExecMultiInTx_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Get provides a mock function with given fields: ctx, dest, query, args
 func (_m *Client) Get(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
 	var _ca []interface{}

--- a/pkg/ddb/repository.go
+++ b/pkg/ddb/repository.go
@@ -187,7 +187,6 @@ func (r *repository) BatchGetItems(ctx context.Context, qb BatchGetItemsBuilder,
 		}
 
 		input.RequestItems, err = r.processBatchReadItemsResponse(qb, out, unmarshaller, result)
-
 		if err != nil {
 			return nil, err
 		}
@@ -203,7 +202,6 @@ func (r *repository) processBatchReadItemsResponse(qb BatchGetItemsBuilder, out 
 	}
 
 	err = unmarshaller.Append(responses)
-
 	if err != nil {
 		return nil, fmt.Errorf("could not unmarshal items after BatchGetItems operation for table %s: %w", r.metadata.TableName, err)
 	}
@@ -406,7 +404,6 @@ func (r *repository) DeleteItem(ctx context.Context, db DeleteItemBuilder, item 
 	}
 
 	err = UnmarshalMap(out.Attributes, item)
-
 	if err != nil {
 		return nil, fmt.Errorf("could not unmarshal old value after DeleteItem operation on table %s: %w", r.metadata.TableName, err)
 	}
@@ -465,7 +462,6 @@ func (r *repository) GetItem(ctx context.Context, qb GetItemBuilder, item interf
 
 	result.IsFound = true
 	err = UnmarshalMap(out.Item, item)
-
 	if err != nil {
 		return nil, err
 	}
@@ -525,7 +521,6 @@ func (r *repository) PutItem(ctx context.Context, qb PutItemBuilder, item interf
 	}
 
 	err = UnmarshalMap(out.Attributes, item)
-
 	if err != nil {
 		return nil, fmt.Errorf("could not unmarshal old value after PutItem operation on table %s: %w", r.metadata.TableName, err)
 	}
@@ -639,7 +634,6 @@ func (r *repository) UpdateItem(ctx context.Context, ub UpdateItemBuilder, item 
 	}
 
 	err = UnmarshalMap(out.Attributes, item)
-
 	if err != nil {
 		return nil, fmt.Errorf("could not unmarshal old value after UpdateItem operation on table %s: %w", r.metadata.TableName, err)
 	}
@@ -759,7 +753,6 @@ func (r *repository) readAll(items interface{}, read func() (*readResult, error)
 		}
 
 		err = unmarshaller.Append(out.Items)
-
 		if err != nil {
 			return fmt.Errorf("could not unmarshal items after Query operation for table %s: %w", r.metadata.TableName, err)
 		}

--- a/pkg/guard/manager_sql.go
+++ b/pkg/guard/manager_sql.go
@@ -59,7 +59,6 @@ func (m SqlManager) Create(ctx context.Context, pol ladon.Policy) error {
 	}
 
 	_, err = m.dbClient.Exec(ctx, sql, args...)
-
 	if err != nil {
 		return err
 	}
@@ -116,7 +115,6 @@ func (m SqlManager) Delete(ctx context.Context, id string) error {
 	}
 
 	_, err = m.dbClient.Exec(ctx, sql, args...)
-
 	if err != nil {
 		m.logger.Error("can not delete from %s: %w", tableName, err)
 		return err

--- a/pkg/httpserver/auth/config_google.go
+++ b/pkg/httpserver/auth/config_google.go
@@ -130,7 +130,6 @@ func (a *configGoogleAuthenticator) IsValid(ginCtx *gin.Context) (bool, error) {
 	}).Info("token not in cache, will perform request")
 
 	tokenInfo, err = a.tokenProvider.GetTokenInfo(idToken)
-
 	if err != nil {
 		a.tokenCache[idToken] = nil
 		return false, errors.Wrap(err, "google auth: failed requesting token info")

--- a/pkg/httpserver/crud/create.go
+++ b/pkg/httpserver/crud/create.go
@@ -54,7 +54,6 @@ func (ch createHandler) Handle(ctx context.Context, request *httpserver.Request)
 
 	reload := ch.transformer.GetModel()
 	err = repo.Read(ctx, model.GetId(), reload)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/httpserver/crud/update.go
+++ b/pkg/httpserver/crud/update.go
@@ -79,7 +79,6 @@ func (uh updateHandler) Handle(ctx context.Context, request *httpserver.Request)
 
 	reload := uh.transformer.GetModel()
 	err = repo.Read(ctx, model.GetId(), reload)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/httpserver/custom_validators.go
+++ b/pkg/httpserver/custom_validators.go
@@ -42,7 +42,6 @@ func AddCustomValidators(customValidators []CustomValidator) error {
 
 	for _, customValidator := range customValidators {
 		err = v.RegisterValidation(customValidator.Name, customValidator.Validator)
-
 		if err != nil {
 			return err
 		}

--- a/pkg/httpserver/sql/query_builder.go
+++ b/pkg/httpserver/sql/query_builder.go
@@ -160,7 +160,6 @@ func (qb baseQueryBuilder) getJoins(inp *Input) ([]string, error) {
 	}
 
 	err = qb.getJoinsFromFilter(&joins, inp.Filter)
-
 	if err != nil {
 		return joins, err
 	}

--- a/pkg/share/create.go
+++ b/pkg/share/create.go
@@ -88,7 +88,6 @@ func (s shareCreateHandler) Handle(ctx context.Context, req *httpserver.Request)
 
 	reload := s.transformer.GetModel()
 	err = shareRepo.Read(ctx, model.GetId(), reload)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stream/consumer_batch.go
+++ b/pkg/stream/consumer_batch.go
@@ -122,7 +122,6 @@ func (c *BatchConsumer) processAggregateMessage(ctx context.Context, cdata *cons
 	var err error
 
 	ctx, _, err = c.encoder.Decode(ctx, cdata.msg, &batch)
-
 	if err != nil {
 		c.logger.WithContext(ctx).Error("an error occurred during disaggregation of the message: %w", err)
 

--- a/pkg/stream/output_sqs.go
+++ b/pkg/stream/output_sqs.go
@@ -110,7 +110,6 @@ func (o *sqsOutput) Write(ctx context.Context, batch []WritableMessage) error {
 		}
 
 		err = o.queue.SendBatch(ctx, messages)
-
 		if err != nil {
 			result = multierror.Append(result, err)
 		}

--- a/pkg/stream/producer.go
+++ b/pkg/stream/producer.go
@@ -89,7 +89,6 @@ func (p *producer) WriteOne(ctx context.Context, model interface{}, attributeSet
 	}
 
 	err = p.output.WriteOne(ctx, msg)
-
 	if err != nil {
 		return fmt.Errorf("can not write msg to output: %w", err)
 	}
@@ -114,7 +113,6 @@ func (p *producer) Write(ctx context.Context, models interface{}, attributeSets 
 	}
 
 	err = p.output.Write(ctx, messages)
-
 	if err != nil {
 		return fmt.Errorf("can not write messages to output: %w", err)
 	}

--- a/pkg/stream/producer_daemon.go
+++ b/pkg/stream/producer_daemon.go
@@ -111,7 +111,6 @@ func ProvideProducerDaemon(ctx context.Context, config cfg.Config, logger log.Lo
 
 	var err error
 	producerDaemons[name], err = NewProducerDaemon(ctx, config, logger, name)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/env/component_stream_input.go
+++ b/pkg/test/env/component_stream_input.go
@@ -63,7 +63,6 @@ func (s *StreamInputComponent) PublishFromJsonFile(fileName string) {
 
 	messages := make([]*stream.Message, 0)
 	err = json.Unmarshal(bytes, &messages)
-
 	if err != nil {
 		s.failNow(err.Error(), "can not unmarshal messages from json file")
 	}

--- a/pkg/test/env/container_runner.go
+++ b/pkg/test/env/container_runner.go
@@ -387,7 +387,6 @@ func (r *containerRunner) resolveBinding(resource *dockertest.Resource, containe
 
 		return nil
 	})
-
 	if err != nil {
 		return address, fmt.Errorf("can not resolve binding for port %s: %w", containerPort, err)
 	}

--- a/pkg/test/suite/testdata/testcase_httpserver_extended_test_input.pb.go
+++ b/pkg/test/suite/testdata/testcase_httpserver_extended_test_input.pb.go
@@ -98,6 +98,7 @@ var (
 		(*TestInput)(nil), // 0: TestInput
 	}
 )
+
 var file_testcase_httpserver_extended_test_input_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/pkg/tracing/tracer_aws.go
+++ b/pkg/tracing/tracer_aws.go
@@ -75,7 +75,6 @@ func NewAwsTracerWithInterfaces(logger log.Logger, appId cfg.AppId, settings *XR
 		SamplingStrategy:       settings.SamplingStrategy,
 		StreamingStrategy:      streamingStrategy,
 	})
-
 	if err != nil {
 		return nil, fmt.Errorf("can not configure xray tracer: %w", err)
 	}


### PR DESCRIPTION
This PR adds several improvements to the db package:

## Sqler and ExecMultiInTx
We added a convenient function to execute multiple sql statements in one transaction:
```golang
sqls := []db.Sqler{
	squirrel.Update("`schemas`").Set("is_default", false),
	squirrel.Insert("`schemas`").Options("IGNORE").Columns("name", "is_default").Values(name, true),
	squirrel.Update("`schemas`").Set("is_default", true).Where(squirrel.Eq{"name": name}),
}

if _, err = client.ExecMultiInTx(ctx, sqls...); err != nil {
	return fmt.Errorf("can not execute queries: %w", err)
}
```	

## MySQL logging
We've added the gosoline logger to the MySQL driver so that critical errors get not printed to `os.Stderr` but instead getting logged as an error.

## Settings
We've added a couple of settings for the db connection. The following yaml shows how to set them. The example shows the default values:
```yaml
db:
  default:
    charset: utf8mb4
    collation: utf8mb4_general_ci
    connection_max_idletime: 120s
    timeouts:
      readTimeout: 0
      writeTimeout: 0
      timeout: 0 # 0 means that the os default will get used
```