### PR TITLE
allow restricting available auth options through config

### DIFF
--- a/pkg/httpserver/auth/auth.go
+++ b/pkg/httpserver/auth/auth.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/gin-gonic/gin"
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/funk"
 )
 
 const Anonymous = "anon"
@@ -38,4 +40,15 @@ func GetSubject(ctx context.Context) *Subject {
 	}
 
 	panic(fmt.Errorf("there is no subject in the context"))
+}
+
+func OnlyConfiguredAuthenticators(config cfg.Config, name string, authenticators map[string]Authenticator) map[string]Authenticator {
+	key := fmt.Sprintf("httpserver.%s.auth", name)
+	settings := &Settings{}
+	config.UnmarshalKey(key, settings)
+	if len(settings.AllowedAuthenticators) == 0 {
+		return authenticators
+	}
+
+	return funk.IntersectMaps(authenticators, funk.SliceToMap(settings.AllowedAuthenticators, func(method string) (string, Authenticator) { return method, nil }))
 }

--- a/pkg/httpserver/auth/jwt_token_handler.go
+++ b/pkg/httpserver/auth/jwt_token_handler.go
@@ -18,12 +18,6 @@ type jwtTokenHandler struct {
 	settings JwtTokenHandlerSettings
 }
 
-type JwtTokenHandlerSettings struct {
-	SigningSecret  string        `cfg:"signingSecret" validate:"min=8"`
-	Issuer         string        `cfg:"issuer" validate:"required"`
-	ExpireDuration time.Duration `cfg:"expireDuration" default:"15m" validate:"min=60000000000"`
-}
-
 type SignUserInput struct {
 	Name  string
 	Email string

--- a/pkg/httpserver/auth/settings.go
+++ b/pkg/httpserver/auth/settings.go
@@ -1,0 +1,15 @@
+package auth
+
+import "time"
+
+type (
+	Settings struct {
+		AllowedAuthenticators []string `cfg:"allowedAuthenticators"`
+	}
+
+	JwtTokenHandlerSettings struct {
+		SigningSecret  string        `cfg:"signingSecret"  validate:"min=8"`
+		Issuer         string        `cfg:"issuer"         validate:"required"`
+		ExpireDuration time.Duration `cfg:"expireDuration" validate:"min=60000000000" default:"15m"`
+	}
+)


### PR DESCRIPTION
The idea here is that we can restrict in the config.dist.yml what authentication options are available. The same can be done with env vars, or we can layer env vars over the config.dist.yml to allow again all (eg disallow one method by default and for certain environments it could be turned on again).

In code we would specify our auth handler like this:
```go
auth.NewChainHandler(auth.OnlyConfiguredAuthenticators(config, "default", map[string]auth.Authenticator{
		auth.ByApiKey:    apiKeyAuthHandler,
		auth.ByGoogle:    googleAuthHandler,
		auth.ByBasicAuth: emailAuthHandler,
	}))
```
and could restrict them to eg just Google and BasicAuth like this in the config.dist.yml:
```yaml
httpserver:
  default:
    auth:
      allowedAuthenticators:
        - google
        - basicAuth
```
All APIKey auths would then result in `401 Unauthorized`.
This can then be extended to allowing different auth options on different environments through either different config.dist.yml files or env vars.