### PR TITLE
httpserver/auth: Added method to JwtTokenHandler to sign claims directly to make it extensible

### DIFF
--- a/pkg/fixtures/named.go
+++ b/pkg/fixtures/named.go
@@ -75,6 +75,10 @@ func (l *NamedFixtureSet) GetValueByName(name string) interface{} {
 }
 
 func (l *NamedFixtureSet) GetValueById(id interface{}) interface{} {
+	if l.Len() == 0 {
+		panic(fmt.Errorf("can not find id = %v in empty fixture set", id))
+	}
+
 	fixture, ok := funk.FindFirstFunc(*l, func(item *NamedFixture) bool {
 		valueId, ok := GetValueId(item.Value)
 
@@ -82,7 +86,7 @@ func (l *NamedFixtureSet) GetValueById(id interface{}) interface{} {
 	})
 
 	if !ok {
-		panic(fmt.Errorf("failed to get value by id"))
+		panic(fmt.Errorf("failed to get value by id = %v, type = %T", id, (*l)[0].Value))
 	}
 
 	return fixture.Value

--- a/pkg/httpserver/auth/jwt_token_handler.go
+++ b/pkg/httpserver/auth/jwt_token_handler.go
@@ -11,7 +11,14 @@ import (
 //go:generate mockery --name JwtTokenHandler
 type JwtTokenHandler interface {
 	Sign(user SignUserInput) (*string, error)
+	SignClaims(claims Claims) (*string, error)
 	Valid(jwtToken string) (bool, *jwt.Token, error)
+}
+
+type Claims interface {
+	jwt.Claims
+	GetStandardClaims() jwt.StandardClaims
+	SetStandardClaims(standardClaims jwt.StandardClaims)
 }
 
 type jwtTokenHandler struct {
@@ -37,6 +44,14 @@ type JwtClaims struct {
 	jwt.StandardClaims
 }
 
+func (c *JwtClaims) GetStandardClaims() jwt.StandardClaims {
+	return c.StandardClaims
+}
+
+func (c *JwtClaims) SetStandardClaims(standardClaims jwt.StandardClaims) {
+	c.StandardClaims = standardClaims
+}
+
 func NewJwtTokenHandler(config cfg.Config, name string) JwtTokenHandler {
 	key := fmt.Sprintf("httpserver.%s.auth.jwt", name)
 	settings := &JwtTokenHandlerSettings{}
@@ -52,16 +67,20 @@ func NewJwtTokenHandlerWithInterfaces(settings JwtTokenHandlerSettings) JwtToken
 }
 
 func (h *jwtTokenHandler) Sign(user SignUserInput) (*string, error) {
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, &JwtClaims{
+	return h.SignClaims(&JwtClaims{
 		Name:  user.Name,
 		Email: user.Email,
 		Image: user.Image,
-		StandardClaims: jwt.StandardClaims{
-			ExpiresAt: time.Now().Add(h.settings.ExpireDuration).Unix(),
-			IssuedAt:  time.Now().Unix(),
-			Issuer:    h.settings.Issuer,
-		},
 	})
+}
+
+func (h *jwtTokenHandler) SignClaims(claims Claims) (*string, error) {
+	stdClaims := claims.GetStandardClaims()
+	stdClaims.ExpiresAt = time.Now().Add(h.settings.ExpireDuration).Unix()
+	stdClaims.IssuedAt = time.Now().Unix()
+	stdClaims.Issuer = h.settings.Issuer
+	claims.SetStandardClaims(stdClaims)
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 
 	tokenString, err := token.SignedString([]byte(h.settings.SigningSecret))
 	if err != nil {

--- a/pkg/httpserver/auth/mocks/JwtTokenHandler.go
+++ b/pkg/httpserver/auth/mocks/JwtTokenHandler.go
@@ -80,6 +80,64 @@ func (_c *JwtTokenHandler_Sign_Call) RunAndReturn(run func(auth.SignUserInput) (
 	return _c
 }
 
+// SignClaims provides a mock function with given fields: claims
+func (_m *JwtTokenHandler) SignClaims(claims auth.Claims) (*string, error) {
+	ret := _m.Called(claims)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SignClaims")
+	}
+
+	var r0 *string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(auth.Claims) (*string, error)); ok {
+		return rf(claims)
+	}
+	if rf, ok := ret.Get(0).(func(auth.Claims) *string); ok {
+		r0 = rf(claims)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(auth.Claims) error); ok {
+		r1 = rf(claims)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// JwtTokenHandler_SignClaims_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SignClaims'
+type JwtTokenHandler_SignClaims_Call struct {
+	*mock.Call
+}
+
+// SignClaims is a helper method to define mock.On call
+//   - claims auth.Claims
+func (_e *JwtTokenHandler_Expecter) SignClaims(claims interface{}) *JwtTokenHandler_SignClaims_Call {
+	return &JwtTokenHandler_SignClaims_Call{Call: _e.mock.On("SignClaims", claims)}
+}
+
+func (_c *JwtTokenHandler_SignClaims_Call) Run(run func(claims auth.Claims)) *JwtTokenHandler_SignClaims_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(auth.Claims))
+	})
+	return _c
+}
+
+func (_c *JwtTokenHandler_SignClaims_Call) Return(_a0 *string, _a1 error) *JwtTokenHandler_SignClaims_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *JwtTokenHandler_SignClaims_Call) RunAndReturn(run func(auth.Claims) (*string, error)) *JwtTokenHandler_SignClaims_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Valid provides a mock function with given fields: jwtToken
 func (_m *JwtTokenHandler) Valid(jwtToken string) (bool, *jwt.Token, error) {
 	ret := _m.Called(jwtToken)


### PR DESCRIPTION
This allows you to sign claims with custom data, for example to implement custom auth flows.