### PR TITLE
fixtures: removed redundant type declarations for kvstore fixtures;

### DIFF
--- a/pkg/fixtures/named.go
+++ b/pkg/fixtures/named.go
@@ -9,6 +9,23 @@ import (
 	"github.com/justtrackio/gosoline/pkg/mdlsub"
 )
 
+func NewNamedKvStoreFixture[T any](name any, value T) *NamedFixture[*KvStoreFixture] {
+	return &NamedFixture[*KvStoreFixture]{
+		Name: fmt.Sprint(name),
+		Value: &KvStoreFixture{
+			Key:   name,
+			Value: value,
+		},
+	}
+}
+
+func NewNamedFixture[T any](name string, value T) *NamedFixture[T] {
+	return &NamedFixture[T]{
+		Name:  name,
+		Value: value,
+	}
+}
+
 type NamedFixture[T any] struct {
 	Name  string
 	Value T

--- a/pkg/fixtures/writer_configurable_kvstore.go
+++ b/pkg/fixtures/writer_configurable_kvstore.go
@@ -14,12 +14,12 @@ type configurableKvStoreFixtureWriter[T any] struct {
 	store  kvstore.KvStore[T]
 }
 
-func ConfigurableKvStoreFixtureSetFactory[T any, T2 any](name string, data NamedFixtures[T], options ...FixtureSetOption) FixtureSetFactory {
+func ConfigurableKvStoreFixtureSetFactory[T any](name string, data NamedFixtures[*KvStoreFixture], options ...FixtureSetOption) FixtureSetFactory {
 	return func(ctx context.Context, config cfg.Config, logger log.Logger) (FixtureSet, error) {
 		var err error
 		var writer FixtureWriter
 
-		if writer, err = NewConfigurableKvStoreFixtureWriter[T2](ctx, config, logger, name); err != nil {
+		if writer, err = NewConfigurableKvStoreFixtureWriter[T](ctx, config, logger, name); err != nil {
 			return nil, fmt.Errorf("failed to create configurable kvstore fixture writer for %s: %w", name, err)
 		}
 

--- a/pkg/fixtures/writer_ddb_kvstore.go
+++ b/pkg/fixtures/writer_ddb_kvstore.go
@@ -24,12 +24,12 @@ type dynamoDbKvStoreFixtureWriter[T any] struct {
 	purger  *dynamodbPurger
 }
 
-func DynamoDbKvStoreFixtureSetFactory[T any, T2 any](modelId *mdl.ModelId, data NamedFixtures[T], options ...FixtureSetOption) FixtureSetFactory {
+func DynamoDbKvStoreFixtureSetFactory[T any](modelId *mdl.ModelId, data NamedFixtures[*KvStoreFixture], options ...FixtureSetOption) FixtureSetFactory {
 	return func(ctx context.Context, config cfg.Config, logger log.Logger) (FixtureSet, error) {
 		var err error
 		var writer FixtureWriter
 
-		if writer, err = NewDynamoDbKvStoreFixtureWriter[T2](ctx, config, logger, modelId); err != nil {
+		if writer, err = NewDynamoDbKvStoreFixtureWriter[T](ctx, config, logger, modelId); err != nil {
 			return nil, fmt.Errorf("failed to create dynamodb kvstore fixture writer for %s: %w", modelId.String(), err)
 		}
 

--- a/pkg/fixtures/writer_redis_kvstore.go
+++ b/pkg/fixtures/writer_redis_kvstore.go
@@ -16,12 +16,12 @@ type redisKvStoreFixtureWriter[T any] struct {
 	purger *redisPurger
 }
 
-func RedisKvStoreFixtureSetFactory[T any, T2 any](modelId *mdl.ModelId, data NamedFixtures[T], options ...FixtureSetOption) FixtureSetFactory {
+func RedisKvStoreFixtureSetFactory[T any](modelId *mdl.ModelId, data NamedFixtures[*KvStoreFixture], options ...FixtureSetOption) FixtureSetFactory {
 	return func(ctx context.Context, config cfg.Config, logger log.Logger) (FixtureSet, error) {
 		var err error
 		var writer FixtureWriter
 
-		if writer, err = NewRedisKvStoreFixtureWriter[T2](ctx, config, logger, modelId); err != nil {
+		if writer, err = NewRedisKvStoreFixtureWriter[T](ctx, config, logger, modelId); err != nil {
 			return nil, fmt.Errorf("failed to create redis kvstore fixture writer for %s: %w", modelId.String(), err)
 		}
 


### PR DESCRIPTION
This release adds some small simplification for the kvstore fixtureset factories by removing a redundant type declaration.\
In addition, we added 2 little helper to create named fixtures.