### PR TITLE
log/mocks: Refactored logger mock factory by adding options and changed return value to interface

### DIFF
--- a/pkg/cloud/aws/executor_test.go
+++ b/pkg/cloud/aws/executor_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestBackoffExecutor_Execute(t *testing.T) {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	executions := 0
 

--- a/pkg/cloud/aws/kinesis/kinsumer_test.go
+++ b/pkg/cloud/aws/kinesis/kinsumer_test.go
@@ -40,7 +40,7 @@ type kinsumerTestSuite struct {
 	suite.Suite
 
 	ctx                context.Context
-	logger             *logMocks.Logger
+	logger             logMocks.LoggerMock
 	stream             gosoKinesis.Stream
 	kinesisClient      *mocks.Client
 	metadataRepository *mocks.MetadataRepository
@@ -61,8 +61,7 @@ func TestKinsumer(t *testing.T) {
 
 func (s *kinsumerTestSuite) SetupTest() {
 	s.ctx = context.Background()
-	s.logger = logMocks.NewLoggerMock()
-	s.T().Cleanup(func() { s.logger.AssertExpectations(s.T()) })
+	s.logger = logMocks.NewLoggerMock(logMocks.WithTestingT(s.T()))
 	s.stream = "gosoline-test-unitTest-kinesisTest-testData"
 	s.kinesisClient = mocks.NewClient(s.T())
 	s.metadataRepository = mocks.NewMetadataRepository(s.T())

--- a/pkg/cloud/aws/kinesis/record_writer_test.go
+++ b/pkg/cloud/aws/kinesis/record_writer_test.go
@@ -29,8 +29,7 @@ func TestRecordWriterPutRecords(t *testing.T) {
 		"stream_name":              "streamName",
 	})
 
-	logger := logMocks.NewLoggerMock()
-	t.Cleanup(func() { logger.AssertExpectations(t) })
+	logger := logMocks.NewLoggerMock(logMocks.WithTestingT(t))
 	logger.EXPECT().Warn("PutRecords failed %d of %d records with reason: %s: after %d attempts in %s", 1, 3, "1 ProvisionedThroughputExceededException errors", 1, time.Second)
 	logger.EXPECT().Warn("PutRecords successful after %d attempts in %s", 2, mock.AnythingOfType("time.Duration"))
 

--- a/pkg/cloud/aws/resourcegroupstaggingapi/resources_test.go
+++ b/pkg/cloud/aws/resourcegroupstaggingapi/resources_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestResourcesManager_GetResources(t *testing.T) {
 	ctx := context.Background()
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	client := gosoResMocks.NewClient(t)
 	client.EXPECT().GetResources(ctx, mock.AnythingOfType("*resourcegroupstaggingapi.GetResourcesInput"), mock.AnythingOfType("func(*resourcegroupstaggingapi.Options)")).Return(&resourcegroupstaggingapi.GetResourcesOutput{

--- a/pkg/cloud/aws/sns/create_test.go
+++ b/pkg/cloud/aws/sns/create_test.go
@@ -22,7 +22,7 @@ func TestCreateTopic(t *testing.T) {
 		TopicArn: aws.String("arn"),
 	}, nil)
 
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	arn, err := gosoSns.CreateTopic(ctx, logger, client, "mcoins-test-analytics-topicker-topic")
 
@@ -37,7 +37,7 @@ func TestCreateTopicFailing(t *testing.T) {
 		Name: aws.String("mcoins-test-analytics-topicker-topic"),
 	}).Return(nil, errors.New(""))
 
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	arn, err := gosoSns.CreateTopic(ctx, logger, client, "mcoins-test-analytics-topicker-topic")
 

--- a/pkg/cloud/aws/sns/topic_test.go
+++ b/pkg/cloud/aws/sns/topic_test.go
@@ -29,7 +29,7 @@ type TopicTestSuite struct {
 }
 
 func (s *TopicTestSuite) SetupTest() {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
 
 	s.ctx = context.Background()
 	s.client = gosoSnsMocks.NewClient(s.T())

--- a/pkg/cloud/aws/sqs/queue_test.go
+++ b/pkg/cloud/aws/sqs/queue_test.go
@@ -25,7 +25,7 @@ type queueTestSuite struct {
 }
 
 func (s *queueTestSuite) SetupTest() {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
 
 	s.ctx = context.Background()
 	s.client = new(sqsMocks.Client)

--- a/pkg/cloud/aws/sqs/service_test.go
+++ b/pkg/cloud/aws/sqs/service_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestService_CreateQueue(t *testing.T) {
 	ctx := context.Background()
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	client := mocks.NewClient(t)
 
 	client.EXPECT().GetQueueUrl(ctx, &awsSqs.GetQueueUrlInput{
@@ -92,7 +92,7 @@ func TestService_CreateQueue(t *testing.T) {
 
 func TestService_GetPropertiesByName(t *testing.T) {
 	ctx := context.Background()
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	client := mocks.NewClient(t)
 
 	srv := sqs.NewServiceWithInterfaces(logger, client, &sqs.ServiceSettings{
@@ -129,7 +129,7 @@ func TestService_GetPropertiesByName(t *testing.T) {
 
 func TestService_GetPropertiesByArn(t *testing.T) {
 	ctx := context.Background()
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	client := mocks.NewClient(t)
 
 	srv := sqs.NewServiceWithInterfaces(logger, client, &sqs.ServiceSettings{
@@ -157,7 +157,7 @@ func TestService_GetPropertiesByArn(t *testing.T) {
 
 func TestService_Purge(t *testing.T) {
 	ctx := context.Background()
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	client := mocks.NewClient(t)
 
 	url := "https://sqs.eu-central-1.amazonaws.com/accountId/applike-test-gosoline-queue-id"

--- a/pkg/conc/ddb/ddb_lock_provider_test.go
+++ b/pkg/conc/ddb/ddb_lock_provider_test.go
@@ -59,7 +59,7 @@ func (s *ddbLockProviderTestSuite) SetupSuite() {
 }
 
 func (s *ddbLockProviderTestSuite) SetupTest() {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
 	s.ctx = context.Background()
 	s.repo = new(ddbMocks.Repository)
 	s.clock = clock.NewFakeClock()

--- a/pkg/currency/service_test.go
+++ b/pkg/currency/service_test.go
@@ -19,7 +19,7 @@ type serviceTestSuite struct {
 	suite.Suite
 	ctx context.Context
 
-	logger *logMocks.Logger
+	logger logMocks.LoggerMock
 	store  *kvStoreMock.KvStore[float64]
 	clock  clock.FakeClock
 
@@ -33,16 +33,11 @@ func TestService(t *testing.T) {
 func (s *serviceTestSuite) SetupTest() {
 	s.ctx = context.Background()
 
-	s.logger = logMocks.NewLoggerMockedAll()
-	s.store = new(kvStoreMock.KvStore[float64])
+	s.logger = logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
+	s.store = kvStoreMock.NewKvStore[float64](s.T())
 	s.clock = clock.NewFakeClockAt(time.Date(2021, 1, 3, 4, 20, 33, 0, time.UTC))
 
 	s.service = currency.NewWithInterfaces(s.store, s.clock)
-}
-
-func (s *serviceTestSuite) TearDownTest() {
-	s.logger.AssertExpectations(s.T())
-	s.store.AssertExpectations(s.T())
 }
 
 func (s *serviceTestSuite) TestToEur_Calculation() {

--- a/pkg/currency/updater_test.go
+++ b/pkg/currency/updater_test.go
@@ -82,7 +82,7 @@ type updaterServiceTestSuite struct {
 	suite.Suite
 	ctx context.Context
 
-	logger *logMocks.Logger
+	logger logMocks.LoggerMock
 	store  *kvStoreMock.KvStore[float64]
 	client *httpMock.Client
 	clock  clock.FakeClock
@@ -97,18 +97,12 @@ func TestNewUpdaterService(t *testing.T) {
 func (s *updaterServiceTestSuite) SetupTest() {
 	s.ctx = context.Background()
 
-	s.logger = logMocks.NewLoggerMockedAll()
-	s.store = new(kvStoreMock.KvStore[float64])
-	s.client = new(httpMock.Client)
+	s.logger = logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
+	s.store = kvStoreMock.NewKvStore[float64](s.T())
+	s.client = httpMock.NewClient(s.T())
 	s.clock = clock.NewFakeClockAt(time.Date(2021, 5, 27, 0, 0, 0, 0, time.UTC))
 
 	s.updater = currency.NewUpdaterWithInterfaces(s.logger, s.store, s.client, s.clock)
-}
-
-func (s *updaterServiceTestSuite) TearDownTest() {
-	s.logger.AssertExpectations(s.T())
-	s.store.AssertExpectations(s.T())
-	s.client.AssertExpectations(s.T())
 }
 
 func (s *updaterServiceTestSuite) TestEnsureRecentExchangeRates() {

--- a/pkg/db-repo/notification_publisher_test.go
+++ b/pkg/db-repo/notification_publisher_test.go
@@ -45,7 +45,15 @@ func Test_Publish_Notifier(t *testing.T) {
 		Environment: "test",
 	}
 
-	notifier := db_repo.NewPublisherNotifier(context.Background(), cfg.New(), &publisher, logMocks.NewLoggerMockedAll(), modelId, 1, transformer)
+	notifier := db_repo.NewPublisherNotifier(
+		context.Background(),
+		cfg.New(),
+		&publisher,
+		logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t)),
+		modelId,
+		1,
+		transformer,
+	)
 
 	err := notifier.Send(context.Background(), "CREATE", input)
 	assert.NoError(t, err)

--- a/pkg/db-repo/repository_test.go
+++ b/pkg/db-repo/repository_test.go
@@ -796,7 +796,7 @@ func TestRepository_DeleteHasManyNoRelation(t *testing.T) {
 }
 
 func getMocks(t *testing.T, whichMetadata string) (goSqlMock.Sqlmock, db_repo.Repository) {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	tracer := tracing.NewNoopTracer()
 
 	db, clientMock, _ := goSqlMock.New()
@@ -820,7 +820,7 @@ func getMocks(t *testing.T, whichMetadata string) (goSqlMock.Sqlmock, db_repo.Re
 }
 
 func getTimedMocks(t *testing.T, time time.Time, whichMetadata string) (goSqlMock.Sqlmock, db_repo.Repository) {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	tracer := tracing.NewNoopTracer()
 
 	db, clientMock, _ := goSqlMock.New()

--- a/pkg/db/client_test.go
+++ b/pkg/db/client_test.go
@@ -129,7 +129,7 @@ func TestClient_Exec(t *testing.T) {
 
 func getMocks() (db.Client, goSqlMock.Sqlmock) {
 	dbMock, sqlMock, _ := goSqlMock.New()
-	loggerMock := logMocks.NewLoggerMockedAll()
+	loggerMock := logMocks.NewLoggerMock(logMocks.WithMockAll)
 	sqlxDB := sqlx.NewDb(dbMock, "sqlmock")
 
 	client := db.NewClientWithInterfaces(loggerMock, sqlxDB, exec.NewDefaultExecutor())

--- a/pkg/db/driver_mysql_test.go
+++ b/pkg/db/driver_mysql_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/db"
 	"github.com/justtrackio/gosoline/pkg/log"
-	"github.com/justtrackio/gosoline/pkg/log/mocks"
+	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -33,7 +33,7 @@ func (s *MysqlDriverTestSuite) SetupTest() {
 	s.settings = &db.Settings{}
 	s.config.UnmarshalDefaults(s.settings)
 
-	s.logger = mocks.NewLoggerMockedAll()
+	s.logger = logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
 }
 
 func (s *MysqlDriverTestSuite) TestDsn() {

--- a/pkg/ddb/repository_test.go
+++ b/pkg/ddb/repository_test.go
@@ -38,7 +38,7 @@ type RepositoryTestSuite struct {
 }
 
 func (s *RepositoryTestSuite) SetupTest() {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
 	tracer := tracing.NewNoopTracer()
 
 	s.ctx = context.Background()

--- a/pkg/ddb/repository_transaction_test.go
+++ b/pkg/ddb/repository_transaction_test.go
@@ -22,7 +22,7 @@ type RepositoryTransactionTestSuite struct {
 
 	ctx        context.Context
 	span       *tracingMocks.Span
-	logger     *logMocks.Logger
+	logger     logMocks.LoggerMock
 	client     *dynamodbMocks.Client
 	tracer     *tracingMocks.Tracer
 	repository ddb.TransactionRepository
@@ -34,7 +34,7 @@ func TestRepositoryTransactionTestSuite(t *testing.T) {
 
 func (s *RepositoryTransactionTestSuite) SetupTest() {
 	s.ctx = context.Background()
-	s.logger = logMocks.NewLoggerMockedAll()
+	s.logger = logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
 	s.client = dynamodbMocks.NewClient(s.T())
 	s.tracer = tracingMocks.NewTracer(s.T())
 	s.span = tracingMocks.NewSpan(s.T())

--- a/pkg/ddb/service_test.go
+++ b/pkg/ddb/service_test.go
@@ -63,7 +63,7 @@ func TestService_sanitizeSettings(t *testing.T) {
 
 func TestService_CreateTable(t *testing.T) {
 	ctx := context.Background()
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	client := dynamodbMocks.NewClient(t)
 
 	describeInput := &dynamodb.DescribeTableInput{

--- a/pkg/exec/executor_backoff_test.go
+++ b/pkg/exec/executor_backoff_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/justtrackio/gosoline/pkg/exec"
-	"github.com/justtrackio/gosoline/pkg/log/mocks"
+	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/sys/unix"
 )
@@ -33,7 +33,7 @@ func (s *ExecutorBackoffTestSuite) SetupTest() {
 			MaxElapsedTime:  maxElapsedTime,
 		}
 
-		logger := mocks.NewLoggerMockedAll()
+		logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
 
 		return exec.NewBackoffExecutor(logger, resource, settings, checkers)
 	}

--- a/pkg/fixtures/writer_mysql_sqlx_test.go
+++ b/pkg/fixtures/writer_mysql_sqlx_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/justtrackio/gosoline/pkg/db"
 	"github.com/justtrackio/gosoline/pkg/exec"
 	"github.com/justtrackio/gosoline/pkg/fixtures"
-	"github.com/justtrackio/gosoline/pkg/log/mocks"
+	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -34,7 +34,7 @@ func (s *MysqlSqlxFixtureWriterTestSuite) SetupSuite() {
 	s.NoError(err)
 
 	xdb := sqlx.NewDb(sdb, "mysql")
-	logger := mocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
 
 	client = db.NewClientWithInterfaces(logger, xdb, exec.NewDefaultExecutor())
 	s.writer = fixtures.NewMysqlSqlxFixtureWriterWithInterfaces(logger, client, &fixtures.MysqlSqlxMetaData{TableName: "table"}, nil)

--- a/pkg/grpcserver/health_test.go
+++ b/pkg/grpcserver/health_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Test_healthServer_Check(t *testing.T) {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 

--- a/pkg/grpcserver/server_test.go
+++ b/pkg/grpcserver/server_test.go
@@ -33,7 +33,7 @@ func TestGRPCServer_Run_Handler(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	tests := []struct {
 		name    string
 		defs    *grpcserver.Definitions
@@ -110,7 +110,7 @@ func TestGRPCServer_Run_Handler_WithHealth(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	tests := []struct {
 		name    string
 		defs    *grpcserver.Definitions

--- a/pkg/http/client_test.go
+++ b/pkg/http/client_test.go
@@ -68,7 +68,7 @@ func getClient(t *testing.T, retries int, timeout time.Duration) http.Client {
 	ctx := appctx.WithContainer(context.Background())
 	config := getConfig(t, retries, timeout)
 
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	client, err := http.ProvideHttpClient(ctx, config, logger, "default")
 	assert.NoError(t, err)

--- a/pkg/httpserver/auth/basic_auth_test.go
+++ b/pkg/httpserver/auth/basic_auth_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/justtrackio/gosoline/pkg/httpserver/auth"
 	"github.com/justtrackio/gosoline/pkg/log"
-	"github.com/justtrackio/gosoline/pkg/log/mocks"
+	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
 	"github.com/stretchr/testify/assert"
 )
 
 func getBasicAuthMocks(user string, password string) (log.Logger, *gin.Context) {
-	logger := mocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll)
 
 	header := http.Header{}
 	header.Set("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", user, password)))))

--- a/pkg/httpserver/auth/config_google_test.go
+++ b/pkg/httpserver/auth/config_google_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/justtrackio/gosoline/pkg/httpserver/auth"
 	authMocks "github.com/justtrackio/gosoline/pkg/httpserver/auth/mocks"
 	"github.com/justtrackio/gosoline/pkg/log"
-	"github.com/justtrackio/gosoline/pkg/log/mocks"
+	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/oauth2/v2"
 )
 
 func getMocks(idToken string) (log.Logger, *authMocks.TokenInfoProvider, *gin.Context) {
-	logger := mocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll)
 	tokenProvider := new(authMocks.TokenInfoProvider)
 
 	ginCtx := getGinCtx(idToken)

--- a/pkg/httpserver/auth/config_key_test.go
+++ b/pkg/httpserver/auth/config_key_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/justtrackio/gosoline/pkg/httpserver/auth"
 	"github.com/justtrackio/gosoline/pkg/log"
-	"github.com/justtrackio/gosoline/pkg/log/mocks"
+	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
 	"github.com/stretchr/testify/assert"
 )
 
 func getHeaderKeyMocks(idToken string) (log.Logger, *gin.Context) {
-	logger := mocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll)
 
 	header := http.Header{}
 	header.Set("X-API-KEY", idToken)
@@ -32,7 +32,7 @@ func getHeaderKeyMocks(idToken string) (log.Logger, *gin.Context) {
 }
 
 func getQueryKeyMocks(idToken string) (log.Logger, *gin.Context) {
-	logger := mocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll)
 
 	request := &http.Request{
 		URL: &url.URL{

--- a/pkg/httpserver/auth/token_bearer_test.go
+++ b/pkg/httpserver/auth/token_bearer_test.go
@@ -87,7 +87,7 @@ func makeDdbProvider(test *tokenBearerTestCase) (auth.TokenBearerProvider, []has
 }
 
 func (test *tokenBearerTestCase) run(t *testing.T, providerProvider providerProvider) {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	provider, hasExpectations := providerProvider(test)
 
 	headers := http.Header{}

--- a/pkg/httpserver/crud/crud_test.go
+++ b/pkg/httpserver/crud/crud_test.go
@@ -124,7 +124,7 @@ func TestCreateHandler_Handle(t *testing.T) {
 		Name: mdl.Box("foobar"),
 	}
 
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	transformer := NewTransformer()
 
 	transformer.Repo.On("Create", mock.AnythingOfType("context.backgroundCtx"), model).Run(func(args mock.Arguments) {
@@ -155,7 +155,7 @@ func TestCreateHandler_Handle_ValidationError(t *testing.T) {
 		Name: mdl.Box("foobar"),
 	}
 
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	transformer := NewTransformer()
 
 	transformer.Repo.On("Create", mock.AnythingOfType("context.backgroundCtx"), model).Return(&validation.Error{
@@ -176,7 +176,7 @@ func TestCreateHandler_Handle_ValidationError(t *testing.T) {
 func TestReadHandler_Handle(t *testing.T) {
 	model := &Model{}
 
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	transformer := NewTransformer()
 	transformer.Repo.On("Read", mock.AnythingOfType("context.backgroundCtx"), mdl.Box(uint(1)), model).Run(func(args mock.Arguments) {
 		model := args.Get(2).(*Model)
@@ -209,7 +209,7 @@ func TestUpdateHandler_Handle(t *testing.T) {
 		Name: mdl.Box("updated"),
 	}
 
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	transformer := NewTransformer()
 
 	transformer.Repo.On("Update", mock.AnythingOfType("context.backgroundCtx"), updateModel).Return(nil)
@@ -245,7 +245,7 @@ func TestUpdateHandler_Handle_ValidationError(t *testing.T) {
 		Name: mdl.Box("updated"),
 	}
 
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	transformer := NewTransformer()
 
 	transformer.Repo.On("Update", mock.AnythingOfType("context.backgroundCtx"), updateModel).Return(&validation.Error{
@@ -283,7 +283,7 @@ func TestDeleteHandler_Handle(t *testing.T) {
 		Name: mdl.Box("foobar"),
 	}
 
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	transformer := NewTransformer()
 	transformer.Repo.On("Read", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("*uint"), model).Run(func(args mock.Arguments) {
 		model := args.Get(2).(*Model)
@@ -317,7 +317,7 @@ func TestDeleteHandler_Handle_ValidationError(t *testing.T) {
 		Name: mdl.Box("foobar"),
 	}
 
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	transformer := NewTransformer()
 	transformer.Repo.On("Read", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("*uint"), model).Run(func(args mock.Arguments) {
 		model := args.Get(2).(*Model)
@@ -341,7 +341,7 @@ func TestDeleteHandler_Handle_ValidationError(t *testing.T) {
 }
 
 func TestListHandler_Handle(t *testing.T) {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	transformer := NewTransformer()
 	handler := crud.NewListHandler(logger, transformer)
 

--- a/pkg/httpserver/health_check_test.go
+++ b/pkg/httpserver/health_check_test.go
@@ -18,7 +18,7 @@ func HealthCheckerMock() kernel.HealthCheckResult {
 func TestNewApiHealthCheck(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ginEngine := gin.New()
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	httpserver.NewHealthCheckWithInterfaces(logger, ginEngine, HealthCheckerMock, &httpserver.HealthCheckSettings{
 		Path: "/health",

--- a/pkg/httpserver/middleware_recover_test.go
+++ b/pkg/httpserver/middleware_recover_test.go
@@ -16,7 +16,7 @@ import (
 func TestRecoveryWithSentryCaseNil(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	loggerMock := logMocks.NewLoggerMockedAll()
+	loggerMock := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	r := gin.New()
 	r.Use(httpserver.RecoveryWithSentry(loggerMock))
@@ -36,7 +36,7 @@ func TestRecoveryWithSentryCaseNil(t *testing.T) {
 func TestRecoveryWithSentryCaseError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	loggerMock := logMocks.NewLoggerMockedAll()
+	loggerMock := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	r := gin.New()
 	r.Use(httpserver.RecoveryWithSentry(loggerMock))
@@ -60,7 +60,7 @@ func TestRecoveryWithSentryCaseError(t *testing.T) {
 func TestRecoveryWithSentryCaseResponseBodyWriterAndConnectionErrors(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	loggerMock := logMocks.NewLoggerMockedAll()
+	loggerMock := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	r := gin.New()
 	r.Use(httpserver.RecoveryWithSentry(loggerMock))
@@ -84,7 +84,7 @@ func TestRecoveryWithSentryCaseResponseBodyWriterAndConnectionErrors(t *testing.
 func TestRecoveryWithSentryCaseResponseBodyWriterErrorButNotConnectionError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	loggerMock := logMocks.NewLoggerMockedAll()
+	loggerMock := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	r := gin.New()
 	r.Use(httpserver.RecoveryWithSentry(loggerMock))
@@ -108,7 +108,7 @@ func TestRecoveryWithSentryCaseResponseBodyWriterErrorButNotConnectionError(t *t
 func TestRecoveryWithSentryCaseString(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	loggerMock := logMocks.NewLoggerMockedAll()
+	loggerMock := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	r := gin.New()
 	r.Use(httpserver.RecoveryWithSentry(loggerMock))

--- a/pkg/httpserver/server_test.go
+++ b/pkg/httpserver/server_test.go
@@ -31,7 +31,7 @@ func TestServerTestSuite(t *testing.T) {
 }
 
 func (s *ServerTestSuite) SetupTest() {
-	s.logger = logMocks.NewLoggerMockedAll()
+	s.logger = logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
 
 	gin.SetMode(gin.TestMode)
 	s.router = gin.New()

--- a/pkg/kafka/consumer/consumer_offset_manager_test.go
+++ b/pkg/kafka/consumer/consumer_offset_manager_test.go
@@ -42,7 +42,7 @@ func TestOffsetManager_NotCommitting(t *testing.T) {
 	reader.On("Close").Times(1).Return(nil)
 	defer reader.AssertExpectations(t)
 
-	manager := consumer.NewOffsetManager(logMocks.NewLoggerMockedAll(), reader, 2, time.Second)
+	manager := consumer.NewOffsetManager(logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t)), reader, 2, time.Second)
 	pool.GoWithContext(ctx, manager.Start)
 
 	// 1st call to batch() should return a non-empty batch.
@@ -91,7 +91,7 @@ func TestOffsetManager_PartialCommit(t *testing.T) {
 	reader.On("Close").Times(1).Return(nil)
 	defer reader.AssertExpectations(t)
 
-	manager := consumer.NewOffsetManager(logMocks.NewLoggerMockedAll(), reader, 2, time.Second)
+	manager := consumer.NewOffsetManager(logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t)), reader, 2, time.Second)
 	pool.GoWithContext(ctx, manager.Start)
 
 	// 1st call to batch() should return a non-empty batch.
@@ -146,7 +146,7 @@ func TestOffsetManager_DoubleCommit(t *testing.T) {
 	reader.On("Close").Times(1).Return(nil)
 	defer reader.AssertExpectations(t)
 
-	manager := consumer.NewOffsetManager(logMocks.NewLoggerMockedAll(), reader, 2, time.Second)
+	manager := consumer.NewOffsetManager(logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t)), reader, 2, time.Second)
 	pool.GoWithContext(ctx, manager.Start)
 
 	// 1st call to batch() should return a non-empty batch.
@@ -208,7 +208,7 @@ func TestOffsetManager_FullCommit(t *testing.T) {
 	reader.On("Close").Times(1).Return(nil)
 	defer reader.AssertExpectations(t)
 
-	manager := consumer.NewOffsetManager(logMocks.NewLoggerMockedAll(), reader, 2, time.Second)
+	manager := consumer.NewOffsetManager(logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t)), reader, 2, time.Second)
 	pool.GoWithContext(ctx, manager.Start)
 
 	// 1st call to batch() should return a non-empty batch.
@@ -265,7 +265,7 @@ func TestOffsetManager_FetchMessageErrors(t *testing.T) {
 	reader.On("Close").Times(1).Return(nil)
 	defer reader.AssertExpectations(t)
 
-	manager := consumer.NewOffsetManager(logMocks.NewLoggerMockedAll(), reader, 2, time.Second)
+	manager := consumer.NewOffsetManager(logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t)), reader, 2, time.Second)
 	assert.ErrorIs(t, manager.Start(ctx), readerErr)
 }
 
@@ -290,7 +290,7 @@ func TestOffsetManager_FlushErrors(t *testing.T) {
 	reader.On("Close").Times(1).Return(readerErr)
 	defer reader.AssertExpectations(t)
 
-	manager := consumer.NewOffsetManager(logMocks.NewLoggerMockedAll(), reader, 2, time.Second)
+	manager := consumer.NewOffsetManager(logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t)), reader, 2, time.Second)
 	assert.ErrorIs(t, manager.Start(ctx), readerErr)
 }
 

--- a/pkg/kafka/consumer/consumer_test.go
+++ b/pkg/kafka/consumer/consumer_test.go
@@ -46,7 +46,7 @@ func TestConsumer_Manager_Batch_Commit(t *testing.T) {
 			BatchSize:    100,
 			BatchTimeout: time.Second,
 		},
-		logMocks.NewLoggerMockedAll(),
+		logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t)),
 		manager,
 	)
 	assert.Nil(t, err)

--- a/pkg/kafka/consumer/reader_test.go
+++ b/pkg/kafka/consumer/reader_test.go
@@ -23,7 +23,7 @@ var (
 )
 
 func TestSaneDefaults(t *testing.T) {
-	reader, err := consumer.NewReader(logMocks.NewLoggerMockedAll(), readerDialer, readerSettings)
+	reader, err := consumer.NewReader(logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t)), readerDialer, readerSettings)
 	assert.Nil(t, err)
 
 	assert.Equal(t, reader.Config().MaxAttempts, 3)
@@ -40,7 +40,7 @@ func TestSaneDefaults(t *testing.T) {
 
 func TestFallsbackToSaneDefaults(t *testing.T) {
 	reader, err := consumer.NewReader(
-		logMocks.NewLoggerMockedAll(),
+		logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t)),
 		readerDialer,
 		readerSettings,
 		consumer.WithBatch(1e6),
@@ -57,7 +57,7 @@ func TestAppliesWithBatch(t *testing.T) {
 	)
 
 	reader, err := consumer.NewReader(
-		logMocks.NewLoggerMockedAll(),
+		logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t)),
 		readerDialer,
 		readerSettings,
 		consumer.WithBatch(batchMaxSize),

--- a/pkg/kafka/producer/producer_test.go
+++ b/pkg/kafka/producer/producer_test.go
@@ -17,8 +17,8 @@ import (
 func Test_Write_WriteOne(t *testing.T) {
 	var (
 		ctx, cancel = context.WithCancel(context.Background())
-		logger      = logMocks.NewLoggerMockedAll()
-		writer      = &producerMocks.Writer{}
+		logger      = logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
+		writer      = producerMocks.NewWriter(t)
 		conf        = &producer.Settings{
 			FQTopic: "fq-topic",
 		}
@@ -53,8 +53,6 @@ func Test_Write_WriteOne(t *testing.T) {
 			},
 		}
 	)
-	defer logger.AssertExpectations(t)
-	defer writer.AssertExpectations(t)
 
 	writer.On("WriteMessages", mock.Anything, mock.Anything).Return(
 		func(ctx context.Context, ms ...kafka.Message) error {

--- a/pkg/kafka/producer/writer_test.go
+++ b/pkg/kafka/producer/writer_test.go
@@ -31,7 +31,7 @@ var (
 
 func TestTransport(t *testing.T) {
 	writer, err := producer.NewWriter(
-		logMocks.NewLoggerMockedAll(), writerDialer, writerConf.Connection().Bootstrap,
+		logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t)), writerDialer, writerConf.Connection().Bootstrap,
 		producer.WithAsyncWrites(),
 	)
 	assert.Nil(t, err)
@@ -52,7 +52,7 @@ func TestTransport(t *testing.T) {
 }
 
 func TestSaneDefaults(t *testing.T) {
-	writer, err := producer.NewWriter(logMocks.NewLoggerMockedAll(), writerDialer, writerConf.Connection().Bootstrap)
+	writer, err := producer.NewWriter(logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t)), writerDialer, writerConf.Connection().Bootstrap)
 	assert.Nil(t, err)
 
 	// Endpoint
@@ -73,7 +73,7 @@ func TestSaneDefaults(t *testing.T) {
 
 func TestSaneDefaultsFallback(t *testing.T) {
 	writer, err := producer.NewWriter(
-		logMocks.NewLoggerMockedAll(), writerDialer, writerConf.Connection().Bootstrap,
+		logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t)), writerDialer, writerConf.Connection().Bootstrap,
 		producer.WithBatch(0, time.Microsecond),
 	)
 	assert.Nil(t, err)
@@ -89,7 +89,7 @@ func TestWithBatch(t *testing.T) {
 	)
 
 	writer, err := producer.NewWriter(
-		logMocks.NewLoggerMockedAll(), writerDialer, writerConf.Connection().Bootstrap,
+		logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t)), writerDialer, writerConf.Connection().Bootstrap,
 		producer.WithBatch(batchSize, batchInterval),
 	)
 	assert.Nil(t, err)
@@ -101,7 +101,7 @@ func TestWithBatch(t *testing.T) {
 
 func TestWithAsyncWrites(t *testing.T) {
 	writer, err := producer.NewWriter(
-		logMocks.NewLoggerMockedAll(), writerDialer, writerConf.Connection().Bootstrap,
+		logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t)), writerDialer, writerConf.Connection().Bootstrap,
 		producer.WithAsyncWrites(),
 	)
 

--- a/pkg/kernel/kernel_test.go
+++ b/pkg/kernel/kernel_test.go
@@ -69,7 +69,7 @@ func (s *KernelTestSuite) SetupTest() {
 
 func (s *KernelTestSuite) TestHangingModule() {
 	timeout(s.T(), time.Second*3, func(t *testing.T) {
-		logger := logMocks.NewLoggerMockedAll()
+		logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 		options := []kernel.Option{
 			s.mockExitHandler(kernel.ExitCodeErr),

--- a/pkg/kvstore/chain_test.go
+++ b/pkg/kvstore/chain_test.go
@@ -457,7 +457,7 @@ func nilFactory[T any](_ kvstore.ElementFactory[T], _ *kvstore.Settings) (kvstor
 }
 
 func buildTestableChainStore[T any](missingCacheEnabled bool) (kvstore.KvStore[T], *kvStoreMocks.KvStore[T], *kvStoreMocks.KvStore[T]) {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll)
 
 	element0 := new(kvStoreMocks.KvStore[T])
 	element1 := new(kvStoreMocks.KvStore[T])

--- a/pkg/log/mocks/factory.go
+++ b/pkg/log/mocks/factory.go
@@ -1,52 +1,265 @@
 package mocks
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"slices"
+	"sync"
+	"testing"
+	"time"
 
+	"github.com/justtrackio/gosoline/pkg/funk"
 	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/justtrackio/gosoline/pkg/mdl"
+	"github.com/stretchr/objx"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"golang.org/x/exp/maps"
 )
 
-func NewLoggerMock() *Logger {
-	logger := new(Logger)
+type Mock interface {
+	String() string
+	TestData() objx.Map
+	Test(t mock.TestingT)
+	On(methodName string, arguments ...interface{}) *mock.Call
+	Called(arguments ...interface{}) mock.Arguments
+	MethodCalled(methodName string, arguments ...interface{}) mock.Arguments
+	AssertExpectations(t mock.TestingT) bool
+	AssertNumberOfCalls(t mock.TestingT, methodName string, expectedCalls int) bool
+	AssertCalled(t mock.TestingT, methodName string, arguments ...interface{}) bool
+	AssertNotCalled(t mock.TestingT, methodName string, arguments ...interface{}) bool
+	IsMethodCallable(t mock.TestingT, methodName string, arguments ...interface{}) bool
+}
 
-	logger.On("WithChannel", mock.AnythingOfType("string")).Return(logger).Maybe()
-	logger.On("WithContext", mock.Anything).Return(logger).Maybe()
-	logger.On("WithFields", mock.Anything).Return(logger).Maybe()
+type LoggerMock interface {
+	log.Logger
+	Mock
+	EXPECT() *Logger_Expecter
+}
+
+type loggerMockOptions struct {
+	t              *testing.T
+	mockUntilLevel *int
+}
+
+type LoggerMockOption func(*loggerMockOptions)
+
+type loggerMock struct {
+	*Logger
+	t              *testing.T
+	currentChannel string
+	currentFields  log.Fields
+	lck            *sync.Mutex
+	pendingLogs    map[string][]pendingLogMessage
+}
+
+type pendingLogMessage struct {
+	message   string
+	level     string
+	channel   string
+	fields    log.Fields
+	timestamp time.Time
+}
+
+func (l *loggerMock) WithChannel(channel string) log.Logger {
+	// forward potential calls to the underlying mock if we expect some
+	if _, ok := funk.FindFirstFunc(l.Logger.ExpectedCalls, func(call *mock.Call) bool {
+		return call.Method == "WithChannel"
+	}); ok {
+		l.Logger.WithChannel(channel)
+	}
+
+	return &loggerMock{
+		Logger:         l.Logger,
+		t:              l.t,
+		currentChannel: channel,
+		currentFields:  l.currentFields,
+		lck:            l.lck,
+		pendingLogs:    l.pendingLogs,
+	}
+}
+
+func (l *loggerMock) WithContext(ctx context.Context) log.Logger {
+	// forward potential calls to the underlying mock if we expect some
+	if _, ok := funk.FindFirstFunc(l.Logger.ExpectedCalls, func(call *mock.Call) bool {
+		return call.Method == "WithContext"
+	}); ok {
+		l.Logger.WithContext(ctx)
+	}
+
+	contextFields := log.ContextFieldsResolver(ctx)
+
+	return l.WithFields(contextFields)
+}
+
+func (l *loggerMock) WithFields(fields log.Fields) log.Logger {
+	// forward potential calls to the underlying mock if we expect some
+	if _, ok := funk.FindFirstFunc(l.Logger.ExpectedCalls, func(call *mock.Call) bool {
+		return call.Method == "WithFields"
+	}); ok {
+		l.Logger.WithFields(fields)
+	}
+
+	return &loggerMock{
+		Logger:         l.Logger,
+		t:              l.t,
+		currentChannel: l.currentChannel,
+		currentFields:  funk.MergeMaps(l.currentFields, fields),
+		lck:            l.lck,
+		pendingLogs:    l.pendingLogs,
+	}
+}
+
+// WithTestingT creates a LoggerMockOption that supplies the testing.T value to use for the logger. This enables the logger to fail the test instead
+// of panicking (which could be caught) if a non-mocked log level is used, print the logs in case of a failed test after the test, and automatically
+// assert any expectations for the created mock.
+func WithTestingT(t *testing.T) LoggerMockOption {
+	return func(options *loggerMockOptions) {
+		options.t = t
+	}
+}
+
+// WithMockUntilLevel creates a LoggerMockOption that mocks calls up to the given log level. All other calls will cause an error and fail the test.
+func WithMockUntilLevel(level int) LoggerMockOption {
+	return func(options *loggerMockOptions) {
+		options.mockUntilLevel = &level
+	}
+}
+
+// WithMockAll is a LoggerMockOption that mocks calls to all log levels.
+func WithMockAll(options *loggerMockOptions) {
+	options.mockUntilLevel = mdl.Box(log.PriorityError)
+}
+
+// NewLoggerMock creates a new logger mock with the given options.
+func NewLoggerMock(opts ...LoggerMockOption) LoggerMock {
+	var options loggerMockOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	var baseLogger *Logger
+	if options.t != nil {
+		baseLogger = NewLogger(options.t)
+	} else {
+		baseLogger = new(Logger)
+	}
+
+	logger := &loggerMock{
+		Logger:         baseLogger,
+		t:              options.t,
+		currentChannel: "main",
+		currentFields:  log.Fields{},
+		lck:            &sync.Mutex{},
+		pendingLogs:    map[string][]pendingLogMessage{},
+	}
+
+	if logger.t != nil {
+		logger.t.Cleanup(func() {
+			if !logger.t.Failed() {
+				return
+			}
+
+			logger.printLogs()
+		})
+	}
+
+	if options.mockUntilLevel != nil {
+		logger.mockLoggerMethod("Debug", log.LevelDebug, *options.mockUntilLevel >= log.PriorityDebug)
+		logger.mockLoggerMethod("Info", log.LevelInfo, *options.mockUntilLevel >= log.PriorityInfo)
+		logger.mockLoggerMethod("Warn", log.LevelWarn, *options.mockUntilLevel >= log.PriorityWarn)
+		logger.mockLoggerMethod("Error", log.LevelError, *options.mockUntilLevel >= log.PriorityError)
+	}
 
 	return logger
 }
 
-func NewLoggerMockedAll() *Logger {
-	return NewLoggerMockedUntilLevel(log.PriorityError)
+// NewLoggerMockedAll is the same as NewLoggerMock(WithMockAll).
+//
+// Deprecated: use NewLoggerMock(WithMockAll) instead.
+func NewLoggerMockedAll(opts ...LoggerMockOption) LoggerMock {
+	return NewLoggerMock(append([]LoggerMockOption{WithMockAll}, opts...)...)
 }
 
-// return a logger mocked up to the given log level. All other calls will cause an error and fail the test.
-func NewLoggerMockedUntilLevel(level int) *Logger {
-	logger := NewLoggerMock()
-
-	mockLoggerMethod(logger, "Debug", log.LevelDebug, level >= log.PriorityDebug)
-	mockLoggerMethod(logger, "Info", log.LevelInfo, level >= log.PriorityInfo)
-	mockLoggerMethod(logger, "Warn", log.LevelWarn, level >= log.PriorityWarn)
-	mockLoggerMethod(logger, "Error", log.LevelError, level >= log.PriorityError)
-
-	return logger
+// NewLoggerMockedUntilLevel returns a logger mocked up to the given log level. All other calls will cause an error and fail the test.
+//
+// Deprecated: use NewLoggerMock(WithMockUntilLevel(level)) instead.
+func NewLoggerMockedUntilLevel(level int, opts ...LoggerMockOption) LoggerMock {
+	return NewLoggerMock(append([]LoggerMockOption{WithMockUntilLevel(level)}, opts...)...)
 }
 
-func mockLoggerMethod(logger *Logger, method string, level string, allowed bool) {
+func (l *loggerMock) mockLoggerMethod(method string, level string, allowed bool) {
 	anythings := make(mock.Arguments, 0)
-	f := inspectLogFunction(level, allowed)
+	f := l.inspectLogFunction(level, allowed)
 
 	for i := 0; i < 10; i++ {
 		anythings = append(anythings, mock.Anything)
-		logger.On(method, anythings...).Run(f).Return(logger).Maybe()
+		l.On(method, anythings...).Run(f).Return(l).Maybe()
 	}
 }
 
-func inspectLogFunction(level string, allowed bool) func(args mock.Arguments) {
+func (l *loggerMock) inspectLogFunction(level string, allowed bool) func(args mock.Arguments) {
 	return func(args mock.Arguments) {
+		msg := args.Get(0).(string)
+		msg = fmt.Sprintf(msg, args[1:]...)
+
+		if l.t != nil {
+			testName := l.t.Name()
+
+			l.lck.Lock()
+			l.pendingLogs[testName] = append(l.pendingLogs[testName], pendingLogMessage{
+				message:   msg,
+				level:     level,
+				channel:   l.currentChannel,
+				fields:    l.currentFields,
+				timestamp: time.Now().UTC(),
+			})
+			l.lck.Unlock()
+		}
+
 		if !allowed {
-			panic(fmt.Errorf("invalid log message '%s'. Logs of level %s are not allowed", args.Get(0), level))
+			if l.t != nil {
+				l.t.Fatalf("invalid log message %q. Logs of level %s are not allowed", msg, level)
+			} else {
+				panic(fmt.Errorf("invalid log message %q. Logs of level %s are not allowed", msg, level))
+			}
 		}
 	}
+}
+
+func (l *loggerMock) printLogs() {
+	_, err := fmt.Println("--- LOGS FROM FAILED TEST:")
+	assert.NoError(l.t, err, "Failed to write to stdout")
+
+	l.lck.Lock()
+	defer l.lck.Unlock()
+	testNames := maps.Keys(l.pendingLogs)
+	slices.Sort(testNames)
+
+	for _, testName := range testNames {
+		prefix := "    "
+		if len(testNames) > 1 {
+			prefix = fmt.Sprintf("    [%s] ", testName)
+		}
+
+		for _, pendingLog := range l.pendingLogs[testName] {
+			fieldsJson, err := json.MarshalIndent(pendingLog.fields, "", "    ")
+			assert.NoError(l.t, err, "failed to marshal logger fields as JSON")
+
+			_, err = fmt.Printf(
+				"%s%s %s: %s (channel = %s, fields = %s)\n",
+				prefix,
+				pendingLog.timestamp.Format("2006-01-02 15:04:05.999Z07:00"),
+				pendingLog.level,
+				pendingLog.message,
+				pendingLog.channel,
+				string(fieldsJson),
+			)
+			assert.NoError(l.t, err, "Failed to write to stdout")
+		}
+	}
+
+	_, err = fmt.Println("--- END OF LOGS")
+	assert.NoError(l.t, err, "Failed to write to stdout")
 }

--- a/pkg/mdlsub/publisher_test.go
+++ b/pkg/mdlsub/publisher_test.go
@@ -22,7 +22,7 @@ type PublisherTestSuite struct {
 }
 
 func (s *PublisherTestSuite) SetupTest() {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
 	s.producer = new(streamMocks.Producer)
 
 	s.publisher = mdlsub.NewPublisherWithInterfaces(logger, s.producer, &mdlsub.PublisherSettings{

--- a/pkg/metric/writer_cw_test.go
+++ b/pkg/metric/writer_cw_test.go
@@ -33,7 +33,7 @@ func TestOutput_Write_OutOfRange(t *testing.T) {
 func buildMocksAndWrite(now time.Time, metricTimeStamp time.Time) *cloudwatchMocks.Client {
 	testClock := clock.NewFakeClockAt(now)
 
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll)
 	cwClient := new(cloudwatchMocks.Client)
 
 	cwClient.On("PutMetricData", context.Background(), &cloudwatch.PutMetricDataInput{

--- a/pkg/metric/writer_prometheus_test.go
+++ b/pkg/metric/writer_prometheus_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Test_promWriter_WriteOne(t *testing.T) {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	tests := []struct {
 		name string
@@ -74,7 +74,7 @@ func Test_promWriter_WriteOne(t *testing.T) {
 }
 
 func Test_promWriter_Write(t *testing.T) {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	type fields struct {
 		unit  string
@@ -173,7 +173,7 @@ func Test_promWriter_Write(t *testing.T) {
 }
 
 func Test_promWriter_ExceedsLimit(t *testing.T) {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	registry := prometheus.NewRegistry()
 	w := metric.NewPromWriterWithInterfaces(logger, registry, "ns:test:exceedslimit", 1)

--- a/pkg/parquet/file_recorder_test.go
+++ b/pkg/parquet/file_recorder_test.go
@@ -29,7 +29,7 @@ func TestNopRecorder(t *testing.T) {
 }
 
 func TestS3FileRecorder(t *testing.T) {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	s3Client := new(s3Mocks.Client)
 
 	r := parquet.NewS3FileRecorderWithInterfaces(logger, s3Client)

--- a/pkg/redis/client_test.go
+++ b/pkg/redis/client_test.go
@@ -34,7 +34,7 @@ func (s *ClientWithMiniRedisTestSuite) SetupTest() {
 	}
 
 	s.settings = &redis.Settings{}
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
 	executor := exec.NewDefaultExecutor()
 
 	s.baseClient = baseRedis.NewClient(&baseRedis.Options{
@@ -689,7 +689,7 @@ type ClientWithMockTestSuite struct {
 
 func (s *ClientWithMockTestSuite) SetupTest() {
 	settings := &redis.Settings{}
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
 	executor := redis.NewBackoffExecutor(logger, settings.BackoffSettings, "test")
 
 	s.redisMock = redismock.NewMock()

--- a/pkg/stream/consumer_batch_test.go
+++ b/pkg/stream/consumer_batch_test.go
@@ -56,7 +56,7 @@ func (s *BatchConsumerTestSuite) SetupTest() {
 	s.callback = new(mocks.RunnableBatchConsumerCallback)
 
 	uuidGen := uuid.New()
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
 	tracer := tracing.NewNoopTracer()
 	mw := metricMocks.NewWriterMockedAll()
 	me := stream.NewMessageEncoder(&stream.MessageEncoderSettings{})

--- a/pkg/stream/consumer_test.go
+++ b/pkg/stream/consumer_test.go
@@ -83,7 +83,7 @@ func (s *ConsumerTestSuite) SetupTest() {
 	s.uuidGen = uuidMocks.NewUuid(s.T())
 	s.callback = mocks.NewRunnableConsumerCallback(s.T())
 
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
 	tracer := tracing.NewNoopTracer()
 	mw := metricMocks.NewWriterMockedAll()
 	me := stream.NewMessageEncoder(&stream.MessageEncoderSettings{})

--- a/pkg/stream/input_file_test.go
+++ b/pkg/stream/input_file_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestFileInput_Run(t *testing.T) {
 	configMock := new(configMocks.Config)
-	loggerMock := logMocks.NewLoggerMockedAll()
+	loggerMock := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	input := NewFileInput(configMock, loggerMock, FileSettings{
 		Filename: "testdata/file_input.json",

--- a/pkg/stream/input_sqs_test.go
+++ b/pkg/stream/input_sqs_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestSqsInput_Run(t *testing.T) {
 	ctx := context.Background()
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	var count int32
 	waitReadDone := make(chan struct{})
@@ -70,7 +70,7 @@ func TestSqsInput_Run(t *testing.T) {
 }
 
 func TestSqsInput_Run_Failure(t *testing.T) {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	count := 0
 	waitRunDone := make(chan struct{})

--- a/pkg/stream/output_channel_test.go
+++ b/pkg/stream/output_channel_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestOutputChannel_Simple(t *testing.T) {
-	logger := logMocks.NewLoggerMock()
+	logger := logMocks.NewLoggerMock(logMocks.WithTestingT(t))
 
 	msg := []stream.WritableMessage{
 		stream.NewMessage("hello"),
@@ -28,12 +28,10 @@ func TestOutputChannel_Simple(t *testing.T) {
 
 	_, ok = ch.Read()
 	assert.False(t, ok, "should not be able to read from empty channel")
-
-	logger.AssertExpectations(t)
 }
 
 func TestOutputChannel_WriteAfterClose(t *testing.T) {
-	logger := logMocks.NewLoggerMockedUntilLevel(log.PriorityWarn)
+	logger := logMocks.NewLoggerMock(logMocks.WithMockUntilLevel(log.PriorityWarn), logMocks.WithTestingT(t))
 
 	msg := []stream.WritableMessage{
 		stream.NewMessage("hello"),

--- a/pkg/stream/output_sns_test.go
+++ b/pkg/stream/output_sns_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Test_snsOutput_WriteOne(t *testing.T) {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	messages := []*stream.Message{
 		mkTestMessage(t, 1, make(map[string]string)),
@@ -45,7 +45,7 @@ func Test_snsOutput_WriteOne(t *testing.T) {
 }
 
 func Test_snsOutput_WriteBatch(t *testing.T) {
-	logger := logMocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	topic := &mocks.Topic{}
 	topic.On("PublishBatch", context.Background(), mock.AnythingOfType("[]string"), mock.AnythingOfType("[]map[string]string")).Return(nil).Once()
 

--- a/pkg/stream/output_sqs_test.go
+++ b/pkg/stream/output_sqs_test.go
@@ -89,7 +89,7 @@ func TestSqsOutput_WriteOne(t *testing.T) {
 	for test, data := range tests {
 		data := data
 		t.Run(test, func(t *testing.T) {
-			logger := logMocks.NewLoggerMockedAll()
+			logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 			queue := new(sqsMocks.Queue)
 			queue.On("Send", context.Background(), &data.expectedSqsMessage).Return(nil).Once()
@@ -252,7 +252,7 @@ func TestSqsOutput_Write(t *testing.T) {
 	for test, data := range tests {
 		data := data
 		t.Run(test, func(t *testing.T) {
-			logger := logMocks.NewLoggerMockedAll()
+			logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 			expectedSqsMessageChunks := funk.Chunk(data.expectedSqsMessage, stream.SqsOutputBatchSize)
 

--- a/pkg/stream/producer_daemon_partitioned_aggregator_test.go
+++ b/pkg/stream/producer_daemon_partitioned_aggregator_test.go
@@ -14,7 +14,7 @@ import (
 type producerDaemonPartitionedAggregatorTestSuite struct {
 	suite.Suite
 	ctx         context.Context
-	logger      *logMocks.Logger
+	logger      logMocks.LoggerMock
 	rand        *mocks.PartitionerRand
 	aggregators []*mocks.ProducerDaemonAggregator
 	aggregator  stream.ProducerDaemonAggregator
@@ -22,8 +22,8 @@ type producerDaemonPartitionedAggregatorTestSuite struct {
 
 func (s *producerDaemonPartitionedAggregatorTestSuite) SetupTest() {
 	s.ctx = context.Background()
-	s.logger = logMocks.NewLoggerMock()
-	s.rand = new(mocks.PartitionerRand)
+	s.logger = logMocks.NewLoggerMock(logMocks.WithTestingT(s.T()))
+	s.rand = mocks.NewPartitionerRand(s.T())
 	s.aggregators = []*mocks.ProducerDaemonAggregator{
 		new(mocks.ProducerDaemonAggregator),
 		new(mocks.ProducerDaemonAggregator),
@@ -55,8 +55,6 @@ func (s *producerDaemonPartitionedAggregatorTestSuite) SetupTest() {
 }
 
 func (s *producerDaemonPartitionedAggregatorTestSuite) TearDownTest() {
-	s.logger.AssertExpectations(s.T())
-	s.rand.AssertExpectations(s.T())
 	for _, aggregator := range s.aggregators {
 		aggregator.AssertExpectations(s.T())
 	}

--- a/pkg/stream/producer_daemon_test.go
+++ b/pkg/stream/producer_daemon_test.go
@@ -42,7 +42,7 @@ func (s *ProducerDaemonTestSuite) SetupTest() {
 }
 
 func (s *ProducerDaemonTestSuite) SetupDaemon(maxLogLevel int, batchSize int, aggregationSize int, interval time.Duration) {
-	logger := logMocks.NewLoggerMockedUntilLevel(maxLogLevel)
+	logger := logMocks.NewLoggerMock(logMocks.WithMockUntilLevel(maxLogLevel))
 	metric := metricMocks.NewWriterMockedAll()
 
 	s.output = new(streamMocks.Output)

--- a/pkg/tracing/context_span_test.go
+++ b/pkg/tracing/context_span_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 
 	"github.com/justtrackio/gosoline/pkg/cfg"
-	"github.com/justtrackio/gosoline/pkg/log/mocks"
+	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
 	"github.com/justtrackio/gosoline/pkg/tracing"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestContext(t *testing.T) {
-	logger := mocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
 	tracer, err := tracing.NewAwsTracerWithInterfaces(logger, cfg.AppId{}, &tracing.XRaySettings{Enabled: true})
 	assert.NoError(t, err, "we should be able to get a tracer")

--- a/pkg/tracing/tracer_aws_test.go
+++ b/pkg/tracing/tracer_aws_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/aws/aws-xray-sdk-go/strategy/sampling"
 	"github.com/justtrackio/gosoline/pkg/cfg"
-	"github.com/justtrackio/gosoline/pkg/log/mocks"
+	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
 	"github.com/justtrackio/gosoline/pkg/tracing"
 	"github.com/stretchr/testify/assert"
 )
@@ -59,7 +59,7 @@ func TestAwsTracer_StartSpanFromContextWithTrace(t *testing.T) {
 }
 
 func getTracer(t *testing.T) tracing.Tracer {
-	logger := mocks.NewLoggerMockedAll()
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 	tracer, err := tracing.NewAwsTracerWithInterfaces(logger, cfg.AppId{
 		Project:     "test_project",
 		Environment: "test_env",


### PR DESCRIPTION
Deprecated `NewLoggerMockedAll` and `NewLoggerMockedUntilLevel` and replaced them with options to `NewLoggerMock` with the options `WithMockUntilLevel` and `WithMockAll`. Also added the `WithTestingT`
option to supply a `testing.T` instance to the logger, allowing for automatic expectation assertions and printing recorded log messages if a test fails for easier debugging.

This commit also breaks backwards compatibility by changing the return value of these methods to the new `LoggerMock` interface, so if you store the mock in a field of a test suite or similar, you need to adjust the type.