### PR TITLE
fixtures: remove pointer receiver from NamedFixtures and allow purging tables which don't exist (yet) in ddb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/selm0/ladon v0.0.0-20231114080549-31144de4b38d
 	github.com/sha1sum/aws_signing_client v0.0.0-20170514202702-9088e4c7b34b
 	github.com/spf13/cast v1.6.0
+	github.com/stretchr/objx v0.5.0
 	github.com/stretchr/testify v1.8.3
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	github.com/xitongsys/parquet-go v1.6.2
@@ -176,7 +177,6 @@ require (
 	github.com/segmentio/go-snakecase v1.2.0 // indirect
 	github.com/sethvargo/go-retry v0.2.4 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
-	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect

--- a/pkg/fixtures/loader.go
+++ b/pkg/fixtures/loader.go
@@ -36,6 +36,8 @@ func (f *fixtureLoader) Load(ctx context.Context, fixtureSets []FixtureSet) erro
 	}
 
 	for _, fixtureSet := range fixtureSets {
+		f.logger.Info("loading fixtures for set %s", fixtureSet)
+
 		if err := fixtureSet.Write(ctx); err != nil {
 			return fmt.Errorf("failed to write fixtures: %w", err)
 		}

--- a/pkg/fixtures/named.go
+++ b/pkg/fixtures/named.go
@@ -34,24 +34,24 @@ type NamedFixture[T any] struct {
 type NamedFixtures[T any] []*NamedFixture[T]
 
 // All specifically returns a []any instead of a []T, so the fixture loader code doesn't complain that it can't cast a []T to []any
-func (l *NamedFixtures[T]) All() []any {
+func (l NamedFixtures[T]) All() []any {
 	values := make([]any, 0)
 
-	for _, named := range *l {
+	for _, named := range l {
 		values = append(values, named.Value)
 	}
 
 	return values
 }
 
-func (l *NamedFixtures[T]) Len() int {
-	return len(*l)
+func (l NamedFixtures[T]) Len() int {
+	return len(l)
 }
 
-func (l *NamedFixtures[T]) CountIf(f func(elem T) bool) int {
+func (l NamedFixtures[T]) CountIf(f func(elem T) bool) int {
 	count := 0
 
-	for _, elem := range *l {
+	for _, elem := range l {
 		if f(elem.Value) {
 			count++
 		}
@@ -60,8 +60,8 @@ func (l *NamedFixtures[T]) CountIf(f func(elem T) bool) int {
 	return count
 }
 
-func (l *NamedFixtures[T]) FindFirst(f func(elem T) bool) (T, bool) {
-	for _, elem := range *l {
+func (l NamedFixtures[T]) FindFirst(f func(elem T) bool) (T, bool) {
+	for _, elem := range l {
 		if f(elem.Value) {
 			return elem.Value, true
 		}
@@ -72,9 +72,9 @@ func (l *NamedFixtures[T]) FindFirst(f func(elem T) bool) (T, bool) {
 	return *(t), false
 }
 
-func (l *NamedFixtures[T]) FindAll(f func(elem T) bool) []T {
+func (l NamedFixtures[T]) FindAll(f func(elem T) bool) []T {
 	a := make([]T, 0)
-	for _, elem := range *l {
+	for _, elem := range l {
 		if f(elem.Value) {
 			a = append(a, elem.Value)
 		}
@@ -83,8 +83,8 @@ func (l *NamedFixtures[T]) FindAll(f func(elem T) bool) []T {
 	return a
 }
 
-func (l *NamedFixtures[T]) GetValueByName(name string) T {
-	fixture, ok := funk.FindFirstFunc(*l, func(item *NamedFixture[T]) bool {
+func (l NamedFixtures[T]) GetValueByName(name string) T {
+	fixture, ok := funk.FindFirstFunc(l, func(item *NamedFixture[T]) bool {
 		return item.Name == name
 	})
 	if !ok {
@@ -94,19 +94,19 @@ func (l *NamedFixtures[T]) GetValueByName(name string) T {
 	return fixture.Value
 }
 
-func (l *NamedFixtures[T]) GetValueById(id any) T {
+func (l NamedFixtures[T]) GetValueById(id any) T {
 	if l.Len() == 0 {
 		panic(fmt.Errorf("can not find id = %v in empty fixture set", id))
 	}
 
-	fixture, ok := funk.FindFirstFunc(*l, func(item *NamedFixture[T]) bool {
+	fixture, ok := funk.FindFirstFunc(l, func(item *NamedFixture[T]) bool {
 		valueId, ok := GetValueId(item.Value)
 
 		return ok && id == valueId
 	})
 
 	if !ok {
-		panic(fmt.Errorf("failed to get value by id = %v, type = %T", id, (*l)[0].Value))
+		panic(fmt.Errorf("failed to get value by id = %v, type = %T", id, (l)[0].Value))
 	}
 
 	return fixture.Value

--- a/pkg/fixtures/simple_fixture_set.go
+++ b/pkg/fixtures/simple_fixture_set.go
@@ -3,6 +3,8 @@ package fixtures
 import (
 	"context"
 	"fmt"
+
+	"github.com/justtrackio/gosoline/pkg/mdl"
 )
 
 type simpleFixtureSet[T any] struct {
@@ -46,4 +48,17 @@ func (c *simpleFixtureSet[T]) Write(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (c *simpleFixtureSet[T]) String() string {
+	var model any = mdl.Empty[T]()
+
+	if c.Fixtures.Len() > 0 {
+		model = c.Fixtures[0].Value
+		if kvModel, ok := model.(*KvStoreFixture); ok {
+			model = kvModel.Value
+		}
+	}
+
+	return fmt.Sprintf("%T(len=%d, type=%T)", c, c.Fixtures.Len(), model)
 }

--- a/test/guard/fixtures_test.go
+++ b/test/guard/fixtures_test.go
@@ -13,15 +13,48 @@ var metadata = &fixtures.MysqlPlainMetaData{
 
 var namedFixtures = fixtures.NamedFixtures[fixtures.MysqlPlainFixtureValues]{
 	{
-		Name:  "fixture_1",
-		Value: fixtures.MysqlPlainFixtureValues{"a97b104f-4d93-4c15-a97a-4e3173e75cde", `{"id": "a97b104f-4d93-4c15-a97a-4e3173e75cde", "effect": "allow", "actions": ["<.+>"], "subjects": ["r:1"], "resources": ["gsl:<.+>"], "conditions": {}, "description": "global - read and write access"}`},
+		Name: "fixture_1",
+		Value: fixtures.MysqlPlainFixtureValues{
+			"a97b104f-4d93-4c15-a97a-4e3173e75cde",
+			`{
+				"id": "a97b104f-4d93-4c15-a97a-4e3173e75cde",
+				"effect": "allow",
+				"actions": ["<.+>"],
+				"subjects": ["r:1"],
+				"resources": ["gsl:<.+>"],
+				"conditions": {},
+				"description": "global - read and write access"
+			}`,
+		},
 	},
 	{
-		Name:  "fixture_2",
-		Value: fixtures.MysqlPlainFixtureValues{"18a1de65-62eb-4af6-aab4-593d05ed30be", `{"id": "18a1de65-62eb-4af6-aab4-593d05ed30be", "effect": "allow", "actions": ["<.+>"], "subjects": ["r:2"], "resources": ["gsl:e:1:<.+>"], "conditions": {}, "description": "entity - read and write access"}`},
+		Name: "fixture_2",
+		Value: fixtures.MysqlPlainFixtureValues{
+			"18a1de65-62eb-4af6-aab4-593d05ed30be",
+			`{
+				"id": "18a1de65-62eb-4af6-aab4-593d05ed30be",
+				"effect": "allow",
+				"actions": ["<.+>"],
+				"subjects": ["r:2"],
+				"resources": ["gsl:e:1:<.+>"],
+				"conditions": {},
+				"description": "entity - read and write access"
+			}`,
+		},
 	},
 	{
-		Name:  "fixture_3",
-		Value: fixtures.MysqlPlainFixtureValues{"4ab80e96-22ea-469e-96d1-12b232bd4660", `{"id": "4ab80e96-22ea-469e-96d1-12b232bd4660", "effect": "allow", "actions": ["read"], "subjects": [], "resources": [], "conditions": {}, "description": "global - read access"}`},
+		Name: "fixture_3",
+		Value: fixtures.MysqlPlainFixtureValues{
+			"4ab80e96-22ea-469e-96d1-12b232bd4660",
+			`{
+				"id": "4ab80e96-22ea-469e-96d1-12b232bd4660",
+				"effect": "allow",
+				"actions": ["read"],
+				"subjects": [],
+				"resources": [],
+				"conditions": {},
+				"description": "global - read access"
+			}`,
+		},
 	},
 }


### PR DESCRIPTION
When purging a table in ddb, we delete and re-create it. However, this currently fails if the table doesn't exist yet. As deleting a non-existing table achieves our goal (of the table no longer existing), we don't need to treat this as an error.

Additionally, removing the pointer receiver from `fixtures.NamedFixtures` allows for easier usage of the type without impacting performance too much (if at all).