### PR TITLE
test: added option to disable all custom consumer retries

### DIFF
--- a/pkg/application/options.go
+++ b/pkg/application/options.go
@@ -58,6 +58,14 @@ func WithConfigEnvKeyReplacer(replacer *strings.Replacer) Option {
 	}
 }
 
+func WithConfigCallback(call func(config cfg.GosoConf) error) Option {
+	return func(app *App) {
+		app.addConfigOption(func(config cfg.GosoConf) error {
+			return call(config)
+		})
+	}
+}
+
 func WithConfigDebug(app *App) {
 	app.addKernelOption(func(config cfg.GosoConf) kernelPkg.Option {
 		return kernelPkg.WithMiddlewareFactory(func(ctx context.Context, config cfg.Config, logger log.Logger) (kernelPkg.Middleware, error) {

--- a/pkg/stream/consumer_base.go
+++ b/pkg/stream/consumer_base.go
@@ -44,20 +44,7 @@ type RunnableCallback interface {
 }
 
 type BaseConsumerCallback interface {
-	GetModel(attributes map[string]string) interface{}
-}
-
-type ConsumerSettings struct {
-	Input       string                `cfg:"input" default:"consumer" validate:"required"`
-	RunnerCount int                   `cfg:"runner_count" default:"1" validate:"min=1"`
-	Encoding    EncodingType          `cfg:"encoding" default:"application/json"`
-	IdleTimeout time.Duration         `cfg:"idle_timeout" default:"10s"`
-	Retry       ConsumerRetrySettings `cfg:"retry"`
-}
-
-type ConsumerRetrySettings struct {
-	Enabled bool   `cfg:"enabled"`
-	Type    string `cfg:"type" default:"sqs"`
+	GetModel(attributes map[string]string) any
 }
 
 type consumerData struct {
@@ -88,7 +75,7 @@ type baseConsumer struct {
 	id               string
 	name             string
 	settings         *ConsumerSettings
-	consumerCallback interface{}
+	consumerCallback any
 	processed        int32
 }
 
@@ -149,7 +136,7 @@ func NewBaseConsumerWithInterfaces(
 	encoder MessageEncoder,
 	retryInput Input,
 	retryHandler RetryHandler,
-	consumerCallback interface{},
+	consumerCallback any,
 	settings *ConsumerSettings,
 	name string,
 	appId cfg.AppId,
@@ -460,16 +447,4 @@ func getConsumerDefaultMetrics(name string) metric.Data {
 			Value: 0.0,
 		},
 	}
-}
-
-func ConfigurableConsumerKey(name string) string {
-	return fmt.Sprintf("stream.consumer.%s", name)
-}
-
-func readConsumerSettings(config cfg.Config, name string) *ConsumerSettings {
-	settings := &ConsumerSettings{}
-	key := ConfigurableConsumerKey(name)
-	config.UnmarshalKey(key, settings, cfg.UnmarshalWithDefaultForKey("encoding", defaultMessageBodyEncoding))
-
-	return settings
 }

--- a/pkg/stream/consumer_settings.go
+++ b/pkg/stream/consumer_settings.go
@@ -1,0 +1,40 @@
+package stream
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"golang.org/x/exp/maps"
+)
+
+type ConsumerSettings struct {
+	Input       string                `cfg:"input" default:"consumer" validate:"required"`
+	RunnerCount int                   `cfg:"runner_count" default:"1" validate:"min=1"`
+	Encoding    EncodingType          `cfg:"encoding" default:"application/json"`
+	IdleTimeout time.Duration         `cfg:"idle_timeout" default:"10s"`
+	Retry       ConsumerRetrySettings `cfg:"retry"`
+}
+
+type ConsumerRetrySettings struct {
+	Enabled bool   `cfg:"enabled"`
+	Type    string `cfg:"type" default:"sqs"`
+}
+
+func GetAllConsumerNames(config cfg.Config) []string {
+	consumerMap := config.GetStringMap("stream.consumer", map[string]any{})
+
+	return maps.Keys(consumerMap)
+}
+
+func ConfigurableConsumerKey(name string) string {
+	return fmt.Sprintf("stream.consumer.%s", name)
+}
+
+func readConsumerSettings(config cfg.Config, name string) *ConsumerSettings {
+	settings := &ConsumerSettings{}
+	key := ConfigurableConsumerKey(name)
+	config.UnmarshalKey(key, settings, cfg.UnmarshalWithDefaultForKey("encoding", defaultMessageBodyEncoding))
+
+	return settings
+}

--- a/pkg/test/suite/testcase_application.go
+++ b/pkg/test/suite/testcase_application.go
@@ -46,12 +46,15 @@ func buildTestCaseApplication(suite TestingSuite, method reflect.Method) (testCa
 }
 
 func runTestCaseApplication(t *testing.T, suite TestingSuite, suiteOptions *suiteOptions, environment *env.Environment, testcase func(aut *appUnderTest)) {
+	var appOptions []application.Option
+
 	for k, factory := range suiteOptions.appModules {
 		suiteOptions.appModules[k] = newEssentialModuleFactory(factory)
 	}
 
-	appOptions := append(suiteOptions.appOptions, []application.Option{
-		application.WithConfigMap(map[string]interface{}{
+	appOptions = append(appOptions, suiteOptions.appOptions...)
+	appOptions = append(appOptions, []application.Option{
+		application.WithConfigMap(map[string]any{
 			"env": "test",
 		}),
 		application.WithProducerDaemon,


### PR DESCRIPTION
This PR includes two new options for the `github.com/justtrackio/gosoline/pkg/test/suite` package:
#### WithConfigDebug
As the automatic config debug logs got dropped with one of the recent releases, which get printed on application start,
we added the `WithConfigDebug` option to enable it again if needed.

#### WithStreamConsumerRetryDisabled
This new option disables all custom retry handlers for consumers. Most of the tests don't need them and they could have some potential side effects one would want to avoid during test execution.
