### PR TITLE
[db-repo]: disable change history migration by default;

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/selm0/ladon v0.0.0-20231114080549-31144de4b38d
 	github.com/sha1sum/aws_signing_client v0.0.0-20170514202702-9088e4c7b34b
 	github.com/spf13/cast v1.6.0
+	github.com/stretchr/objx v0.5.0
 	github.com/stretchr/testify v1.8.3
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	github.com/xitongsys/parquet-go v1.6.2
@@ -179,7 +180,6 @@ require (
 	github.com/segmentio/go-snakecase v1.2.0 // indirect
 	github.com/sethvargo/go-retry v0.2.4 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
-	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect

--- a/pkg/db-repo/change_history_manager_test.go
+++ b/pkg/db-repo/change_history_manager_test.go
@@ -1,0 +1,75 @@
+package db_repo_test
+
+import (
+	"testing"
+
+	goSqlMock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/justtrackio/gosoline/pkg/db-repo"
+	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
+	"github.com/stretchr/testify/suite"
+)
+
+type changeHistoryManagerTestSuite struct {
+	suite.Suite
+
+	logger   *logMocks.Logger
+	dbClient goSqlMock.Sqlmock
+	manager  *db_repo.ChangeHistoryManager
+}
+
+type testModel struct {
+	db_repo.Model
+	Value string
+}
+
+func TestRunChangeHistoryManagerTestSuite(t *testing.T) {
+	suite.Run(t, new(changeHistoryManagerTestSuite))
+}
+
+func (s *changeHistoryManagerTestSuite) SetupTest() {
+	s.logger = logMocks.NewLogger(s.T())
+	s.logger.EXPECT().WithChannel("change_history_manager").Return(s.logger)
+
+	db, clientMock, err := goSqlMock.New()
+	s.Require().NoError(err)
+
+	orm, err := db_repo.NewOrmWithInterfaces(db, db_repo.OrmSettings{
+		Driver: "mysql",
+	})
+	s.Require().NoError(err)
+
+	s.dbClient = clientMock
+	s.manager = db_repo.NewChangeHistoryManagerWithInterfaces(s.logger, orm, &db_repo.ChangeHistoryManagerSettings{
+		TableSuffix: "history",
+	})
+}
+
+func (s *changeHistoryManagerTestSuite) TearDownTest() {
+	if err := s.dbClient.ExpectationsWereMet(); err != nil {
+		s.T().Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+func (s *changeHistoryManagerTestSuite) TestRunMigration_Disabled() {
+	s.logger.EXPECT().Info("creating change history setup").Once()
+	s.logger.EXPECT().Info("planned schema change: CREATE TABLE `test_models_history` (`change_history_action`  VARCHAR(8) NOT NULL DEFAULT 'insert',`change_history_action_at` DATETIME NULL DEFAULT CURRENT_TIMESTAMP,`change_history_revision` int ,`change_history_author_id` int,`id` int unsigned ,`updated_at` datetime,`created_at` datetime,`value` varchar(255), PRIMARY KEY (`change_history_revision`,`id`))").Once() //nolint:lll // test scenario
+	s.logger.EXPECT().Info("planned schema change: DROP TRIGGER IF EXISTS test_models_ai").Once()
+	s.logger.EXPECT().Info("planned schema change: DROP TRIGGER IF EXISTS test_models_au").Once()
+	s.logger.EXPECT().Info("planned schema change: DROP TRIGGER IF EXISTS test_models_bd").Once()
+	s.logger.EXPECT().Info("planned schema change: DROP TRIGGER IF EXISTS test_models_history_revai").Once()
+	s.logger.EXPECT().Info("planned schema change: CREATE TRIGGER test_models_ai AFTER INSERT ON `test_models` FOR EACH ROW \n\t\tINSERT INTO `test_models_history` (change_history_action,change_history_revision,change_history_action_at,`id`,`updated_at`,`created_at`,`value`,`change_history_author_id`) \n\t\t\tSELECT 'insert', NULL, NOW(), d.`id`, d.`updated_at`, d.`created_at`, d.`value`, @change_history_author_id \n\t\t\tFROM `test_models` AS d WHERE d.`id` = NEW.`id`").Once()                                                                                                                       //nolint:lll // test scenario
+	s.logger.EXPECT().Info("planned schema change: CREATE TRIGGER test_models_au AFTER UPDATE ON `test_models` FOR EACH ROW \n\t\tINSERT INTO `test_models_history` (change_history_action,change_history_revision,change_history_action_at,`id`,`updated_at`,`created_at`,`value`,`change_history_author_id`) \n\t\t\tSELECT 'update', NULL, NOW(), d.`id`, d.`updated_at`, d.`created_at`, d.`value`, @change_history_author_id \n\t\t\tFROM `test_models` AS d WHERE d.`id` = NEW.`id` AND (NOT (OLD.`id` <=> NEW.`id`) OR NOT (OLD.`created_at` <=> NEW.`created_at`) OR NOT (OLD.`value` <=> NEW.`value`))").Once() //nolint:lll // test scenario
+	s.logger.EXPECT().Info("planned schema change: CREATE TRIGGER test_models_bd BEFORE DELETE ON `test_models` FOR EACH ROW \n\t\tINSERT INTO `test_models_history` (change_history_action,change_history_revision,change_history_action_at,`id`,`updated_at`,`created_at`,`value`,`change_history_author_id`) \n\t\t\tSELECT 'delete', NULL, NOW(), d.`id`, d.`updated_at`, d.`created_at`, d.`value`, @change_history_author_id \n\t\t\tFROM `test_models` AS d WHERE d.`id` = OLD.`id`").Once()                                                                                                                      //nolint:lll // test scenario
+	s.logger.EXPECT().Info("planned schema change: CREATE TRIGGER test_models_history_revai BEFORE INSERT ON `test_models_history` FOR EACH ROW SET NEW.change_history_revision = (SELECT IFNULL(MAX(d.change_history_revision), 0) + 1 FROM `test_models_history` as d WHERE d.`id` = NEW.`id`);").Once()                                                                                                                                                                                                                                                                                                               //nolint:lll // test scenario
+	s.logger.EXPECT().Info("change history migration is disabled, please apply the changes manually").Once()
+
+	results := goSqlMock.NewRows([]string{"name"}).AddRow("test_models")
+	s.dbClient.ExpectQuery("SHOW TABLES FROM `` WHERE `Tables_in_` = \\?").WithArgs("test_models").WillReturnRows(results)
+
+	results = goSqlMock.NewRows([]string{"name"})
+	s.dbClient.ExpectQuery("SHOW TABLES FROM `` WHERE `Tables_in_` = \\?").WithArgs("test_models_history").WillReturnRows(results)
+
+	err := s.manager.RunMigration(&testModel{})
+	s.Require().Error(err)
+	s.Equal("cannot execute change history migration: missing schema migrations (disabled)", err.Error())
+}

--- a/test/db-repo/change_history/entity/config.test.yml
+++ b/test/db-repo/change_history/entity/config.test.yml
@@ -26,6 +26,7 @@ stream:
 
 change_history:
   table_suffix: histories
+  migration_enabled: true
 
 test:
   auto_detect:

--- a/test/db-repo/change_history/schema/config.test.yml
+++ b/test/db-repo/change_history/schema/config.test.yml
@@ -23,3 +23,4 @@ db:
 change_history:
   table_suffix: history_entries
   change_author_column: change_author
+  migration_enabled: true


### PR DESCRIPTION
The goose migrations don't work well if there are untracked changes happening through the change history auto-migration feature. To be able to track the change history tables through goose, I want to be able to deactivate the automatic execution of the change history schema updates.

By default, it's deactivated. When changes are detected, it prints the corresponding schema changes but throws an error to notify the user.