### PR TITLE
ipread: fixed module health issue with disabled refresh

### DIFF
--- a/pkg/ipread/refresh_module.go
+++ b/pkg/ipread/refresh_module.go
@@ -62,7 +62,8 @@ func (m *RefreshModule) IsHealthy(ctx context.Context) (bool, error) {
 
 func (m *RefreshModule) Run(ctx context.Context) (err error) {
 	defer func() {
-		m.healthy.Store(false)
+		// if automatic refresh is disabled, the module is still "healthy", as we don't need it
+		m.healthy.Store(!m.settings.Enabled)
 
 		if closeErr := m.provider.Close(); closeErr != nil {
 			err = multierror.Append(err, fmt.Errorf("can not close ipread provider: %w", closeErr))


### PR DESCRIPTION
The `ipread` package has a kernel module which handles automatic updates of the ip database.\
If the automatic refresh is disabled, the module exists after the initial load and marks the module as unhealthy, so that the app never gets healthy. To fix this, the health state of the module will be kept healthy on exit if refresh is disabled.