### PR TITLE
httpserver/sql: allow any value for the bool field of a filter if the field is unused

### DIFF
--- a/pkg/httpserver/sql/query_builder.go
+++ b/pkg/httpserver/sql/query_builder.go
@@ -118,7 +118,7 @@ func (qb baseQueryBuilder) build(inp *Input, dbQb db.QueryBuilder) error {
 
 	query, args, err := qb.buildFilter(inp.Filter)
 	if err != nil {
-		return err
+		return fmt.Errorf("can not build filter: %w", err)
 	}
 
 	if qb.metadata.TableName == "" {
@@ -245,8 +245,8 @@ func (qb baseQueryBuilder) buildFilter(filter Filter) (where string, args []any,
 		args = append(args, groupArgs...)
 	}
 
-	if !strings.EqualFold(filter.Bool, BoolAnd) && !strings.EqualFold(filter.Bool, BoolOr) {
-		return "", nil, fmt.Errorf("invalid boolean: %s", filter.Bool)
+	if !strings.EqualFold(filter.Bool, BoolAnd) && !strings.EqualFold(filter.Bool, BoolOr) && len(matchesWhere) > 1 {
+		return "", nil, fmt.Errorf(`invalid boolean: %q, should be either "AND" or "OR"`, filter.Bool)
 	}
 
 	operator := fmt.Sprintf(" %s ", filter.Bool)
@@ -300,8 +300,8 @@ func (qb baseQueryBuilder) buildFilterValues(match FilterMatch) (where string, a
 		args = append(args, a...)
 	}
 
-	if !strings.EqualFold(mapping.Bool(), BoolAnd) && !strings.EqualFold(mapping.Bool(), BoolOr) {
-		return "", nil, fmt.Errorf("invalid boolean: %s", mapping.Bool())
+	if !strings.EqualFold(mapping.Bool(), BoolAnd) && !strings.EqualFold(mapping.Bool(), BoolOr) && len(stmts) > 1 {
+		return "", nil, fmt.Errorf(`invalid boolean: %q, should be either "AND" or "OR"`, mapping.Bool())
 	}
 
 	b := fmt.Sprintf(" %s ", mapping.Bool())

--- a/pkg/httpserver/sql/query_builder_test.go
+++ b/pkg/httpserver/sql/query_builder_test.go
@@ -380,7 +380,11 @@ func TestListQueryBuilder_BuildSqlInjectionBool(t *testing.T) {
 	lqb := sql.NewOrmQueryBuilder(metadata)
 	qb, err := lqb.Build(inp)
 
-	assert.EqualError(t, err, "invalid boolean: AND (SELECT password FROM admins where id = 42) = 'hunter2' AND")
+	assert.EqualError(
+		t,
+		err,
+		`can not build filter: invalid boolean: "AND (SELECT password FROM admins where id = 42) = 'hunter2' AND", should be either "AND" or "OR"`,
+	)
 	assert.Equal(t, db_repo.NewQueryBuilder(), qb)
 }
 
@@ -424,7 +428,11 @@ func TestListQueryBuilder_BuildSqlInjectionNestedBool(t *testing.T) {
 	lqb := sql.NewOrmQueryBuilder(metadata)
 	qb, err := lqb.Build(inp)
 
-	assert.EqualError(t, err, "invalid boolean: AND (SELECT password FROM admins where id = 42) = 'hunter2' AND")
+	assert.EqualError(
+		t,
+		err,
+		`can not build filter: invalid boolean: "AND (SELECT password FROM admins where id = 42) = 'hunter2' AND", should be either "AND" or "OR"`,
+	)
 	assert.Equal(t, db_repo.NewQueryBuilder(), qb)
 }
 
@@ -457,6 +465,10 @@ func TestListQueryBuilder_BuildSqlInjectionOperator(t *testing.T) {
 	lqb := sql.NewOrmQueryBuilder(metadata)
 	qb, err := lqb.Build(inp)
 
-	assert.EqualError(t, err, `error building filter for column foo: invalid operator "IN (SELECT username FROM admins WHERE id = 42) AND 1 ="`)
+	assert.EqualError(
+		t,
+		err,
+		`can not build filter: error building filter for column foo: invalid operator "IN (SELECT username FROM admins WHERE id = 42) AND 1 ="`,
+	)
 	assert.Equal(t, db_repo.NewQueryBuilder(), qb)
 }


### PR DESCRIPTION
This fixes the use of an empty filter. The previous commit would result in complaints about wrong booleans being used we required it to be set to "AND" or "OR".