### PR TITLE
stream: delay context cancels for retry messages to ensure we can write them to the retry queue

### DIFF
--- a/pkg/kernel/kernel.go
+++ b/pkg/kernel/kernel.go
@@ -62,8 +62,7 @@ type kernel struct {
 }
 
 func newKernel(ctx context.Context, config cfg.Config, logger log.Logger) (*kernel, error) {
-	settings := &Settings{}
-	config.UnmarshalKey("kernel", settings)
+	settings := readSettings(config)
 
 	k := &kernel{
 		logger: logger.WithChannel("kernel"),
@@ -275,7 +274,7 @@ func (k *kernel) waitStopped() {
 			err := fmt.Errorf("kernel was not able to shutdown in %v", k.killTimeout)
 			k.logger.Error("kernel shutdown seems to be blocking.. exiting...: %w", err)
 
-			// we don't need to iterate in order, but doing so is much nicer, so lets do it
+			// we don't need to iterate in order, but doing so is much nicer, so let's do it
 			for _, stageIndex := range k.stages.getIndices() {
 				s := k.stages[stageIndex]
 				for name, ms := range s.modules.modules {
@@ -310,4 +309,11 @@ func (k *kernel) waitAllStagesDone() conc.SignalOnce {
 	}()
 
 	return done
+}
+
+func readSettings(config cfg.Config) Settings {
+	settings := Settings{}
+	config.UnmarshalKey("kernel", &settings)
+
+	return settings
 }

--- a/pkg/kernel/stage.go
+++ b/pkg/kernel/stage.go
@@ -42,8 +42,7 @@ type stage struct {
 func newStage(ctx context.Context, config cfg.Config, logger log.Logger, index int) *stage {
 	cfn, ctx := coffin.WithContext(ctx)
 
-	settings := &Settings{}
-	config.UnmarshalKey("kernel", settings)
+	settings := readSettings(config)
 
 	return &stage{
 		cfn:                 cfn,

--- a/pkg/stream/consumer_batch_test.go
+++ b/pkg/stream/consumer_batch_test.go
@@ -64,7 +64,7 @@ func (s *BatchConsumerTestSuite) SetupTest() {
 	retryHandler := stream.NewRetryHandlerNoopWithInterfaces()
 
 	ticker := time.NewTicker(time.Second)
-	settings := &stream.ConsumerSettings{
+	settings := stream.ConsumerSettings{
 		Input:       "test",
 		RunnerCount: 1,
 		IdleTimeout: time.Second,

--- a/pkg/stream/consumer_settings_test.go
+++ b/pkg/stream/consumer_settings_test.go
@@ -1,0 +1,81 @@
+package stream_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/stream"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadConsumerSettings_Empty(t *testing.T) {
+	config := cfg.New()
+	settings := stream.ReadConsumerSettings(config, "defaultConsumer")
+	assert.Equal(t, stream.ConsumerSettings{
+		Input:       "consumer",
+		RunnerCount: 1,
+		Encoding:    "application/json",
+		IdleTimeout: time.Second * 10,
+		Retry: stream.ConsumerRetrySettings{
+			Enabled:   false,
+			Type:      "sqs",
+			GraceTime: time.Second * 10,
+		},
+	}, settings)
+}
+
+func TestReadConsumerSettings_ReadKernelKillTimeout(t *testing.T) {
+	config := cfg.New(map[string]any{
+		"kernel": map[string]any{
+			"kill_timeout": "5s",
+		},
+	})
+	settings := stream.ReadConsumerSettings(config, "defaultConsumer")
+	assert.Equal(t, stream.ConsumerSettings{
+		Input:       "consumer",
+		RunnerCount: 1,
+		Encoding:    "application/json",
+		IdleTimeout: time.Second * 10,
+		Retry: stream.ConsumerRetrySettings{
+			Enabled:   false,
+			Type:      "sqs",
+			GraceTime: time.Second * 5,
+		},
+	}, settings)
+}
+
+func TestReadConsumerSettings_SpecifyAll(t *testing.T) {
+	config := cfg.New(map[string]any{
+		"stream": map[string]any{
+			"consumer": map[string]any{
+				"defaultConsumer": map[string]any{
+					"input":        "my_consumer",
+					"runner_count": 2,
+					"encoding":     "application/protobuf",
+					"idle_timeout": "5s",
+					"retry": map[string]any{
+						"enabled":    true,
+						"type":       "kinesis",
+						"grace_time": "3s",
+					},
+				},
+			},
+		},
+		"kernel": map[string]any{
+			"kill_timeout": "5s",
+		},
+	})
+	settings := stream.ReadConsumerSettings(config, "defaultConsumer")
+	assert.Equal(t, stream.ConsumerSettings{
+		Input:       "my_consumer",
+		RunnerCount: 2,
+		Encoding:    "application/protobuf",
+		IdleTimeout: time.Second * 5,
+		Retry: stream.ConsumerRetrySettings{
+			Enabled:   true,
+			Type:      "kinesis",
+			GraceTime: time.Second * 3,
+		},
+	}, settings)
+}

--- a/test/stream/retry_handler_sqs/config.dist.yml
+++ b/test/stream/retry_handler_sqs/config.dist.yml
@@ -15,7 +15,7 @@ stream:
       type: sqs
       id: consumer
       target_queue_id: test
-      wait_time: 5
+      wait_time: 1
       visibility_timeout: 2
       runner_count: 1
       redrive_policy:


### PR DESCRIPTION
If we get a context cancel while processing a message from something like kinesis, writing to the retry queue would also happen on a canceled context, failing immediately and loosing our message. We need some small delay for the cancel to prevent this.