### PR TITLE
test/suite: accept maps of tests and run them as sub-tests

### DIFF
--- a/pkg/test/suite/testcase_application.go
+++ b/pkg/test/suite/testcase_application.go
@@ -35,7 +35,7 @@ func isTestCaseApplication(method reflect.Method) bool {
 	return actualType1 == expectedType
 }
 
-func buildTestCaseApplication(suite TestingSuite, method reflect.Method) (testCaseRunner, error) {
+func buildTestCaseApplication(_ TestingSuite, method reflect.Method) (testCaseRunner, error) {
 	return func(t *testing.T, suite TestingSuite, suiteOptions *suiteOptions, environment *env.Environment) {
 		suite.SetT(t)
 
@@ -45,7 +45,7 @@ func buildTestCaseApplication(suite TestingSuite, method reflect.Method) (testCa
 	}, nil
 }
 
-func runTestCaseApplication(t *testing.T, suite TestingSuite, suiteOptions *suiteOptions, environment *env.Environment, testcase func(aut *appUnderTest)) {
+func runTestCaseApplication(t *testing.T, _ TestingSuite, suiteOptions *suiteOptions, environment *env.Environment, testcase func(aut *appUnderTest)) {
 	var appOptions []application.Option
 
 	for k, factory := range suiteOptions.appModules {

--- a/pkg/test/suite/testcase_application.go
+++ b/pkg/test/suite/testcase_application.go
@@ -2,6 +2,7 @@ package suite
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -14,25 +15,35 @@ import (
 )
 
 func init() {
-	testCaseDefinitions["application"] = testCaseDefinition{
-		matcher: isTestCaseApplication,
-		builder: buildTestCaseApplication,
-	}
+	registerTestCaseDefinition("application", isTestCaseApplication, buildTestCaseApplication)
 }
 
-func isTestCaseApplication(method reflect.Method) bool {
+const expectedTestCaseApplicationSignature = "func (s TestingSuite) TestFunc(AppUnderTest)"
+
+func isTestCaseApplication(method reflect.Method) error {
 	if method.Func.Type().NumIn() != 2 {
-		return false
+		return fmt.Errorf("expected %q, but function has %d arguments", expectedTestCaseApplicationSignature, method.Func.Type().NumIn())
 	}
 
 	if method.Func.Type().NumOut() != 0 {
-		return false
+		return fmt.Errorf("expected %q, but function has %d return values", expectedTestCaseApplicationSignature, method.Func.Type().NumOut())
+	}
+
+	actualType0 := method.Func.Type().In(0)
+	expectedType0 := reflect.TypeOf((*TestingSuite)(nil)).Elem()
+
+	if !actualType0.Implements(expectedType0) {
+		return fmt.Errorf("expected %q, but first argument type/receiver type is %s", expectedTestCaseApplicationSignature, actualType0.String())
 	}
 
 	actualType1 := method.Func.Type().In(1)
-	expectedType := reflect.TypeOf((*AppUnderTest)(nil)).Elem()
+	expectedType1 := reflect.TypeOf((*AppUnderTest)(nil)).Elem()
 
-	return actualType1 == expectedType
+	if actualType1 != expectedType1 {
+		return fmt.Errorf("expected %q, but last argument type is %s", expectedTestCaseApplicationSignature, actualType1.String())
+	}
+
+	return nil
 }
 
 func buildTestCaseApplication(_ TestingSuite, method reflect.Method) (testCaseRunner, error) {

--- a/pkg/test/suite/testcase_application_test.go
+++ b/pkg/test/suite/testcase_application_test.go
@@ -1,0 +1,45 @@
+package suite_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/kernel"
+	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/justtrackio/gosoline/pkg/test/suite"
+	"github.com/stretchr/testify/assert"
+)
+
+type ApplicationTestSuite struct {
+	kernel.EssentialModule
+	suite.Suite
+	called bool
+}
+
+func TestApplicationTestSuite(t *testing.T) {
+	var s ApplicationTestSuite
+	suite.Run(t, &s)
+	assert.True(t, s.called)
+}
+
+func (s *ApplicationTestSuite) SetupSuite() []suite.Option {
+	return []suite.Option{
+		suite.WithLogLevel("info"),
+		suite.WithModule("testModule", func(ctx context.Context, config cfg.Config, logger log.Logger) (kernel.Module, error) {
+			return s, nil
+		}),
+		suite.WithSharedEnvironment(),
+	}
+}
+
+func (s *ApplicationTestSuite) Run(_ context.Context) error {
+	return nil
+}
+
+func (s *ApplicationTestSuite) TestApp(app suite.AppUnderTest) {
+	defer app.WaitDone()
+	defer app.Stop()
+
+	s.called = true
+}

--- a/pkg/test/suite/testcase_base.go
+++ b/pkg/test/suite/testcase_base.go
@@ -1,6 +1,7 @@
 package suite
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -8,21 +9,31 @@ import (
 )
 
 func init() {
-	testCaseDefinitions["base"] = testCaseDefinition{
-		matcher: isTestCaseBase,
-		builder: buildTestCaseBase,
-	}
+	registerTestCaseDefinition("base", isTestCaseBase, buildTestCaseBase)
 }
 
-func isTestCaseBase(method reflect.Method) bool {
+const expectedTestCaseBaseSignature = "func (s TestingSuite) TestFunc()"
+
+func isTestCaseBase(method reflect.Method) error {
 	if method.Func.Type().NumIn() != 1 {
-		return false
+		return fmt.Errorf("expected %q, but function has %d arguments", expectedTestCaseBaseSignature, method.Func.Type().NumIn())
 	}
 
-	return method.Func.Type().NumOut() == 0
+	if method.Func.Type().NumOut() != 0 {
+		return fmt.Errorf("expected %q, but function has %d return values", expectedTestCaseBaseSignature, method.Func.Type().NumOut())
+	}
+
+	actualType0 := method.Func.Type().In(0)
+	expectedType0 := reflect.TypeOf((*TestingSuite)(nil)).Elem()
+
+	if !actualType0.Implements(expectedType0) {
+		return fmt.Errorf("expected %q, but first argument type/receiver type is %s", expectedTestCaseBaseSignature, actualType0.String())
+	}
+
+	return nil
 }
 
-func buildTestCaseBase(suite TestingSuite, method reflect.Method) (testCaseRunner, error) {
+func buildTestCaseBase(_ TestingSuite, method reflect.Method) (testCaseRunner, error) {
 	return func(t *testing.T, suite TestingSuite, suiteOptions *suiteOptions, environment *env.Environment) {
 		suite.SetT(t)
 		method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})

--- a/pkg/test/suite/testcase_base_test.go
+++ b/pkg/test/suite/testcase_base_test.go
@@ -1,0 +1,30 @@
+package suite_test
+
+import (
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/test/suite"
+	"github.com/stretchr/testify/assert"
+)
+
+type BaseTestSuite struct {
+	suite.Suite
+	called bool
+}
+
+func TestBaseTestSuite(t *testing.T) {
+	var s BaseTestSuite
+	suite.Run(t, &s)
+	assert.True(t, s.called)
+}
+
+func (s *BaseTestSuite) SetupSuite() []suite.Option {
+	return []suite.Option{
+		suite.WithLogLevel("info"),
+		suite.WithSharedEnvironment(),
+	}
+}
+
+func (s *BaseTestSuite) TestBase() {
+	s.called = true
+}

--- a/pkg/test/suite/testcase_httpserver_extended.go
+++ b/pkg/test/suite/testcase_httpserver_extended.go
@@ -266,12 +266,14 @@ func runHttpServerExtendedTestsMap(suite TestingSuite, testCases map[string]ToHt
 
 func runHttpServerExtendedTests(suite TestingSuite, getTestCases func() []*HttpserverTestCase) (testCaseRunner, error) {
 	return runTestCaseHttpserver(suite, func(suite TestingSuite, app *appUnderTest, client *resty.Client) {
-		runTestCaseInSuite(suite, func() {
+		runTestCaseInSuite(suite.T(), suite, func() {
 			testCases := funk.Filter(getTestCases(), func(elem *HttpserverTestCase) bool {
 				return elem != nil
 			})
 
 			if len(testCases) == 0 {
+				app.Stop()
+				app.WaitDone()
 				suite.T().SkipNow()
 			}
 

--- a/pkg/test/suite/testcase_httpserver_extended_test.go
+++ b/pkg/test/suite/testcase_httpserver_extended_test.go
@@ -48,7 +48,7 @@ func (p *TestInput) FromMessage(message proto.Message) error {
 func TestGatewayTestSuite(t *testing.T) {
 	var s GatewayTestSuite
 	suite.Run(t, &s)
-	assert.Equal(t, int32(6), s.totalTests)
+	assert.Equal(t, int32(16), s.totalTests)
 }
 
 func (s *GatewayTestSuite) SetupSuite() []suite.Option {
@@ -75,12 +75,62 @@ func (s *GatewayTestSuite) SetupApiDefinitions() httpserver.Definer {
 	}
 }
 
+func (s *GatewayTestSuite) TestCaseMap() map[string]*suite.HttpserverTestCase {
+	return map[string]*suite.HttpserverTestCase{
+		"AnotherSingleTest": s.createTestCase(),
+		"EmptyTest":         nil,
+	}
+}
+
+func (s *GatewayTestSuite) TestCasesMap() map[string][]*suite.HttpserverTestCase {
+	return map[string][]*suite.HttpserverTestCase{
+		"AnotherSingleTest": {
+			s.createTestCase(),
+		},
+		"AnotherMultipleTests": {
+			s.createTestCase(),
+			s.createProtobufTestCase(),
+			s.createFileTestCase(),
+		},
+		"EmptyTest": {},
+		"AnotherSkippedTest": {
+			nil,
+		},
+	}
+}
+
+func (s *GatewayTestSuite) TestCasesMapWithProvider() map[string]suite.ToHttpserverTestCaseList {
+	return map[string]suite.ToHttpserverTestCaseList{
+		"AnotherSingleTest": s.createTestCase(),
+		"AnotherMultipleTests": suite.HttpserverTestCaseListProvider(func() []*suite.HttpserverTestCase {
+			return []*suite.HttpserverTestCase{
+				s.createTestCase(),
+				s.createProtobufTestCase(),
+				s.createFileTestCase(),
+			}
+		}),
+		"Nil": nil,
+	}
+}
+
+func (s *GatewayTestSuite) TestCasesEmptyMap() map[string][]*suite.HttpserverTestCase {
+	return map[string][]*suite.HttpserverTestCase{}
+}
+
 func (s *GatewayTestSuite) TestSingleTest() *suite.HttpserverTestCase {
 	return s.createTestCase()
 }
 
 func (s *GatewayTestSuite) TestSkipped() *suite.HttpserverTestCase {
 	return nil
+}
+
+func (s *GatewayTestSuite) TestNilProvider() suite.ToHttpserverTestCaseList {
+	return nil
+}
+
+func (s *GatewayTestSuite) TestProvider() suite.ToHttpserverTestCaseList {
+	return s.createTestCase()
 }
 
 func (s *GatewayTestSuite) TestMultipleTests() []*suite.HttpserverTestCase {

--- a/pkg/test/suite/testcase_httpserver_extended_test.go
+++ b/pkg/test/suite/testcase_httpserver_extended_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/go-resty/resty/v2"
 	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/funk"
 	"github.com/justtrackio/gosoline/pkg/httpserver"
 	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/justtrackio/gosoline/pkg/test/suite"
@@ -69,6 +70,15 @@ func (s *GatewayTestSuite) SetupApiDefinitions() httpserver.Definer {
 			contentType := ginCtx.ContentType()
 
 			ginCtx.Data(http.StatusOK, contentType, body)
+		})
+
+		d.POST("/reverse", func(ginCtx *gin.Context) {
+			body, err := io.ReadAll(ginCtx.Request.Body)
+			s.NoError(err)
+
+			contentType := ginCtx.ContentType()
+
+			ginCtx.Data(http.StatusOK, contentType, funk.Reverse(body))
 		})
 
 		return d, nil

--- a/pkg/test/suite/testcase_httpserver_test.go
+++ b/pkg/test/suite/testcase_httpserver_test.go
@@ -1,0 +1,26 @@
+package suite_test
+
+import (
+	"net/http"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/justtrackio/gosoline/pkg/funk"
+	"github.com/justtrackio/gosoline/pkg/test/suite"
+)
+
+func (s *GatewayTestSuite) TestBase(app suite.AppUnderTest, client *resty.Client) error {
+	defer app.WaitDone()
+	defer app.Stop()
+
+	response, err := client.R().
+		SetBody("this is a test").
+		Execute(http.MethodPost, "/reverse")
+	if err != nil {
+		return err
+	}
+
+	s.Equal(http.StatusOK, response.StatusCode())
+	s.Equal(funk.Reverse([]byte("this is a test")), response.Body())
+
+	return nil
+}

--- a/pkg/test/suite/testcase_stream.go
+++ b/pkg/test/suite/testcase_stream.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/justtrackio/gosoline/pkg/funk"
 	"github.com/justtrackio/gosoline/pkg/test/env"
 	"github.com/stretchr/testify/assert"
 )
@@ -32,6 +33,20 @@ type StreamTestCase struct {
 	Assert func() error
 }
 
+type ToStreamTestCase interface {
+	ToTestCase() *StreamTestCase
+}
+
+type StreamTestCaseProvider func() *StreamTestCase
+
+func (f StreamTestCaseProvider) ToTestCase() *StreamTestCase {
+	return f()
+}
+
+func (c *StreamTestCase) ToTestCase() *StreamTestCase {
+	return c
+}
+
 func isTestCaseStream(method reflect.Method) bool {
 	if method.Func.Type().NumIn() != 1 {
 		return false
@@ -43,47 +58,132 @@ func isTestCaseStream(method reflect.Method) bool {
 
 	actualType0 := method.Func.Type().Out(0)
 	expectedType := reflect.TypeOf((*StreamTestCase)(nil))
+	expectedProviderType := reflect.TypeOf((*ToStreamTestCase)(nil)).Elem()
 
-	return actualType0 == expectedType
+	return actualType0 == expectedType || actualType0 == expectedProviderType || isTestCaseMapStream(method)
+}
+
+func isTestCaseMapStream(method reflect.Method) bool {
+	actualType0 := method.Func.Type().Out(0)
+	expectedMapType := reflect.TypeOf(map[string]*StreamTestCase{})
+	expectedProviderMapType := reflect.TypeOf(map[string]ToStreamTestCase{})
+
+	return actualType0 == expectedMapType ||
+		actualType0 == expectedProviderMapType
 }
 
 func buildTestCaseStream(suite TestingSuite, method reflect.Method) (testCaseRunner, error) {
-	return func(t *testing.T, suite TestingSuite, suiteOptions *suiteOptions, environment *env.Environment) {
-		suite.SetT(t)
+	if isTestCaseMapStream(method) {
+		out := method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})[0].Interface()
 
-		out := method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})
-		tc := out[0].Interface().(*StreamTestCase)
+		var providerMap map[string]ToStreamTestCase
 
-		runTestCaseApplication(t, suite, suiteOptions, environment, func(app *appUnderTest) {
-			for inputName, data := range tc.Input {
-				input := suite.Env().StreamInput(inputName)
+		switch testCases := out.(type) {
+		case map[string]*StreamTestCase:
+			providerMap = funk.MapValues(testCases, func(value *StreamTestCase) ToStreamTestCase {
+				return value
+			})
+		case map[string]ToStreamTestCase:
+			providerMap = testCases
+		}
 
-				for _, d := range data {
-					input.Publish(d.Body, d.Attributes)
-				}
+		return runStreamTestMap(providerMap)
+	}
 
-				input.Stop()
+	return runStreamTest(func() *StreamTestCase {
+		out := method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})[0].Interface()
+
+		switch tc := out.(type) {
+		case *StreamTestCase:
+			return tc
+		case ToStreamTestCase:
+			if tc != nil {
+				return tc.ToTestCase()
+			}
+		}
+
+		return nil
+	}), nil
+}
+
+func runStreamTestMap(testCases map[string]ToStreamTestCase) (testCaseRunner, error) {
+	testCaseRunners := make([]testCaseRunner, 0, len(testCases))
+
+	for name, testCasesProvider := range testCases {
+		name := name
+		testCasesProvider := testCasesProvider
+		runner := runStreamTest(func() *StreamTestCase {
+			if testCasesProvider == nil {
+				return nil
 			}
 
-			app.WaitDone()
-
-			for outputName, data := range tc.Output {
-				output := suite.Env().StreamOutput(outputName)
-
-				for i, d := range data {
-					model := d.Model
-					attrs := output.Unmarshal(i, model)
-
-					assert.Equal(t, d.ExpectedAttributes, attrs, "attributes do not match")
-					assert.Equal(t, d.ExpectedBody, model, "body does not match")
-				}
-			}
-
-			if tc.Assert != nil {
-				if err := tc.Assert(); err != nil {
-					assert.NoError(t, err, "there should be no error happening on assert")
-				}
-			}
+			return testCasesProvider.ToTestCase()
 		})
+
+		testCaseRunners = append(testCaseRunners, func(t *testing.T, suite TestingSuite, suiteOptions *suiteOptions, environment *env.Environment) {
+			t.Run(name, func(t *testing.T) {
+				runner(t, suite, suiteOptions, environment)
+			})
+		})
+	}
+
+	return func(t *testing.T, suite TestingSuite, suiteOptions *suiteOptions, environment *env.Environment) {
+		if len(testCaseRunners) == 0 {
+			t.SkipNow()
+		}
+
+		for _, testCaseRunner := range testCaseRunners {
+			testCaseRunner(t, suite, suiteOptions, environment)
+		}
 	}, nil
+}
+
+func runStreamTest(getTestCase func() *StreamTestCase) testCaseRunner {
+	return func(t *testing.T, suite TestingSuite, suiteOptions *suiteOptions, environment *env.Environment) {
+		runTestCaseApplication(t, suite, suiteOptions, environment, func(app *appUnderTest) {
+			runTestCaseInSuite(t, suite, func() {
+				tc := getTestCase()
+
+				if tc == nil {
+					app.Stop()
+					app.WaitDone()
+					t.SkipNow()
+				}
+
+				writeStreamTestInputData(tc, suite)
+				app.WaitDone()
+				assertStreamTestOutputs(tc, suite, t)
+			})
+		})
+	}
+}
+
+func writeStreamTestInputData(tc *StreamTestCase, suite TestingSuite) {
+	for inputName, data := range tc.Input {
+		input := suite.Env().StreamInput(inputName)
+
+		for _, d := range data {
+			input.Publish(d.Body, d.Attributes)
+		}
+
+		input.Stop()
+	}
+}
+
+func assertStreamTestOutputs(tc *StreamTestCase, suite TestingSuite, t *testing.T) {
+	for outputName, data := range tc.Output {
+		output := suite.Env().StreamOutput(outputName)
+
+		for i, d := range data {
+			model := d.Model
+			attrs := output.Unmarshal(i, model)
+
+			assert.Equal(t, d.ExpectedAttributes, attrs, "attributes do not match")
+			assert.Equal(t, d.ExpectedBody, model, "body does not match")
+		}
+	}
+
+	if tc.Assert != nil {
+		assert.NoError(t, tc.Assert(), "there should be no error happening on assert")
+	}
 }

--- a/pkg/test/suite/testcase_stream_test.go
+++ b/pkg/test/suite/testcase_stream_test.go
@@ -1,0 +1,168 @@
+package suite_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/justtrackio/gosoline/pkg/mdlsub"
+	"github.com/justtrackio/gosoline/pkg/stream"
+	"github.com/justtrackio/gosoline/pkg/test/suite"
+	"github.com/justtrackio/gosoline/pkg/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+type ConsumerTestSuite struct {
+	suite.Suite
+	expectedMessageIds []string
+	seenMessageIds     []string
+	publisher          mdlsub.Publisher
+}
+
+type TestMessage struct {
+	Id           string `json:"id"`
+	ShouldOutput bool   `json:"shouldOutput"`
+}
+
+func TestConsumerTestSuite(t *testing.T) {
+	var s ConsumerTestSuite
+	suite.Run(t, &s)
+	assert.Len(t, s.seenMessageIds, len(s.expectedMessageIds))
+
+	slices.Sort(s.expectedMessageIds)
+	slices.Sort(s.seenMessageIds)
+	assert.Equal(t, s.expectedMessageIds, s.seenMessageIds)
+}
+
+func (s *ConsumerTestSuite) SetupSuite() []suite.Option {
+	return []suite.Option{
+		suite.WithLogLevel("info"),
+		suite.WithConfigMap(map[string]any{
+			"mdlsub": map[string]any{
+				"publishers": map[string]any{
+					"echo": map[string]any{
+						"output_type": "sqs",
+					},
+				},
+			},
+			"stream": map[string]any{
+				"input": map[string]any{
+					"consumer": map[string]any{
+						"type": "sqs",
+					},
+				},
+			},
+		}),
+		suite.WithConsumer(func(ctx context.Context, config cfg.Config, logger log.Logger) (stream.ConsumerCallback, error) {
+			publisher, err := mdlsub.NewPublisher(ctx, config, logger, "echo")
+			if err != nil {
+				return nil, err
+			}
+
+			s.publisher = publisher
+
+			return s, nil
+		}),
+		suite.WithSharedEnvironment(),
+	}
+}
+
+func (s *ConsumerTestSuite) GetModel(_ map[string]string) any {
+	return &TestMessage{}
+}
+
+func (s *ConsumerTestSuite) Consume(ctx context.Context, model any, _ map[string]string) (bool, error) {
+	msg := model.(*TestMessage)
+
+	s.seenMessageIds = append(s.seenMessageIds, msg.Id)
+
+	if msg.ShouldOutput {
+		if err := s.publisher.Publish(ctx, mdlsub.TypeCreate, 0, msg); err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func (s *ConsumerTestSuite) TestCaseMap() map[string]*suite.StreamTestCase {
+	return map[string]*suite.StreamTestCase{
+		"AnotherSingleTest": s.createTestCase(false),
+		"EmptyTest":         nil,
+	}
+}
+
+func (s *ConsumerTestSuite) TestCasesMapWithProvider() map[string]suite.ToStreamTestCase {
+	return map[string]suite.ToStreamTestCase{
+		"AnotherSingleTest":   s.createTestCase(true),
+		"AnotherWithProvider": suite.ToStreamTestCase(s.createTestCase(true)),
+		"Nil":                 nil,
+	}
+}
+
+func (s *ConsumerTestSuite) TestCasesEmptyMap() map[string]*suite.StreamTestCase {
+	return map[string]*suite.StreamTestCase{}
+}
+
+func (s *ConsumerTestSuite) TestSingleTest() *suite.StreamTestCase {
+	return s.createTestCase(false)
+}
+
+func (s *ConsumerTestSuite) TestSkipped() *suite.StreamTestCase {
+	return nil
+}
+
+func (s *ConsumerTestSuite) TestNilProvider() suite.ToStreamTestCase {
+	return nil
+}
+
+func (s *ConsumerTestSuite) TestProvider() suite.ToStreamTestCase {
+	return s.createTestCase(true)
+}
+
+func (s *ConsumerTestSuite) createTestCase(hasOutput bool) *suite.StreamTestCase {
+	messageId := uuid.New().NewV4()
+	s.expectedMessageIds = append(s.expectedMessageIds, messageId)
+
+	var output map[string][]suite.StreamTestCaseOutput
+	if hasOutput {
+		output = map[string][]suite.StreamTestCaseOutput{
+			"publisher-echo": {
+				{
+					Model: &TestMessage{},
+					ExpectedAttributes: map[string]string{
+						"encoding": "application/json",
+						"modelId":  "justtrack.gosoline.test.echo",
+						"type":     "create",
+						"version":  "0",
+					},
+					ExpectedBody: &TestMessage{
+						Id:           messageId,
+						ShouldOutput: true,
+					},
+				},
+			},
+		}
+	}
+
+	return &suite.StreamTestCase{
+		Input: map[string][]suite.StreamTestCaseInput{
+			"consumer": {
+				{
+					Body: TestMessage{
+						Id:           messageId,
+						ShouldOutput: hasOutput,
+					},
+				},
+			},
+		},
+		Output: output,
+		Assert: func() error {
+			s.Contains(s.seenMessageIds, messageId)
+
+			return nil
+		},
+	}
+}

--- a/pkg/test/suite/testcase_subscriber_test.go
+++ b/pkg/test/suite/testcase_subscriber_test.go
@@ -1,0 +1,101 @@
+package suite_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/justtrackio/gosoline/pkg/mdlsub"
+	"github.com/justtrackio/gosoline/pkg/test/suite"
+)
+
+type TestModel struct {
+	Id   int
+	Text string
+}
+
+type SubscriberTestSuite struct {
+	suite.Suite
+}
+
+func TestSubscriberTestSuite(t *testing.T) {
+	suite.Run(t, &SubscriberTestSuite{})
+}
+
+func (m TestModel) GetId() any {
+	return m.Id
+}
+
+func (s *SubscriberTestSuite) SetupSuite() []suite.Option {
+	return []suite.Option{
+		suite.WithLogLevel("info"),
+		suite.WithConfigMap(map[string]any{
+			"kvstore": map[string]any{
+				"testModel": map[string]any{
+					"type": "chain",
+					"elements": []string{
+						"inMemory",
+						"ddb",
+					},
+				},
+			},
+			"mdlsub": map[string]any{
+				"subscribers": map[string]any{
+					"testModel": map[string]any{
+						"output": "kvstore",
+					},
+				},
+			},
+			"test": map[string]any{
+				"components": map[string]any{
+					"ddb": map[string]any{
+						"default": map[string]any{},
+					},
+				},
+			},
+		}),
+		suite.WithSubscribers(map[string]mdlsub.TransformerMapVersionFactories{
+			"justtrack.gosoline.test.testModel": {
+				0: func(ctx context.Context, config cfg.Config, logger log.Logger) (mdlsub.ModelTransformer, error) {
+					return s, nil
+				},
+			},
+		}),
+		suite.WithSharedEnvironment(),
+	}
+}
+
+func (s *SubscriberTestSuite) GetInput() any {
+	return &TestInput{}
+}
+
+func (s *SubscriberTestSuite) Transform(_ context.Context, inp any) (out mdlsub.Model, err error) {
+	input := inp.(*TestInput)
+
+	return &TestModel{
+		Id:   1,
+		Text: input.Text,
+	}, nil
+}
+
+func (s *SubscriberTestSuite) TestInput() (suite.SubscriberTestCase, error) {
+	return suite.KvstoreTestCase(suite.KvstoreSubscriberTestCase{
+		Name:    "testModel",
+		ModelId: "justtrack.gosoline.test.testModel",
+		Input: &TestInput{
+			Text: "this is a test",
+		},
+		Assert: func(t *testing.T, fetcher *suite.KvstoreSubscriberFetcher) {
+			actual := &TestModel{}
+			fetcher.Get(1, actual)
+
+			expected := &TestModel{
+				Id:   1,
+				Text: "this is a test",
+			}
+
+			s.Equal(expected, actual)
+		},
+	})
+}


### PR DESCRIPTION
If you have complex logic generating test cases, it can be helpful to be able to generate a map of test cases to run. Normally, you would then use `t.Run(name, func() {...})` to execute each test case, but this isn't an option when using the test suite to run http or stream test cases. Therefore, we now allow you to return a `map[string]T` where `T` is either a `ToHttpserverTestCaseList` interface or directly a `[]*HttpserverTestCase` slice.

Additionally, the `HttpserverTestCaseListProvider` type was added to allow you to return a function creating the test cases. The function runs after fixtures (and the app itself) have been loaded compared to the test case generator (which runs before the app has been loaded).

---

This expands the test case map logic from the http server test cases to the stream test cases. `ToStreamTestCase` and `StreamTestCaseProvider` have been added with similar roles to their http server counterparts.

---

This changes the way we check method signatures of test methods slightly. For one, we are now checking the complete signature    (previously, we wouldn't check for example the receiver argument).    On the other hand, we now check that at least one matcher actually    matches a method starting with "Test" and raise an error otherwise.    This ensures that a test is not silently skipped because there is a    small error in the method signature.
    
Therefore, this is technically a breaking change.

