### PR TITLE
db: close the sql.Rows object once we are done with it

### DIFF
--- a/pkg/metric/daemon.go
+++ b/pkg/metric/daemon.go
@@ -85,7 +85,7 @@ func (d *Daemon) GetStage() int {
 
 func (d *Daemon) Run(ctx context.Context) error {
 	if !d.settings.Enabled {
-		d.logger.Info("metrics not enabled..")
+		d.logger.Info("metrics not enabled")
 
 		return nil
 	}


### PR DESCRIPTION
We sometimes have code which would iterate an sql.Rows object, returning an error if we failed to read the next row. As long as we don't get an error, this works, as calling `rows.Next()` will eventually close the rows object once the last row was read. However, in case of an error we have to make sure to explicitly call `rows.Close()`, otherwise we leak connections for some drivers.