### PR TITLE
cloud/aws/kinesis: avoid error logs from canceled contexts

### DIFF
--- a/pkg/cloud/aws/kinesis/kinsumer.go
+++ b/pkg/cloud/aws/kinesis/kinsumer.go
@@ -205,7 +205,9 @@ func (k *kinsumer) Run(ctx context.Context, handler MessageHandler) (finalErr er
 		shardIds:     nil,
 	}
 	// don't care whether we changed, will be true anyway as we had nothing running yet
-	if _, err := k.refreshShards(ctx, runtimeCtx); err != nil {
+	if _, err := k.refreshShards(ctx, runtimeCtx); exec.IsRequestCanceled(err) {
+		return nil
+	} else if err != nil {
 		return fmt.Errorf("failed to load first list of shard ids and register as client: %w", err)
 	}
 

--- a/pkg/cloud/aws/kinesis/metadata_repository_test.go
+++ b/pkg/cloud/aws/kinesis/metadata_repository_test.go
@@ -15,6 +15,7 @@ import (
 	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
 	"github.com/justtrackio/gosoline/pkg/mdl"
 	"github.com/justtrackio/gosoline/pkg/uuid"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -356,7 +357,7 @@ func (s *metadataRepositoryTestSuite) mockAcquireShardPutItem(sequenceNumber kin
 	qb.EXPECT().WithCondition(ddb.AttributeNotExists("owningClientId").Or(ddb.Lte("updatedAt", s.clock.Now().Add(-time.Minute)))).Return(qb).Once()
 
 	s.repo.EXPECT().PutItemBuilder().Return(qb).Once()
-	s.repo.EXPECT().PutItem(s.ctx, qb, &kinesis.CheckpointRecord{
+	s.repo.EXPECT().PutItem(mock.AnythingOfType("*exec.stoppableContext"), qb, &kinesis.CheckpointRecord{
 		BaseRecord: kinesis.BaseRecord{
 			Namespace: s.checkpointNamespace,
 			Resource:  string(s.shardId),

--- a/pkg/cloud/aws/kinesis/shard_reader.go
+++ b/pkg/cloud/aws/kinesis/shard_reader.go
@@ -68,7 +68,7 @@ func NewShardReaderWithInterfaces(stream Stream, shardId ShardId, logger log.Log
 }
 
 func (s *shardReader) Run(ctx context.Context, handler func(record []byte) error) (finalErr error) {
-	if ok, err := s.acquireShard(ctx); errors.Is(err, ErrShardAlreadyFinished) {
+	if ok, err := s.acquireShard(ctx); errors.Is(err, ErrShardAlreadyFinished) || exec.IsRequestCanceled(err) {
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("failed to acquire shard: %w", err)

--- a/pkg/db/client.go
+++ b/pkg/db/client.go
@@ -207,7 +207,7 @@ func (c *ClientSqlx) GetResult(ctx context.Context, query string, args ...any) (
 }
 
 func (c *ClientSqlx) Exec(ctx context.Context, query string, args ...any) (sql.Result, error) {
-	c.logger.Debug("> %s %q", query, args)
+	c.logger.WithContext(ctx).Debug("> %s %q", query, args)
 
 	res, err := c.executor.Execute(ctx, func(ctx context.Context) (any, error) {
 		return c.db.ExecContext(ctx, query, args...)
@@ -220,7 +220,7 @@ func (c *ClientSqlx) Exec(ctx context.Context, query string, args ...any) (sql.R
 }
 
 func (c *ClientSqlx) NamedExec(ctx context.Context, query string, arg any) (sql.Result, error) {
-	c.logger.Debug("> %s %q", query, arg)
+	c.logger.WithContext(ctx).Debug("> %s %q", query, arg)
 
 	return c.db.NamedExecContext(ctx, query, arg)
 }
@@ -313,7 +313,7 @@ func (c *ClientSqlx) PrepareNamed(ctx context.Context, query string) (*sqlx.Name
 }
 
 func (c *ClientSqlx) Query(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
-	c.logger.Debug("> %s %q", query, args)
+	c.logger.WithContext(ctx).Debug("> %s %q", query, args)
 
 	res, err := c.executor.Execute(ctx, func(ctx context.Context) (any, error) {
 		return c.db.QueryContext(ctx, query, args...)
@@ -326,7 +326,7 @@ func (c *ClientSqlx) Query(ctx context.Context, query string, args ...any) (*sql
 }
 
 func (c *ClientSqlx) QueryRow(ctx context.Context, query string, args ...any) *sql.Row {
-	c.logger.Debug("> %s %q", query, args)
+	c.logger.WithContext(ctx).Debug("> %s %q", query, args)
 
 	res, err := c.executor.Execute(ctx, func(ctx context.Context) (any, error) {
 		return c.db.QueryRowContext(ctx, query, args...), nil
@@ -339,7 +339,7 @@ func (c *ClientSqlx) QueryRow(ctx context.Context, query string, args ...any) *s
 }
 
 func (c *ClientSqlx) NamedQuery(ctx context.Context, query string, arg any) (*sqlx.Rows, error) {
-	c.logger.Debug("> %s %q", query, arg)
+	c.logger.WithContext(ctx).Debug("> %s %q", query, arg)
 
 	res, err := c.executor.Execute(ctx, func(ctx context.Context) (any, error) {
 		return c.db.NamedQueryContext(ctx, query, arg)
@@ -352,7 +352,7 @@ func (c *ClientSqlx) NamedQuery(ctx context.Context, query string, arg any) (*sq
 }
 
 func (c *ClientSqlx) Queryx(ctx context.Context, query string, args ...any) (*sqlx.Rows, error) {
-	c.logger.Debug("> %s %q", query, args)
+	c.logger.WithContext(ctx).Debug("> %s %q", query, args)
 
 	res, err := c.executor.Execute(ctx, func(ctx context.Context) (any, error) {
 		return c.db.QueryxContext(ctx, query, args...)
@@ -365,7 +365,7 @@ func (c *ClientSqlx) Queryx(ctx context.Context, query string, args ...any) (*sq
 }
 
 func (c *ClientSqlx) Select(ctx context.Context, dest any, query string, args ...any) error {
-	c.logger.Debug("> %s %q", query, args)
+	c.logger.WithContext(ctx).Debug("> %s %q", query, args)
 
 	_, err := c.executor.Execute(ctx, func(ctx context.Context) (any, error) {
 		return nil, c.db.SelectContext(ctx, dest, query, args...)
@@ -375,7 +375,7 @@ func (c *ClientSqlx) Select(ctx context.Context, dest any, query string, args ..
 }
 
 func (c *ClientSqlx) NamedSelect(ctx context.Context, dest any, query string, arg any) error {
-	c.logger.Debug("> %s %q", query, arg)
+	c.logger.WithContext(ctx).Debug("> %s %q", query, arg)
 
 	_, err := c.executor.Execute(ctx, func(ctx context.Context) (any, error) {
 		stmt, err := c.db.PrepareNamedContext(ctx, query)
@@ -396,7 +396,7 @@ func (c *ClientSqlx) NamedSelect(ctx context.Context, dest any, query string, ar
 }
 
 func (c *ClientSqlx) Get(ctx context.Context, dest any, query string, args ...any) error {
-	c.logger.Debug("> %s %q", query, args)
+	c.logger.WithContext(ctx).Debug("> %s %q", query, args)
 
 	_, err := c.executor.Execute(ctx, func(ctx context.Context) (any, error) {
 		return nil, c.db.GetContext(ctx, dest, query, args...)
@@ -406,7 +406,7 @@ func (c *ClientSqlx) Get(ctx context.Context, dest any, query string, args ...an
 }
 
 func (c *ClientSqlx) BeginTx(ctx context.Context, ops *sql.TxOptions) (*sqlx.Tx, error) {
-	c.logger.Debug("start tx")
+	c.logger.WithContext(ctx).Debug("start tx")
 
 	res, err := c.executor.Execute(ctx, func(ctx context.Context) (any, error) {
 		return c.db.BeginTxx(ctx, ops)


### PR DESCRIPTION
When a kinsumer shuts down, we have to handle the canceled context gracefully. Right now we log this as a full error, but we can handle it way better by either ignoring the error (if we just tried to read something) or preventing the context cancel (when writing data) and shutting down gracefully.