### PR TITLE
cloud/aws/athena: automatic retry on internal query errors

### DIFF
--- a/pkg/cloud/aws/athena/repository_test.go
+++ b/pkg/cloud/aws/athena/repository_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Masterminds/squirrel"
 	"github.com/justtrackio/gosoline/pkg/clock"
 	"github.com/justtrackio/gosoline/pkg/cloud/aws/athena"
+	"github.com/justtrackio/gosoline/pkg/exec"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -36,7 +37,7 @@ func (s *AthenaRepositoryTestSuite) SetupSuite() {
 	settings := &athena.Settings{TableName: "testSchema"}
 
 	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
-	raw := athena.NewRepositoryRawWithInterfaces(db, settings)
+	raw := athena.NewRepositoryRawWithInterfaces(db, exec.NewDefaultExecutor(), settings)
 	s.NoError(err)
 
 	s.ctx = context.Background()


### PR DESCRIPTION
If AWS responses with *Amazon Athena experienced an internal error while executing this query. Please try submitting the query again* while executing an Athena query, the client will trigger an automatic retry now.