### PR TITLE
httpserver: don't treat request cancels as errors;

### DIFF
--- a/docs/docs/quickstart/http-server/create-an-http-server.mdx
+++ b/docs/docs/quickstart/http-server/create-an-http-server.mdx
@@ -127,7 +127,10 @@ Finally, you created a `Handle()` function that accepts a `context.Context` and 
 
 <CodeBlock language="go" title="handler.go" snippet="handle">{Handler}</CodeBlock>
 
-Here, you handle requests and responses in just a few lines of code. `handler.go` does most of the heavy lifting for your web service. However, you still need a main entry point to your service, where you'll make use of the logic in `handler.go`. This, you'll add in `main.go`.
+Here, you handle requests and responses in just a few lines of code. `handler.go` does most of the heavy lifting for your web service.
+Notice, that you can return an error to the httpserver package - there is built in error handling to respond with appropriate status and responses.
+
+However, you still need a main entry point to your service, where you'll make use of the logic in `handler.go`. This, you'll add in `main.go`.
 
 ## Implement main.go
 

--- a/docs/docs/quickstart/http-server/src/create-an-http-server/handler.go
+++ b/docs/docs/quickstart/http-server/src/create-an-http-server/handler.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/justtrackio/gosoline/pkg/cfg"
@@ -54,8 +55,13 @@ func (t TodoHandler) Handle(ctx context.Context, request *httpserver.Request) (*
 	// Set its CreatedAt to now
 	todo.CreatedAt = time.Now()
 
+	// The error gets transformed within the http server to an HTTP 500 response
+	if todo.Id <= 0 {
+		return nil, fmt.Errorf("invalid id")
+	}
+
 	// Log the request using the TodoHandler struct's logger
-	t.logger.Info("got todo with id %d", todo.Id)
+	t.logger.WithContext(ctx).Info("got todo with id %d", todo.Id)
 
 	// Return a Json response object with information from the Todo struct
 	return httpserver.NewJsonResponse(todo), nil

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/justtrackio/gosoline/pkg/appctx"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/log"
@@ -12,12 +13,11 @@ import (
 type (
 	dispatcherCtxKey string
 
-	Callback func(ctx context.Context, event interface{}) error
-	Result   map[string]error
+	Callback func(ctx context.Context, event any) error
 )
 
 type Dispatcher interface {
-	Fire(ctx context.Context, name string, event interface{}) Result
+	Fire(ctx context.Context, name string, event any) error
 	On(name string, call Callback)
 }
 
@@ -41,22 +41,23 @@ func newDispatcher(logger log.Logger) (Dispatcher, error) {
 	}, nil
 }
 
-func (d *dispatcher) Fire(ctx context.Context, name string, event interface{}) Result {
+func (d *dispatcher) Fire(ctx context.Context, name string, event any) error {
 	d.mx.RLock()
 	defer d.mx.RUnlock()
 
 	callbacks, ok := d.listeners[name]
 	if !ok {
-		return map[string]error{}
+		return nil
 	}
 
-	errors := make(Result)
+	errors := &multierror.Error{}
 
 	for _, c := range callbacks {
-		errors[name] = c(ctx, event)
+		err := c(ctx, event)
+		errors = multierror.Append(errors, err)
 	}
 
-	return errors
+	return errors.ErrorOrNil()
 }
 
 func (d *dispatcher) On(name string, call Callback) {

--- a/pkg/dispatcher/repository_db.go
+++ b/pkg/dispatcher/repository_db.go
@@ -35,15 +35,13 @@ func (r Repository) Create(ctx context.Context, value db_repo.ModelBased) error 
 	}
 
 	eventName := fmt.Sprintf("%s.%s", r.Repository.GetModelName(), db_repo.Create)
-	errs := r.dispatcher.Fire(ctx, eventName, value)
 
-	for _, err := range errs {
-		if err != nil {
-			r.logger.Error("error on %s for event %s: %w", db_repo.Create, eventName, err)
-		}
+	err = r.dispatcher.Fire(ctx, eventName, value)
+	if err != nil {
+		r.logger.WithContext(ctx).Error("error on %s for event %s: %w", db_repo.Create, eventName, err)
 	}
 
-	return nil
+	return err
 }
 
 func (r Repository) Update(ctx context.Context, value db_repo.ModelBased) error {
@@ -53,15 +51,13 @@ func (r Repository) Update(ctx context.Context, value db_repo.ModelBased) error 
 	}
 
 	eventName := fmt.Sprintf("%s.%s", r.Repository.GetModelName(), db_repo.Update)
-	errs := r.dispatcher.Fire(ctx, eventName, value)
 
-	for _, err := range errs {
-		if err != nil {
-			r.logger.Error("error on %s for event %s: %w", db_repo.Update, eventName, err)
-		}
+	err = r.dispatcher.Fire(ctx, eventName, value)
+	if err != nil {
+		r.logger.WithContext(ctx).Error("error on %s for event %s: %w", db_repo.Update, eventName, err)
 	}
 
-	return nil
+	return err
 }
 
 func (r Repository) Delete(ctx context.Context, value db_repo.ModelBased) error {
@@ -71,13 +67,11 @@ func (r Repository) Delete(ctx context.Context, value db_repo.ModelBased) error 
 	}
 
 	eventName := fmt.Sprintf("%s.%s", r.Repository.GetModelName(), db_repo.Delete)
-	errs := r.dispatcher.Fire(ctx, eventName, value)
 
-	for _, err := range errs {
-		if err != nil {
-			r.logger.Error("error on %s for event %s: %w", db_repo.Delete, eventName, err)
-		}
+	err = r.dispatcher.Fire(ctx, eventName, value)
+	if err != nil {
+		r.logger.Error("error on %s for event %s: %w", db_repo.Delete, eventName, err)
 	}
 
-	return nil
+	return err
 }

--- a/pkg/exec/error.go
+++ b/pkg/exec/error.go
@@ -48,8 +48,12 @@ func CheckConnectionError(_ interface{}, err error) ErrorType {
 }
 
 func IsConnectionError(err error) bool {
-	if errors.Is(err, io.EOF) || errors.Is(err, unix.ECONNREFUSED) || errors.Is(err, unix.ECONNRESET) || errors.Is(err, unix.EPIPE) {
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, unix.ECONNREFUSED) || errors.Is(err, unix.ECONNRESET) || errors.Is(err, unix.EPIPE) {
 		return true
+	}
+
+	if err == nil {
+		return false
 	}
 
 	if strings.Contains(err.Error(), "read: connection reset") {
@@ -80,6 +84,10 @@ func CheckClientAwaitHeaderTimeoutError(_ interface{}, err error) ErrorType {
 }
 
 func IsClientAwaitHeadersTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+
 	return strings.Contains(err.Error(), "(Client.Timeout exceeded while awaiting headers)")
 }
 
@@ -92,5 +100,9 @@ func CheckTlsHandshakeTimeoutError(_ interface{}, err error) ErrorType {
 }
 
 func IsTlsHandshakeTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+
 	return strings.Contains(err.Error(), "net/http: TLS handshake timeout")
 }

--- a/pkg/httpserver/crud/errors.go
+++ b/pkg/httpserver/crud/errors.go
@@ -14,8 +14,6 @@ import (
 	"github.com/justtrackio/gosoline/pkg/validation"
 )
 
-const HttpStatusClientClosedRequest = 499
-
 var ErrModelNotChanged = fmt.Errorf("nothing has changed on model")
 
 // handleErrorOnWrite handles errors for read operations.
@@ -27,7 +25,7 @@ func handleErrorOnRead(logger log.Logger, err error) (*httpserver.Response, erro
 	if exec.IsRequestCanceled(err) {
 		logger.Info("read model(s) aborted: %s", err.Error())
 
-		return httpserver.NewStatusResponse(HttpStatusClientClosedRequest), nil
+		return httpserver.NewStatusResponse(httpserver.HttpStatusClientWentAway), nil
 	}
 
 	if db_repo.IsRecordNotFoundError(err) || db_repo.IsNoQueryResultsError(err) {

--- a/pkg/httpserver/middleware_logger_test.go
+++ b/pkg/httpserver/middleware_logger_test.go
@@ -1,0 +1,212 @@
+package httpserver_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/justtrackio/gosoline/pkg/clock"
+	clockMocks "github.com/justtrackio/gosoline/pkg/clock/mocks"
+	"github.com/justtrackio/gosoline/pkg/httpserver"
+	"github.com/justtrackio/gosoline/pkg/log"
+	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type loggingMiddlewareTestSuite struct {
+	suite.Suite
+
+	logger *logMocks.Logger
+
+	handler gin.HandlerFunc
+}
+
+func TestLoggingMiddlewareTestSuite(t *testing.T) {
+	suite.Run(t, new(loggingMiddlewareTestSuite))
+}
+
+func (s *loggingMiddlewareTestSuite) SetupTest() {
+	s.logger = logMocks.NewLogger(s.T())
+	s.logger.EXPECT().WithContext(mock.Anything).Return(s.logger)
+	s.logger.EXPECT().WithFields(mock.Anything).Return(s.logger)
+
+	s.handler = httpserver.NewLoggingMiddlewareWithInterfaces(s.logger, httpserver.LoggingSettings{}, clock.Provider)
+}
+
+func (s *loggingMiddlewareTestSuite) TestSuccess() {
+	ginCtx := buildRequest()
+
+	s.logger.EXPECT().Info("%s %s %s", "GET", "path", "HTTP/1.1")
+
+	s.handler(ginCtx)
+}
+
+func (s *loggingMiddlewareTestSuite) TestRequestCanceledError() {
+	ginCtx := buildRequest()
+
+	err := ginCtx.Error(context.Canceled)
+
+	s.Require().Error(err)
+
+	s.logger.EXPECT().Info("%s %s %s - request canceled: %w", "GET", "path", "HTTP/1.1", mock.AnythingOfType("*gin.Error"))
+
+	s.handler(ginCtx)
+}
+
+func (s *loggingMiddlewareTestSuite) TestEOFError() {
+	ginCtx := buildRequest()
+
+	err := ginCtx.Error(io.EOF)
+
+	s.Require().Error(err)
+
+	s.logger.EXPECT().Info("%s %s %s - connection error: %w", "GET", "path", "HTTP/1.1", mock.AnythingOfType("*gin.Error"))
+
+	s.handler(ginCtx)
+}
+
+func (s *loggingMiddlewareTestSuite) TestBindError() {
+	ginCtx := buildRequest()
+
+	err := ginCtx.Error(&gin.Error{
+		Err:  fmt.Errorf("failed to read body"),
+		Type: gin.ErrorTypeBind,
+	})
+
+	s.Require().Error(err)
+
+	s.logger.EXPECT().Warn("%s %s %s - bind error: %w", "GET", "path", "HTTP/1.1", mock.AnythingOfType("*errors.errorString"))
+
+	s.handler(ginCtx)
+}
+
+func (s *loggingMiddlewareTestSuite) TestRenderError() {
+	ginCtx := buildRequest()
+
+	err := ginCtx.Error(&gin.Error{
+		Err:  fmt.Errorf("failed to write body"),
+		Type: gin.ErrorTypeRender,
+	})
+
+	s.Require().Error(err)
+
+	s.logger.EXPECT().Warn("%s %s %s - render error: %w", "GET", "path", "HTTP/1.1", mock.AnythingOfType("*errors.errorString"))
+
+	s.handler(ginCtx)
+}
+
+func (s *loggingMiddlewareTestSuite) TestDefaultError() {
+	ginCtx := buildRequest()
+
+	err := ginCtx.Error(fmt.Errorf("error"))
+
+	s.Require().Error(err)
+
+	s.logger.EXPECT().Error("%s %s %s: %w", "GET", "path", "HTTP/1.1", mock.AnythingOfType("*errors.errorString"))
+
+	s.handler(ginCtx)
+}
+
+func TestLogFields(t *testing.T) {
+	ginCtx := buildRequest()
+	ginCtx.Request.Host = "host.io"
+	ginCtx.Request.Header.Set("User-Agent", "test/User-Agent")
+	ginCtx.Request.Header.Set("Referer", "referer")
+	ginCtx.Request.Header.Set("X-Request-Id", "request123")
+	ginCtx.Request.Header.Set("X-Session-Id", "session123")
+	ginCtx.Request.RemoteAddr = "127.0.0.1:80"
+	ginCtx.Status(http.StatusOK)
+
+	_, err := ginCtx.Writer.WriteString("{}")
+	assert.NoError(t, err)
+
+	now := time.Date(2024, 12, 20, 12, 9, 3, 0, time.UTC)
+
+	clock := clockMocks.NewClock(t)
+	clock.EXPECT().Now().Return(now).Once()
+	clock.EXPECT().Since(now).Return(250 * time.Millisecond).Once()
+
+	logger := logMocks.NewLogger(t)
+	logger.EXPECT().WithContext(mock.Anything).Return(logger)
+
+	expected := log.Fields{
+		"bytes":            2,
+		"client_ip":        "127.0.0.1",
+		"host":             "host.io",
+		"protocol":         "HTTP/1.1",
+		"request_method":   "GET",
+		"request_path":     "path",
+		"request_path_raw": "path",
+		"request_referer":  "referer",
+		"request_time":     0.25,
+		"request_query":    "foo=bar",
+		"request_query_parameters": map[string]string{
+			"foo": "bar",
+		},
+		"request_user_agent": "test/User-Agent",
+		"scheme":             "https",
+		"status":             200,
+	}
+
+	logger.EXPECT().WithFields(mock.Anything).Run(func(fields log.Fields) {
+		assert.Equal(t, expected, fields)
+	}).Return(logger)
+
+	logger.EXPECT().Info("%s %s %s", "GET", "path", "HTTP/1.1")
+
+	handler := httpserver.NewLoggingMiddlewareWithInterfaces(logger, httpserver.LoggingSettings{}, clock)
+
+	handler(ginCtx)
+}
+
+func TestLogEncodedRequestBody(t *testing.T) {
+	ginCtx := buildRequest()
+	ginCtx.Request.Body = io.NopCloser(strings.NewReader("{}"))
+
+	logger := logMocks.NewLogger(t)
+	logger.EXPECT().WithContext(mock.Anything).Return(logger)
+
+	logger.EXPECT().WithFields(mock.Anything).Run(func(fields log.Fields) {
+		requestBody, ok := fields["request_body"]
+		assert.True(t, ok)
+		assert.Equal(t, "e30=", requestBody)
+	}).Return(logger)
+
+	logger.EXPECT().Info("%s %s %s", "GET", "path", "HTTP/1.1")
+
+	handler := httpserver.NewLoggingMiddlewareWithInterfaces(logger, httpserver.LoggingSettings{
+		RequestBody:       true,
+		RequestBodyBase64: true,
+	}, clock.Provider)
+
+	handler(ginCtx)
+}
+
+func buildRequest() *gin.Context {
+	w := httptest.NewRecorder()
+
+	ginCtx, _ := gin.CreateTestContext(w)
+	ginCtx.Request = &http.Request{
+		Header: make(http.Header),
+		Method: http.MethodGet,
+		Proto:  "HTTP/1.1",
+		URL: &url.URL{
+			Scheme:   "https",
+			Host:     "host.io",
+			Path:     "path",
+			RawPath:  "/path",
+			RawQuery: "foo=bar",
+		},
+	}
+
+	return ginCtx
+}


### PR DESCRIPTION
**HTTP Server**
The standard http server treats external context cancellations and disconnects as errors; even though the client may have closed or canceled the request on purpose.
As a follow up to https://github.com/justtrackio/gosoline/pull/1178 (targeting the crud handlers), this PR is adjusting the standard behaviour of any other handler similarly.
The most common use cases:
 - access forbidden transformed into HTTP 403
 - context cancellation / disconnects are transformed into HTTP 499
 - any other error being transformed into a HTTP 500

The logger middleware is also adjusted appropriately, logging connection and request cancelations as level info. Bind errors and render errors are continously logged as warnings; by default any other error is logged as an error.

**Exec*
- fixing bugs which causes the code to panic on nil errors

**Dispatcher**
The dispatcher is hiding some errors which may happen during execution of the callbacks. They're now propagated back to the callee, making them obvious and necessary to deal with.
In some cases, you may have to wrap adding callbacks into the appctx to prevent them from being added multiple times.

_This is a breaking change, as the dispatcher will now stop execution if any error is encountered_