### PR TITLE
db-repo: use db client on creating orm instances

### DIFF
--- a/pkg/db-repo/change_history_manager.go
+++ b/pkg/db-repo/change_history_manager.go
@@ -37,7 +37,7 @@ func ProvideChangeHistoryManager(ctx context.Context, config cfg.Config, logger 
 }
 
 func NewChangeHistoryManager(ctx context.Context, config cfg.Config, logger log.Logger) (*ChangeHistoryManager, error) {
-	orm, err := NewOrm(ctx, config, logger)
+	orm, err := NewOrm(ctx, config, logger, "default")
 	if err != nil {
 		return nil, fmt.Errorf("can not create orm: %w", err)
 	}

--- a/pkg/mdlsub/output_db.go
+++ b/pkg/mdlsub/output_db.go
@@ -37,7 +37,7 @@ type OutputDb struct {
 }
 
 func NewOutputDb(ctx context.Context, config cfg.Config, logger log.Logger) (*OutputDb, error) {
-	orm, err := db_repo.NewOrm(ctx, config, logger)
+	orm, err := db_repo.NewOrm(ctx, config, logger, "default")
 	if err != nil {
 		return nil, fmt.Errorf("can not create orm: %w", err)
 	}

--- a/pkg/share/manager.go
+++ b/pkg/share/manager.go
@@ -46,7 +46,7 @@ func ProvideShareManager(ctx context.Context, config cfg.Config, logger log.Logg
 }
 
 func NewShareManager(ctx context.Context, config cfg.Config, logger log.Logger) (*shareManager, error) {
-	orm, err := db_repo.NewOrm(ctx, config, logger)
+	orm, err := db_repo.NewOrm(ctx, config, logger, "default")
 	if err != nil {
 		return nil, fmt.Errorf("can not create orm: %w", err)
 	}

--- a/pkg/test/suite/testcase_subscriber.go
+++ b/pkg/test/suite/testcase_subscriber.go
@@ -133,7 +133,7 @@ func buildTestCaseSubscriber(_ TestingSuite, method reflect.Method) (testCaseRun
 					return
 				}
 
-				orm, err := db_repo.NewOrm(suite.Env().Context(), config, logger)
+				orm, err := db_repo.NewOrm(suite.Env().Context(), config, logger, "default")
 				if err != nil {
 					assert.FailNow(t, "can't initialize orm", "the test case for the subscription of %s can't be initialized", tc.GetName())
 				}


### PR DESCRIPTION
This release enables the use of different db client names on creating orm instances.