### PR TITLE
fixtures: added post processors to loaders

### DIFF
--- a/docs/docs/quickstart/testing/src/integration-test-server/server_test.go
+++ b/docs/docs/quickstart/testing/src/integration-test-server/server_test.go
@@ -36,7 +36,7 @@ func (s *HttpTestSuite) SetupSuite() []suite.Option {
 		suite.WithConfigFile("./config.dist.yml"),
 
 		// The fixture set you created in the last section.
-		suite.WithFixtureSetFactories(fixtureSetsFactory),
+		suite.WithFixtureSetFactory(fixtureSetsFactory),
 
 		// suite.WithClockProvider(s.clock),
 		suite.WithClockProvider(s.clock),

--- a/pkg/application/options.go
+++ b/pkg/application/options.go
@@ -174,11 +174,21 @@ func WithHttpServerShares(app *App) {
 	})
 }
 
-func WithFixtureSetFactory(group string, factory fixtures.FixtureSetsFactory) Option {
+func WithFixtureSetFactory(group string, factory fixtures.FixtureSetsFactory, postprocessorFactories ...fixtures.PostProcessorFactory) Option {
 	return func(app *App) {
 		app.addKernelOption(func(config cfg.GosoConf) kernelPkg.Option {
-			return kernelPkg.WithMiddlewareFactory(fixtures.KernelMiddlewareLoader(group, factory), kernelPkg.PositionEnd)
+			return kernelPkg.WithMiddlewareFactory(fixtures.KernelMiddlewareLoader(group, factory, postprocessorFactories...), kernelPkg.PositionEnd)
 		})
+	}
+}
+
+func WithFixtureSetFactories(factories map[string]fixtures.FixtureSetsFactory, postprocessorFactories ...fixtures.PostProcessorFactory) Option {
+	return func(app *App) {
+		for group, factory := range factories {
+			app.addKernelOption(func(config cfg.GosoConf) kernelPkg.Option {
+				return kernelPkg.WithMiddlewareFactory(fixtures.KernelMiddlewareLoader(group, factory, postprocessorFactories...), kernelPkg.PositionEnd)
+			})
+		}
 	}
 }
 

--- a/pkg/fixtures/loader_noop.go
+++ b/pkg/fixtures/loader_noop.go
@@ -14,13 +14,13 @@ type noopFixtureLoader struct {
 	settings *fixtureLoaderSettings
 }
 
-func NewFixtureLoader(ctx context.Context, config cfg.Config, logger log.Logger) FixtureLoader {
+func NewFixtureLoader(ctx context.Context, config cfg.Config, logger log.Logger, postProcessorFactories ...PostProcessorFactory) (FixtureLoader, error) {
 	settings := unmarshalFixtureLoaderSettings(config)
 
 	return &noopFixtureLoader{
 		logger:   logger.WithChannel("fixture_loader"),
 		settings: settings,
-	}
+	}, nil
 }
 
 func (n *noopFixtureLoader) Load(ctx context.Context, group string, fixtureSets []FixtureSet) error {

--- a/pkg/fixtures/post_processor.go
+++ b/pkg/fixtures/post_processor.go
@@ -1,0 +1,14 @@
+package fixtures
+
+import (
+	"context"
+
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/log"
+)
+
+type PostProcessor interface {
+	Process(ctx context.Context) error
+}
+
+type PostProcessorFactory func(ctx context.Context, config cfg.Config, logger log.Logger) (PostProcessor, error)

--- a/pkg/test/suite/options_suite.go
+++ b/pkg/test/suite/options_suite.go
@@ -22,7 +22,8 @@ type suiteOptions struct {
 	envSetup    []func() error
 	envIsShared bool
 
-	fixtureSetFactories []fixtures.FixtureSetsFactory
+	fixtureSetFactories              []fixtures.FixtureSetsFactory
+	fixtureSetPostProcessorFactories []fixtures.PostProcessorFactory
 
 	appOptions   []application.Option
 	appModules   map[string]kernel.ModuleFactory
@@ -122,9 +123,17 @@ func WithEnvSetup(setups ...func() error) Option {
 	}
 }
 
-func WithFixtureSetFactories(factories ...fixtures.FixtureSetsFactory) Option {
+func WithFixtureSetFactory(factory fixtures.FixtureSetsFactory, postProcessorFactories ...fixtures.PostProcessorFactory) Option {
+	return func(s *suiteOptions) {
+		s.fixtureSetFactories = append(s.fixtureSetFactories, factory)
+		s.fixtureSetPostProcessorFactories = append(s.fixtureSetPostProcessorFactories, postProcessorFactories...)
+	}
+}
+
+func WithFixtureSetFactories(factories []fixtures.FixtureSetsFactory, postProcessorFactories ...fixtures.PostProcessorFactory) Option {
 	return func(s *suiteOptions) {
 		s.fixtureSetFactories = append(s.fixtureSetFactories, factories...)
+		s.fixtureSetPostProcessorFactories = append(s.fixtureSetPostProcessorFactories, postProcessorFactories...)
 	}
 }
 

--- a/pkg/test/suite/run.go
+++ b/pkg/test/suite/run.go
@@ -180,7 +180,7 @@ func runTestCaseWithSharedEnvironment(t *testing.T, suite TestingSuite, suiteOpt
 	}
 
 	start := time.Now()
-	if err = environment.LoadFixtureSets(suiteOptions.fixtureSetFactories...); err != nil {
+	if err = environment.LoadFixtureSets(suiteOptions.fixtureSetFactories, suiteOptions.fixtureSetPostProcessorFactories...); err != nil {
 		assert.FailNow(t, "failed to load fixtures from factories", err.Error())
 	}
 

--- a/test/db-repo/change_history/entity/change_history_test.go
+++ b/test/db-repo/change_history/entity/change_history_test.go
@@ -32,7 +32,7 @@ func (s *ChangeHistoryTestSuite) SetupSuite() []suite.Option {
 		suite.WithDbRepoChangeHistory(),
 		suite.WithClockProviderAt("2024-01-01T00:00:00Z"),
 		suite.WithContainerExpireAfter(2 * time.Minute),
-		suite.WithFixtureSetFactories(definitions.FixtureSetsFactory),
+		suite.WithFixtureSetFactory(definitions.FixtureSetsFactory),
 	}
 }
 

--- a/test/db/migration-golang-migrate/mysql_test.go
+++ b/test/db/migration-golang-migrate/mysql_test.go
@@ -40,7 +40,8 @@ func (s *MysqlTestSuite) TestPlainFixturesMysql() {
 	envLogger := s.Env().Logger()
 	envClient := s.Env().MySql("default").Client()
 
-	loader := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	loader, err := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	s.NoError(err)
 
 	fss, err := s.provideFixtureSets()
 	s.NoError(err)

--- a/test/db/migration-goose/mysql_test.go
+++ b/test/db/migration-goose/mysql_test.go
@@ -40,7 +40,8 @@ func (s *MysqlTestSuite) TestPlainFixturesMysql() {
 	envLogger := s.Env().Logger()
 	envClient := s.Env().MySql("default").Client()
 
-	loader := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	loader, err := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	s.NoError(err)
 
 	fss, err := s.provideFixtureSets()
 	s.NoError(err)

--- a/test/fixtures/dynamodb/dynamodb_test.go
+++ b/test/fixtures/dynamodb/dynamodb_test.go
@@ -42,7 +42,8 @@ func (s *DynamoDbSuite) TestDynamoDb() {
 	envConfig := s.Env().Config()
 	envLogger := s.Env().Logger()
 
-	loader := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	loader, err := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	s.NoError(err)
 
 	fss, err := s.dynamoDbFixtureSet1()
 	s.NoError(err)
@@ -91,7 +92,8 @@ func (s *DynamoDbSuite) TestDynamoDbWithPurge() {
 	envConfig := s.Env().Config()
 	envLogger := s.Env().Logger()
 
-	loader := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	loader, err := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	s.NoError(err)
 
 	fss, err := s.dynamoDbFixtureSet1()
 	s.NoError(err)
@@ -173,7 +175,8 @@ func (s *DynamoDbSuite) TestDynamoDbKvStore() {
 	envConfig := s.Env().Config()
 	envLogger := s.Env().Logger()
 
-	loader := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	loader, err := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	s.NoError(err)
 
 	fss, err := s.dynamoDbKvStoreFixtureSet1()
 	s.NoError(err)
@@ -215,7 +218,8 @@ func (s *DynamoDbSuite) TestDynamoDbKvStoreWithPurge() {
 	envConfig := s.Env().Config()
 	envLogger := s.Env().Logger()
 
-	loader := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	loader, err := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	s.NoError(err)
 
 	fss, err := s.dynamoDbKvStoreFixtureSet1()
 	s.NoError(err)

--- a/test/fixtures/kvstore/configurable_kvstore_test.go
+++ b/test/fixtures/kvstore/configurable_kvstore_test.go
@@ -34,7 +34,8 @@ func (s *ConfigurableKvStoreTestSuite) TestConfigurableKvStore() {
 	envConfig := s.Env().Config()
 	envLogger := s.Env().Logger()
 
-	loader := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	loader, err := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	s.NoError(err)
 
 	fss, err := s.provideFixtures()
 	s.NoError(err)

--- a/test/fixtures/mysql/mysql_test.go
+++ b/test/fixtures/mysql/mysql_test.go
@@ -43,7 +43,9 @@ func (s *MysqlTestSuite) TestOrmFixturesMysql() {
 	envContext := s.Env().Context()
 	envClient := s.Env().MySql("default").Client()
 
-	loader := s.buildFixtureLoader(envContext)
+	loader, err := s.buildFixtureLoader(envContext)
+	s.NoError(err)
+
 	fss, err := s.provideMysqlOrmFixtureSets()
 	s.NoError(err)
 
@@ -58,7 +60,9 @@ func (s *MysqlTestSuite) TestPlainFixturesMysql() {
 	envContext := s.Env().Context()
 	envClient := s.Env().MySql("default").Client()
 
-	loader := s.buildFixtureLoader(envContext)
+	loader, err := s.buildFixtureLoader(envContext)
+	s.NoError(err)
+
 	fss, err := s.provideMysqlPlainFixtureSets()
 	s.NoError(err)
 
@@ -73,7 +77,9 @@ func (s *MysqlTestSuite) TestPurgedOrmFixturesMysql() {
 	envContext := s.Env().Context()
 	envClient := s.Env().MySql("default").Client()
 
-	loader := s.buildFixtureLoader(envContext)
+	loader, err := s.buildFixtureLoader(envContext)
+	s.NoError(err)
+
 	fss, err := s.provideMysqlOrmFixtureSets()
 	s.NoError(err)
 
@@ -98,7 +104,9 @@ func (s *MysqlTestSuite) TestPurgedPlainFixturesMysql() {
 	envLogger := s.Env().Logger()
 	envClient := s.Env().MySql("default").Client()
 
-	loader := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	loader, err := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	s.NoError(err)
+
 	fss, err := s.provideMysqlPlainFixtureSets()
 	s.NoError(err)
 
@@ -117,7 +125,7 @@ func (s *MysqlTestSuite) TestPurgedPlainFixturesMysql() {
 	gosoAssert.SqlColumnHasSpecificValue(s.T(), envClient, "mysql_plain_writer_test", "name", "purgedBefore")
 }
 
-func (s *MysqlTestSuite) buildFixtureLoader(ctx context.Context) fixtures.FixtureLoader {
+func (s *MysqlTestSuite) buildFixtureLoader(ctx context.Context) (fixtures.FixtureLoader, error) {
 	envConfig := s.Env().Config()
 	envLogger := s.Env().Logger()
 

--- a/test/fixtures/redis/redis_test.go
+++ b/test/fixtures/redis/redis_test.go
@@ -41,7 +41,8 @@ func (s *RedisTestSuite) TestRedis() {
 	s.NoError(err)
 	s.Equal("OK", result)
 
-	loader := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	loader, err := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	s.NoError(err)
 
 	fs1, err := s.provideRedisOpSetFixtureSet()
 	s.NoError(err)
@@ -80,7 +81,8 @@ func (s *RedisTestSuite) TestRedisWithPurge() {
 	s.NoError(err)
 	s.Equal("OK", result)
 
-	loader := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	loader, err := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	s.NoError(err)
 
 	fs1, err := s.provideRedisOpSetFixtureSet()
 	s.NoError(err)
@@ -135,7 +137,8 @@ func (s *RedisTestSuite) TestRedisKvStore() {
 	s.NoError(err)
 	s.Equal("OK", result)
 
-	loader := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	loader, err := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	s.NoError(err)
 
 	fss, err := s.provideKvStoreFixtureSet()
 	s.NoError(err)
@@ -161,7 +164,8 @@ func (s *RedisTestSuite) TestRedisKvStoreWithPurge() {
 	s.NoError(err)
 	s.Equal("OK", result)
 
-	loader := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	loader, err := fixtures.NewFixtureLoader(envContext, envConfig, envLogger)
+	s.NoError(err)
 
 	fss, err := s.provideKvStoreFixtureSet()
 	s.NoError(err)

--- a/test/fixtures/s3/s3_test.go
+++ b/test/fixtures/s3/s3_test.go
@@ -36,7 +36,7 @@ func (s *S3TestSuite) SetupSuite() []suite.Option {
 }
 
 func (s *S3TestSuite) TestS3() {
-	err := s.Env().LoadFixtureSets(purgeDisabledFixtureSetsFactory)
+	err := s.Env().LoadFixtureSet(purgeDisabledFixtureSetsFactory)
 	s.NoError(err)
 
 	s3Client := s.Env().S3("default").Client()
@@ -80,7 +80,7 @@ func (s *S3TestSuite) TestS3() {
 }
 
 func (s *S3TestSuite) TestS3WithPurge() {
-	err := s.Env().LoadFixtureSets(purgeDisabledFixtureSetsFactory)
+	err := s.Env().LoadFixtureSet(purgeDisabledFixtureSetsFactory)
 	s.NoError(err)
 
 	s3Client := s.Env().S3("default").Client()
@@ -98,7 +98,7 @@ func (s *S3TestSuite) TestS3WithPurge() {
 	s.NoError(err)
 	s.Equal(28092, len(body))
 
-	err = s.Env().LoadFixtureSets(purgeEnabledFixtureSetsFactory)
+	err = s.Env().LoadFixtureSet(purgeEnabledFixtureSetsFactory)
 	s.NoError(err)
 
 	input = &s3.GetObjectInput{

--- a/test/guard/guard_test.go
+++ b/test/guard/guard_test.go
@@ -36,7 +36,7 @@ func (s *GuardTestSuite) SetupSuite() []suite.Option {
 		suite.WithLogLevel("debug"),
 		suite.WithSharedEnvironment(),
 		suite.WithConfigFile("config.dist.yml"),
-		suite.WithFixtureSetFactories(fixtureSetsFactory),
+		suite.WithFixtureSetFactory(fixtureSetsFactory),
 	}
 }
 

--- a/test/mdlsub/fixtures_test.go
+++ b/test/mdlsub/fixtures_test.go
@@ -26,7 +26,7 @@ func (s *FixturesTestSuite) SetupSuite() []suite.Option {
 		suite.WithLogLevel("debug"),
 		suite.WithConfigFile("config.dist.yml"),
 		suite.WithModuleFactory(mdlsub.NewSubscriberFactory(transformers)),
-		suite.WithFixtureSetFactories(mdlsub.FixtureSetFactory(transformers)),
+		suite.WithFixtureSetFactory(mdlsub.FixtureSetFactory(transformers)),
 		suite.WithEnvSetup(func() error {
 			wiremockAddress := s.Env().Wiremock("wiremock").Address()
 			config := s.Env().Config()


### PR DESCRIPTION
Major change of this release is the additions of post processors to the fixture package. These allow additional handling after loading the fixture data, e.g. populating internal caches. For this change, the signatures of adding fixtures has changed slightly:
```golang
func main() {
	application.RunHttpDefaultServer(
		api.DefineRouter,
		application.WithFixtureSetFactory("default", service.FixtureSetsFactory, service.PostProcessor),
	)
}
```
or if you want to add multiple groups with the same post processor:
```golang
func main() {
	application.RunHttpDefaultServer(
		api.DefineRouter,
		application.WithFixtureSetFactories(map[string]fixtures.FixtureSetsFactory{
			"group1": service.FixtureSetsFactory1,
			"group2": service.FixtureSetsFactory2,
		}, service.PostProcessor),
	)
}
```
The options for creating test suites have been adjusted accordingly:
```golang
func (s *TestSuite) SetupSuite() []suite.Option {
	return []suite.Option{
		suite.WithLogLevel(log.LevelWarn),
		suite.WithConfigFile("./config.test.yml"),
		suite.WithFixtureSetFactory(service.FixtureSetsFactory, service.PostProcessors...),
	}
}
```
and
```golang
func (s *TestSuite) SetupSuite() []suite.Option {
	return []suite.Option{
		suite.WithLogLevel("warn"),
		suite.WithConfigFile("../config.test.yml"),
		suite.WithFixtureSetFactories([]fixtures.FixtureSetsFactory{
			common.FixtureSetsFactory,
			service.FixtureSetsFactory,
		}, service.PostProcessor),
	}
}
```
Post processors have to implement a simple interface:
```golang
type PostProcessor interface {
	Process(ctx context.Context) error
}
```

