### PR TITLE
guard, reqctx: added cache to guard for current request and reqctx package to store data for the current request

### DIFF
--- a/pkg/appctx/appctx.go
+++ b/pkg/appctx/appctx.go
@@ -1,5 +1,5 @@
 // Package appctx provides a [context.Context] based mechanism of sharing certain "global" resources
 // across different parts of an application.
 // When building applications with the [github.com/justtrackio/gosoline/pkg/application] package
-// a Container is automatically injected into the applications context.
+// a Container is automatically injected into the application's context.
 package appctx

--- a/pkg/guard/guard.go
+++ b/pkg/guard/guard.go
@@ -39,7 +39,7 @@ func NewGuard(ctx context.Context, config cfg.Config, logger log.Logger) (*Ladon
 
 	auditLogger := NewAuditLogger(config, logger)
 
-	return NewGuardWithInterfaces(sqlManager, auditLogger), nil
+	return NewGuardWithInterfaces(NewCachedManagerWithInterfaces(sqlManager), auditLogger), nil
 }
 
 func NewGuardWithInterfaces(manager Manager, logger AuditLogger) *LadonGuard {

--- a/pkg/guard/manager_cache.go
+++ b/pkg/guard/manager_cache.go
@@ -1,0 +1,130 @@
+package guard
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/justtrackio/gosoline/pkg/reqctx"
+	"github.com/selm0/ladon"
+)
+
+type CachedManager struct {
+	manager Manager
+}
+
+type managerCache struct {
+	policyCache   map[string]ladon.Policy
+	policiesCache map[string]ladon.Policies
+}
+
+func NewCachedManagerWithInterfaces(manager Manager) Manager {
+	return &CachedManager{
+		manager: manager,
+	}
+}
+
+func (m CachedManager) Create(ctx context.Context, pol ladon.Policy) error {
+	reqctx.Delete[managerCache](ctx)
+
+	return m.manager.Create(ctx, pol)
+}
+
+func (m CachedManager) Update(ctx context.Context, pol ladon.Policy) error {
+	reqctx.Delete[managerCache](ctx)
+
+	return m.manager.Update(ctx, pol)
+}
+
+func (m CachedManager) Get(ctx context.Context, id string) (ladon.Policy, error) {
+	return m.findPolicy(ctx, id, func() (ladon.Policy, error) {
+		return m.manager.Get(ctx, id)
+	})
+}
+
+func (m CachedManager) Delete(ctx context.Context, id string) error {
+	reqctx.Delete[managerCache](ctx)
+
+	return m.manager.Delete(ctx, id)
+}
+
+func (m CachedManager) GetAll(ctx context.Context, limit, offset int64) (ladon.Policies, error) {
+	cacheKey := fmt.Sprintf("all:%d:%d", limit, offset)
+
+	return m.findPolicies(ctx, cacheKey, func() (ladon.Policies, error) {
+		return m.manager.GetAll(ctx, limit, offset)
+	})
+}
+
+func (m CachedManager) FindRequestCandidates(ctx context.Context, r *ladon.Request) (ladon.Policies, error) {
+	return m.FindPoliciesForSubject(ctx, r.Subject)
+}
+
+func (m CachedManager) FindPoliciesForSubject(ctx context.Context, subject string) (ladon.Policies, error) {
+	cacheKey := fmt.Sprintf("subject:%s", subject)
+
+	return m.findPolicies(ctx, cacheKey, func() (ladon.Policies, error) {
+		return m.manager.FindPoliciesForSubject(ctx, subject)
+	})
+}
+
+func (m CachedManager) FindPoliciesForResource(ctx context.Context, resource string) (ladon.Policies, error) {
+	cacheKey := fmt.Sprintf("resource:%s", resource)
+
+	return m.findPolicies(ctx, cacheKey, func() (ladon.Policies, error) {
+		return m.manager.FindPoliciesForResource(ctx, resource)
+	})
+}
+
+func (m CachedManager) findPolicy(ctx context.Context, cacheKey string, provider func() (ladon.Policy, error)) (ladon.Policy, error) {
+	cache := reqctx.Get[managerCache](ctx)
+	if cache != nil {
+		result, ok := cache.policyCache[cacheKey]
+		if ok {
+			return result, nil
+		}
+	}
+
+	policies, err := provider()
+	if err != nil {
+		return nil, err
+	}
+
+	if cache == nil {
+		cache = &managerCache{
+			policyCache:   make(map[string]ladon.Policy),
+			policiesCache: make(map[string]ladon.Policies),
+		}
+	}
+
+	cache.policyCache[cacheKey] = policies
+	reqctx.Set(ctx, *cache)
+
+	return policies, nil
+}
+
+func (m CachedManager) findPolicies(ctx context.Context, cacheKey string, provider func() (ladon.Policies, error)) (ladon.Policies, error) {
+	cache := reqctx.Get[managerCache](ctx)
+	if cache != nil {
+		result, ok := cache.policiesCache[cacheKey]
+		if ok {
+			return result, nil
+		}
+	}
+
+	policies, err := provider()
+	if err != nil {
+		return nil, err
+	}
+
+	if cache == nil {
+		cache = &managerCache{
+			policyCache:   make(map[string]ladon.Policy),
+			policiesCache: make(map[string]ladon.Policies),
+		}
+	}
+
+	cache.policiesCache[cacheKey] = policies
+	reqctx.Set(ctx, *cache)
+
+	return policies, nil
+}

--- a/pkg/httpserver/middleware_logger.go
+++ b/pkg/httpserver/middleware_logger.go
@@ -13,6 +13,7 @@ import (
 	"github.com/justtrackio/gosoline/pkg/exec"
 	"github.com/justtrackio/gosoline/pkg/funk"
 	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/justtrackio/gosoline/pkg/reqctx"
 )
 
 type logCall struct {
@@ -32,6 +33,7 @@ func NewLoggingMiddlewareWithInterfaces(logger log.Logger, settings LoggingSetti
 		start := clock.Now()
 
 		ctx := log.InitContext(ginCtx.Request.Context())
+		ctx = reqctx.New(ctx)
 
 		if requestId := ginCtx.Request.Header.Get("X-Request-Id"); requestId != "" {
 			ctx = log.MutateGlobalContextFields(ctx, map[string]any{

--- a/pkg/reqctx/reqctx.go
+++ b/pkg/reqctx/reqctx.go
@@ -1,0 +1,78 @@
+// Package reqctx provides a [context.Context] based mechanism to cache data for the duration of a request.
+// A new cache is automatically created for every request handled by the httpserver or every message consumed
+// by the stream package.
+package reqctx
+
+import (
+	"context"
+	"sync"
+)
+
+type reqCtx struct {
+	lck    sync.Mutex
+	values map[any]any
+}
+
+type reqCtxKey struct{}
+
+// New creates a new request context to hold values for the duration of a single request. The returned context is thread safe.
+func New(ctx context.Context) context.Context {
+	return context.WithValue(ctx, reqCtxKey{}, &reqCtx{
+		values: make(map[any]any),
+	})
+}
+
+// Get returns the stored value for the current request or nil if no value has yet been stored.
+// Nil is also returned if the context was not wrapped using New.
+// The returned value is located based on the requested type (thus, you can't store multiple values of the same type in one request).
+func Get[T any](ctx context.Context) *T {
+	var key *T // use a pointer as that is comparable
+
+	reqCtx, ok := ctx.Value(reqCtxKey{}).(*reqCtx)
+	if !ok {
+		return nil
+	}
+
+	reqCtx.lck.Lock()
+	valueI, ok := reqCtx.values[key]
+	reqCtx.lck.Unlock()
+	if !ok {
+		return nil
+	}
+
+	value, ok := valueI.(T)
+	if !ok {
+		return nil
+	}
+
+	return &value
+}
+
+// Set stores or updates the stored value. It does nothing if the context was not wrapped using New.
+// The value is located based on the type T, existing values in that request are overwritten.
+func Set[T any](ctx context.Context, value T) {
+	var key *T // use a pointer as that is comparable
+
+	reqCtx, ok := ctx.Value(reqCtxKey{}).(*reqCtx)
+	if !ok {
+		return
+	}
+
+	reqCtx.lck.Lock()
+	reqCtx.values[key] = value
+	reqCtx.lck.Unlock()
+}
+
+// Delete removes the stored value. It does nothing if the context was not wrapped using New or no value of the given type was stored.
+func Delete[T any](ctx context.Context) {
+	var key *T // use a pointer as that is comparable
+
+	reqCtx, ok := ctx.Value(reqCtxKey{}).(*reqCtx)
+	if !ok {
+		return
+	}
+
+	reqCtx.lck.Lock()
+	delete(reqCtx.values, key)
+	reqCtx.lck.Unlock()
+}

--- a/pkg/reqctx/reqctx_test.go
+++ b/pkg/reqctx/reqctx_test.go
@@ -1,0 +1,42 @@
+package reqctx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/reqctx"
+	"github.com/stretchr/testify/assert"
+)
+
+type typeA struct {
+	value int
+}
+
+type typeB struct {
+	value string
+}
+
+func TestReqCtx(t *testing.T) {
+	ctx := reqctx.New(context.Background())
+
+	a := reqctx.Get[typeA](ctx)
+	b := reqctx.Get[typeB](ctx)
+	assert.Nil(t, a)
+	assert.Nil(t, b)
+
+	reqctx.Set(ctx, typeA{value: 42})
+	reqctx.Set(ctx, typeB{value: "abc"})
+
+	a = reqctx.Get[typeA](ctx)
+	b = reqctx.Get[typeB](ctx)
+	assert.Equal(t, 42, a.value)
+	assert.Equal(t, "abc", b.value)
+
+	reqctx.Delete[typeA](ctx)
+	reqctx.Set(ctx, typeB{value: "def"})
+
+	a = reqctx.Get[typeA](ctx)
+	b = reqctx.Get[typeB](ctx)
+	assert.Nil(t, a)
+	assert.Equal(t, "def", b.value)
+}

--- a/pkg/stream/consumer.go
+++ b/pkg/stream/consumer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/kernel"
 	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/justtrackio/gosoline/pkg/reqctx"
 )
 
 type ConsumerCallbackFactory func(ctx context.Context, config cfg.Config, logger log.Logger) (ConsumerCallback, error)
@@ -146,6 +147,7 @@ func (c *Consumer) process(ctx context.Context, msg *Message, hasNativeRetry boo
 	defer span.Finish()
 
 	ctx = log.InitContext(ctx)
+	ctx = reqctx.New(ctx)
 
 	if ack, err = c.callback.Consume(ctx, model, attributes); err != nil {
 		c.handleError(ctx, err, "an error occurred during the consume operation")


### PR DESCRIPTION
We can do a lot of queries for the same policies if your response contains multiple objects you have to do access control on (e.g., returning a list of entities). To help here, we introduce a cache for the current request to avoid retrieving the same policies again and again.