### PR TITLE
mdlsub: types provider util for transformers

### DIFF
--- a/pkg/mdlsub/transformer.go
+++ b/pkg/mdlsub/transformer.go
@@ -28,6 +28,16 @@ type ModelTransformer interface {
 	Transform(ctx context.Context, inp any) (out Model, err error)
 }
 
+type TypesProvider[I any, M any] struct{}
+
+func (t TypesProvider[I, M]) GetInput() any {
+	return new(I)
+}
+
+func (t TypesProvider[I, M]) GetModel() any {
+	return new(M)
+}
+
 type (
 	ModelTransformers                  map[string]VersionedModelTransformers
 	TransformerFactory                 func(ctx context.Context, config cfg.Config, logger log.Logger) (ModelTransformer, error)

--- a/pkg/mdlsub/transformer_test.go
+++ b/pkg/mdlsub/transformer_test.go
@@ -14,14 +14,8 @@ type TestModel struct {
 	Id int `json:"id"`
 }
 
-type TestTransformer struct{}
-
-func (t TestTransformer) GetInput() any {
-	return &TestInput{}
-}
-
-func (t TestTransformer) GetModel() any {
-	return &TestModel{}
+type TestTransformer struct {
+	mdlsub.TypesProvider[TestInput, TestModel]
 }
 
 func (t TestTransformer) Transform(ctx context.Context, inp any) (out mdlsub.Model, err error) {

--- a/test/mdlsub/transformers.go
+++ b/test/mdlsub/transformers.go
@@ -28,14 +28,8 @@ func (m TestModel) GetId() any {
 	return m.Id
 }
 
-type TestTransformer struct{}
-
-func (t TestTransformer) GetInput() any {
-	return &TestInput{}
-}
-
-func (t TestTransformer) GetModel() any {
-	return &TestModel{}
+type TestTransformer struct {
+	mdlsub.TypesProvider[TestInput, TestModel]
 }
 
 func (t TestTransformer) Transform(ctx context.Context, inp any) (out mdlsub.Model, err error) {


### PR DESCRIPTION
This release adds a small helper for mdlsub transformers.  
Instead of implementing the `GetInput` and  `GetModel` functions, one can embed the `TypesProvider`.  

### before
```golang
type TestTransformer struct{}

func (t TestTransformer) GetInput() any {
	return &TestInput{}
}

func (t TestTransformer) GetModel() any {
	return &TestModel{}
}
```

### after
```golang
type TestTransformer struct {
	mdlsub.TypesProvider[TestInput, TestModel]
}
```