### PR TITLE
metric: limit warning logs and change metric queue to unbounded queue

### DIFF
--- a/pkg/blob/runner.go
+++ b/pkg/blob/runner.go
@@ -2,6 +2,7 @@ package blob
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -9,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/hashicorp/go-multierror"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	gosoS3 "github.com/justtrackio/gosoline/pkg/cloud/aws/s3"
 	"github.com/justtrackio/gosoline/pkg/kernel"
@@ -181,7 +181,7 @@ func (r *batchRunner) executeWrite(ctx context.Context) {
 			}
 
 			if err := body.Close(); err != nil {
-				object.Error = multierror.Append(object.Error, err)
+				object.Error = errors.Join(object.Error, err)
 			}
 
 			r.writeMetric(operationWrite)

--- a/pkg/cast/string.go
+++ b/pkg/cast/string.go
@@ -4,7 +4,6 @@ func ToSlicePtrString(s []string) []*string {
 	out := make([]*string, len(s))
 
 	for i, v := range s {
-		v := v
 		out[i] = &v
 	}
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -6,6 +6,7 @@ import (
 	"github.com/justtrackio/gosoline/pkg/appctx"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/kernel"
+	"github.com/justtrackio/gosoline/pkg/reslife"
 )
 
 func Run(module kernel.ModuleFactory, otherModuleMaps ...map[string]kernel.ModuleFactory) {
@@ -43,6 +44,7 @@ func Run(module kernel.ModuleFactory, otherModuleMaps ...map[string]kernel.Modul
 
 	options := []kernel.Option{
 		kernel.WithModuleFactory("cli", module, kernel.ModuleType(kernel.TypeEssential), kernel.ModuleStage(kernel.StageApplication)),
+		kernel.WithMiddlewareFactory(reslife.LifeCycleManagerMiddleware, kernel.PositionBeginning),
 	}
 
 	for _, otherModuleMap := range otherModuleMaps {

--- a/pkg/cloud/aws/sqs/attributes_test.go
+++ b/pkg/cloud/aws/sqs/attributes_test.go
@@ -48,7 +48,6 @@ func TestAttributeEncodeHandler_Encode(t *testing.T) {
 	}
 
 	for name, test := range testCases {
-		test := test
 		t.Run(name, func(t *testing.T) {
 			h := sqs.NewAttributeEncodeHandler(test.attr, test.provider)
 			ctx, attributes, err := h.Encode(context.Background(), test.msg, make(map[string]interface{}))

--- a/pkg/conc/lazy_test.go
+++ b/pkg/conc/lazy_test.go
@@ -61,7 +61,6 @@ func TestLazyConcurrently(t *testing.T) {
 	ch := make(chan struct{})
 	cfn := coffin.New()
 	for i := 0; i < 10; i++ {
-		i := i
 		cfn.Go(func() error {
 			<-ch
 			v, err := l.Get(i)

--- a/pkg/conc/scheduler/scheduler_test.go
+++ b/pkg/conc/scheduler/scheduler_test.go
@@ -49,7 +49,6 @@ func TestScheduler(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
-		i := i
 		wg.Add(1)
 		cfn.Go(func() error {
 			defer wg.Done()

--- a/pkg/db-repo/change_history_manager.go
+++ b/pkg/db-repo/change_history_manager.go
@@ -65,7 +65,6 @@ func (c *ChangeHistoryManager) RunMigrations() error {
 
 	cfn.Go(func() error {
 		for _, model := range funk.UniqByType(c.models) {
-			model := model
 			cfn.Go(func() error {
 				if err := c.RunMigration(model); err != nil {
 					return fmt.Errorf("can not run migration for model %T: %w", model, err)

--- a/pkg/exec/error_canceled_test.go
+++ b/pkg/exec/error_canceled_test.go
@@ -96,7 +96,6 @@ func TestIsRequestCanceled(t *testing.T) {
 			isCanceled: true,
 		},
 	} {
-		test := test
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, test.isCanceled, exec.IsRequestCanceled(test.err), "Expected canceled = %v for error %v", test.isCanceled, test.err)
 		})

--- a/pkg/funk/slice_test.go
+++ b/pkg/funk/slice_test.go
@@ -132,7 +132,6 @@ func TestChunk(t *testing.T) {
 		},
 	}
 	for name, data := range tests {
-		data := data
 		t.Run(name, func(t *testing.T) {
 			res := funk.Chunk(data.In.Sl, data.In.Size)
 			assert.Equalf(t, data.Out, res, "Test static failed: %s", data.Name)
@@ -181,7 +180,6 @@ func TestDifference(t *testing.T) {
 	}
 
 	for name, data := range tests {
-		data := data
 		t.Run(name, func(t *testing.T) {
 			l, r := funk.Difference(data.Input1, data.Input2)
 			assert.ElementsMatch(t, l, data.Out1)
@@ -262,7 +260,6 @@ func TestIntersect(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		test := test
 		t.Run(name, func(t *testing.T) {
 			res := funk.Intersect(test.Input1, test.Input2)
 			assert.ElementsMatch(t, res, test.Out)
@@ -312,7 +309,6 @@ func TestRepeatPrimitive(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		test := test
 		t.Run(name, func(t *testing.T) {
 			out := funk.Repeat(test.Element, test.Times)
 			assert.Equal(t, out, test.Out)
@@ -354,7 +350,6 @@ func TestRepeatStructPointer(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		test := test
 		t.Run(name, func(t *testing.T) {
 			out := funk.Repeat(test.Element, test.Times)
 			for idx, el := range out {
@@ -388,7 +383,6 @@ func TestTail(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		test := test
 		t.Run(name, func(t *testing.T) {
 			output := funk.Tail(test.input)
 
@@ -421,7 +415,6 @@ func TestReverse(t *testing.T) {
 	}
 
 	for name, data := range tests {
-		data := data
 		t.Run(name, func(t *testing.T) {
 			res := funk.Reverse(data.In)
 			assert.Equal(t, data.Out, res)
@@ -480,7 +473,6 @@ func TestPartition(t *testing.T) {
 	}
 
 	for name, data := range tests {
-		data := data
 		t.Run(name, func(t *testing.T) {
 			res := funk.Partition(data.In, func(t partitionable) int {
 				return t.time
@@ -523,7 +515,6 @@ func TestUniq(t *testing.T) {
 	}
 
 	for name, data := range tests {
-		data := data
 		t.Run(name, func(t *testing.T) {
 			res := funk.Uniq(data.In)
 
@@ -622,7 +613,6 @@ func TestUniqByType(t *testing.T) {
 	}
 
 	for name, data := range tests {
-		data := data
 		t.Run(name, func(t *testing.T) {
 			res := funk.UniqByType(data.In)
 
@@ -679,7 +669,6 @@ func TestPartitionByField(t *testing.T) {
 	}
 
 	for name, data := range tests {
-		data := data
 		t.Run(name, func(t *testing.T) {
 			keyer := func(el A) (string, int) {
 				return el.Type, el.Value
@@ -718,7 +707,6 @@ func TestAny(t *testing.T) {
 	}
 
 	for name, data := range tests {
-		data := data
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, data.Out, funk.Any(data.In, biggerThenZero))
 		})
@@ -753,7 +741,6 @@ func TestAll(t *testing.T) {
 	}
 
 	for name, data := range tests {
-		data := data
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, data.Out, funk.All(data.In, biggerThenZero))
 		})
@@ -788,7 +775,6 @@ func TestNone(t *testing.T) {
 	}
 
 	for name, data := range tests {
-		data := data
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, data.Out, funk.None(data.In, biggerThenZero))
 		})

--- a/pkg/metric/channel.go
+++ b/pkg/metric/channel.go
@@ -11,17 +11,20 @@ var metricChannelContainer = struct {
 	instance *metricChannel
 }{}
 
-func providerMetricChannel() *metricChannel {
+func providerMetricChannel(configure func(channel *metricChannel)) *metricChannel {
 	metricChannelContainer.Lock()
 	defer metricChannelContainer.Unlock()
 
 	if metricChannelContainer.instance != nil {
+		configure(metricChannelContainer.instance)
+
 		return metricChannelContainer.instance
 	}
 
 	metricChannelContainer.instance = &metricChannel{
 		hasData: make(chan struct{}, 1),
 	}
+	configure(metricChannelContainer.instance)
 
 	return metricChannelContainer.instance
 }

--- a/pkg/metric/daemon_test.go
+++ b/pkg/metric/daemon_test.go
@@ -1,8 +1,17 @@
 package metric_test
 
 import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/justtrackio/gosoline/pkg/appctx"
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/coffin"
 	"github.com/justtrackio/gosoline/pkg/kernel"
+	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/justtrackio/gosoline/pkg/metric"
+	"github.com/stretchr/testify/assert"
 )
 
 // ensure the metric daemon implements the typed and staged module interfaces
@@ -11,3 +20,96 @@ var _ interface {
 	kernel.TypedModule
 	kernel.StagedModule
 } = &metric.Daemon{}
+
+type slowWriter struct {
+	ctx context.Context
+}
+
+func (s slowWriter) GetPriority() int {
+	return metric.PriorityHigh
+}
+
+func (s slowWriter) Write(metric.Data) {
+	select {
+	case <-s.ctx.Done():
+	case <-time.After(time.Second):
+	}
+}
+
+func (s slowWriter) WriteOne(data *metric.Datum) {
+	s.Write(metric.Data{data})
+}
+
+func TestWriteLotsOfBadMetrics(t *testing.T) {
+	metric.RegisterWriterFactory("test", func(ctx context.Context, config cfg.Config, logger log.Logger) (metric.Writer, error) {
+		return slowWriter{
+			ctx: ctx,
+		}, nil
+	})
+
+	ctx, cancel := context.WithCancel(appctx.WithContainer(context.Background()))
+
+	config := cfg.New(map[string]any{
+		"env":         "test",
+		"app_project": "justtrack",
+		"app_family":  "gosoline",
+		"app_group":   "gosoline",
+		"app_name":    "metric_daemon_test",
+		"metric": map[string]any{
+			"enabled":  true,
+			"interval": "1s",
+			"writer":   "test",
+		},
+	})
+	logger := log.NewCliLogger()
+
+	daemon, err := metric.NewDaemonModule(ctx, config, logger)
+	assert.NoError(t, err)
+
+	writer := metric.NewWriter(&metric.Datum{
+		MetricName: "myMetricName",
+	})
+
+	cfn := coffin.New()
+	cfn.GoWithContext(ctx, daemon.Run)
+	cfn.GoWithContext(ctx, func(ctx context.Context) error {
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(time.Millisecond * 10):
+			}
+
+			writer.WriteOne(&metric.Datum{
+				MetricName: "myMetricName",
+			})
+		}
+	})
+	for i := 0; i < 10; i++ {
+		cfn.GoWithContext(ctx, func(ctx context.Context) error {
+			for {
+				select {
+				case <-ctx.Done():
+					return nil
+				default:
+				}
+
+				writer.WriteOne(&metric.Datum{
+					Priority:   metric.PriorityHigh,
+					MetricName: "myOtherMetricName",
+					Unit:       metric.UnitCount,
+					Value:      1,
+				})
+			}
+		})
+	}
+	cfn.Go(func() error {
+		time.Sleep(10 * time.Second)
+		cancel()
+
+		return nil
+	})
+
+	err = cfn.Wait()
+	assert.NoError(t, err)
+}

--- a/pkg/metric/prometheus_metric_server.go
+++ b/pkg/metric/prometheus_metric_server.go
@@ -62,10 +62,7 @@ func NewPrometheusMetricsServerModule(ctx context.Context, config cfg.Config, lo
 
 	settings := getMetricSettings(config)
 
-	if !slices.Contains(settings.Writers, WriterTypePrometheus) {
-		return nil, nil
-	}
-	if !promSettings.Api.Enabled {
+	if !slices.Contains(settings.Writers, WriterTypePrometheus) || !promSettings.Api.Enabled {
 		return nil, nil
 	}
 

--- a/pkg/metric/writer.go
+++ b/pkg/metric/writer.go
@@ -17,7 +17,7 @@ type writer struct {
 }
 
 func NewWriter(defaults ...*Datum) Writer {
-	channel := providerMetricChannel()
+	channel := providerMetricChannel(func(*metricChannel) {})
 
 	addMetricDefaults(defaults...)
 

--- a/pkg/stream/input_sqs.go
+++ b/pkg/stream/input_sqs.go
@@ -120,11 +120,15 @@ func (i *sqsInput) Run(ctx context.Context) error {
 
 	i.logger.Info("starting sqs input with %d runners", i.settings.RunnerCount)
 
-	for j := 0; j < i.settings.RunnerCount; j++ {
-		i.cfn.Gof(func() error {
-			return i.runLoop(ctx)
-		}, "panic in sqs input runner")
-	}
+	i.cfn.Go(func() error {
+		for j := 0; j < i.settings.RunnerCount; j++ {
+			i.cfn.Gof(func() error {
+				return i.runLoop(ctx)
+			}, "panic in sqs input runner")
+		}
+
+		return nil
+	})
 
 	<-i.cfn.Dying()
 	i.Stop()

--- a/pkg/stream/output_sqs_test.go
+++ b/pkg/stream/output_sqs_test.go
@@ -87,7 +87,6 @@ func TestSqsOutput_WriteOne(t *testing.T) {
 	}
 
 	for test, data := range tests {
-		data := data
 		t.Run(test, func(t *testing.T) {
 			logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 
@@ -250,7 +249,6 @@ func TestSqsOutput_Write(t *testing.T) {
 	}
 
 	for test, data := range tests {
-		data := data
 		t.Run(test, func(t *testing.T) {
 			logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
 

--- a/pkg/test/env/container_runner.go
+++ b/pkg/test/env/container_runner.go
@@ -124,8 +124,6 @@ func (r *containerRunner) PullContainerImages(skeletons []*componentSkeleton) er
 	cfn.Go(func() error {
 		for _, skeleton := range skeletons {
 			for _, description := range skeleton.containerDescriptions {
-				description := description
-
 				if description.containerConfig.UseExternalContainer {
 					continue
 				}
@@ -162,7 +160,7 @@ func (r *containerRunner) PullContainerImage(description *componentContainerDesc
 	err = r.pool.Client.PullImage(
 		pullImageOptions, authConfig)
 	if err != nil {
-		return err
+		return fmt.Errorf("could not pull image %q: %w", imageName, err)
 	}
 
 	return nil
@@ -182,8 +180,6 @@ func (r *containerRunner) RunContainers(skeletons []*componentSkeleton) error {
 
 	for i := range skeletons {
 		for name, description := range skeletons[i].containerDescriptions {
-			name := name
-			description := description
 			skeleton := skeletons[i]
 
 			cfn.Gof(func() error {

--- a/pkg/test/suite/testcase_httpserver_extended.go
+++ b/pkg/test/suite/testcase_httpserver_extended.go
@@ -256,8 +256,6 @@ func runHttpServerExtendedTestsMap(suite TestingSuite, testCases map[string]ToHt
 	testCaseRunners := make([]testCaseRunner, 0, len(testCases))
 
 	for name, testCasesProvider := range testCases {
-		name := name
-		testCasesProvider := testCasesProvider
 		runner, err := runHttpServerExtendedTests(suite, func() []*HttpserverTestCase {
 			if testCasesProvider == nil {
 				return nil

--- a/pkg/test/suite/testcase_stream.go
+++ b/pkg/test/suite/testcase_stream.go
@@ -134,8 +134,6 @@ func runStreamTestMap(testCases map[string]ToStreamTestCase) (testCaseRunner, er
 	testCaseRunners := make([]testCaseRunner, 0, len(testCases))
 
 	for name, testCasesProvider := range testCases {
-		name := name
-		testCasesProvider := testCasesProvider
 		runner := runStreamTest(func() *StreamTestCase {
 			if testCasesProvider == nil {
 				return nil

--- a/test/httpserver/compressed_test.go
+++ b/test/httpserver/compressed_test.go
@@ -60,8 +60,6 @@ func (s *CompressedTestSuite) TestCompressed() []*suite.HttpserverTestCase {
 	var result []*suite.HttpserverTestCase
 
 	for i, route := range []string{"/echo", "/uncompressed", "/this-path-uses-no-compression-to-echo"} {
-		i := i
-
 		result = append(result, &suite.HttpserverTestCase{
 			Method: netHttp.MethodPost,
 			Url:    route,


### PR DESCRIPTION
The metric daemon could run into two different deadlocks:
- Writing a metric to a full queue while the daemon was shutting down: In this case, the daemon was waiting for the lock on the metric channel struct, but the metric channel struct was busy writing to the channel and waiting for the daemon to read something from it.
- Writing a metric after an invalid metric: With proper timing, one could fill up the metric channel after the metric daemon took out an invalid message. Now the metric daemon would try to write a warning, which itself would write another metric. But the channel was already full and the metric daemon was now stuck waiting for itself reading a message from it.

This is now solved by changing the metric channel to only feature a single flag (are metrics available) and managing the batch of metrics that are available ourselves. That way, we can just ignore writes to the full flag channel and append the metrics to write anyway. When reading metrics, we can now take the whole batch instead of having to read single metrics from the channel and append them one by one.

Closes #1198