### PR TITLE
cfg: return deepcopy on Get;

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Static code analysis (golangci-lint)
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61.0
+          version: v1.62.2
           only-new-issues: true
           args: -v --build-tags fixtures,integration --timeout 5m --print-issued-lines --print-linter-name --out-format=colored-line-number
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
-golang 1.23.1
+golang 1.23.3
 gofumpt 0.6.0
-golangci-lint 1.61.0
+golangci-lint 1.62.2
 mockery 2.46.0
 nodejs 20.15.1
 protoc 24.2

--- a/go.mod
+++ b/go.mod
@@ -224,4 +224,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-go 1.23.1
+go 1.23.3

--- a/pkg/mapx/mapnode.go
+++ b/pkg/mapx/mapnode.go
@@ -7,10 +7,10 @@ import (
 )
 
 type MapXNode struct {
-	value interface{}
+	value any
 }
 
-func msiToMsn(src map[string]interface{}) map[string]*MapXNode {
+func msiToMsn(src map[string]any) map[string]*MapXNode {
 	target := make(map[string]*MapXNode)
 
 	for k, v := range src {
@@ -20,13 +20,13 @@ func msiToMsn(src map[string]interface{}) map[string]*MapXNode {
 	return target
 }
 
-func interfaceToMapNode(val interface{}) *MapXNode {
+func interfaceToMapNode(val any) *MapXNode {
 	switch val := val.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		msn := msiToMsn(val)
 		return &MapXNode{value: msn}
 
-	case []map[string]interface{}:
+	case []map[string]any:
 		slice := make([]map[string]*MapXNode, len(val))
 
 		for i, elem := range val {
@@ -35,8 +35,8 @@ func interfaceToMapNode(val interface{}) *MapXNode {
 
 		return &MapXNode{value: slice}
 
-	case []interface{}:
-		slice := make([]interface{}, len(val))
+	case []any:
+		slice := make([]any, len(val))
 
 		for i, v := range val {
 			slice[i] = interfaceToMapNode(v).value
@@ -49,19 +49,19 @@ func interfaceToMapNode(val interface{}) *MapXNode {
 	}
 }
 
-func nodeMsnToMsi(msn map[string]*MapXNode) map[string]interface{} {
-	msi := make(map[string]interface{})
+func nodeMsnToMsi(msn map[string]*MapXNode) map[string]any {
+	msi := make(map[string]any)
 
 	for k, node := range msn {
 		switch val := node.value.(type) {
 		case map[string]*MapXNode:
-			subMsi := make(map[string]interface{})
+			subMsi := make(map[string]any)
 
 			for k, node := range val {
 				switch val := node.value.(type) {
 				case map[string]*MapXNode:
 					subMsi[k] = nodeMsnToMsi(val)
-				case []interface{}:
+				case []any:
 					subMsi[k] = nodeSliceToSlice(val)
 				default:
 					subMsi[k] = val
@@ -70,7 +70,7 @@ func nodeMsnToMsi(msn map[string]*MapXNode) map[string]interface{} {
 
 			msi[k] = subMsi
 
-		case []interface{}:
+		case []any:
 			msi[k] = nodeSliceToSlice(val)
 
 		default:
@@ -81,14 +81,14 @@ func nodeMsnToMsi(msn map[string]*MapXNode) map[string]interface{} {
 	return msi
 }
 
-func nodeSliceToSlice(val []interface{}) []interface{} {
-	slice := make([]interface{}, len(val))
+func nodeSliceToSlice(val []any) []any {
+	slice := make([]any, len(val))
 
 	for i, elem := range val {
 		switch val := elem.(type) {
 		case map[string]*MapXNode:
 			slice[i] = nodeMsnToMsi(val)
-		case []interface{}:
+		case []any:
 			slice[i] = nodeSliceToSlice(val)
 		default:
 			slice[i] = val
@@ -98,11 +98,11 @@ func nodeSliceToSlice(val []interface{}) []interface{} {
 	return slice
 }
 
-func (n *MapXNode) Data() interface{} {
+func (n *MapXNode) Data() any {
 	switch val := n.value.(type) {
 	case map[string]*MapXNode:
 		return nodeMsnToMsi(val)
-	case []interface{}:
+	case []any:
 		return nodeSliceToSlice(val)
 	default:
 		return val
@@ -124,7 +124,7 @@ func (n *MapXNode) Map() (*MapX, error) {
 	return nil, fmt.Errorf("value should be of type map[string]*MapXNode but instead is %T", n.value)
 }
 
-func (n *MapXNode) Msi() (map[string]interface{}, error) {
+func (n *MapXNode) Msi() (map[string]any, error) {
 	var ok bool
 	var msn map[string]*MapXNode
 
@@ -137,12 +137,12 @@ func (n *MapXNode) Msi() (map[string]interface{}, error) {
 	return msi, nil
 }
 
-func (n *MapXNode) Slice() ([]interface{}, error) {
+func (n *MapXNode) Slice() ([]any, error) {
 	var ok bool
-	var slice []interface{}
+	var slice []any
 
-	if slice, ok = n.value.([]interface{}); !ok {
-		return nil, fmt.Errorf("value should be of type []interface{} but instead is %T", n.value)
+	if slice, ok = n.value.([]any); !ok {
+		return nil, fmt.Errorf("value should be of type []any but instead is %T", n.value)
 	}
 
 	return nodeSliceToSlice(slice), nil

--- a/pkg/mapx/struct_decode.go
+++ b/pkg/mapx/struct_decode.go
@@ -9,11 +9,11 @@ import (
 	"github.com/spf13/cast"
 )
 
-type MapStructDecoder func(targetType reflect.Type, val interface{}) (interface{}, error)
+type MapStructDecoder func(targetType reflect.Type, val any) (any, error)
 
-type MapStructCaster func(targetType reflect.Type, value interface{}) (interface{}, error)
+type MapStructCaster func(targetType reflect.Type, value any) (any, error)
 
-func MapStructDurationCaster(targetType reflect.Type, value interface{}) (interface{}, error) {
+func MapStructDurationCaster(targetType reflect.Type, value any) (any, error) {
 	if targetType != reflect.TypeOf(time.Duration(0)) {
 		return nil, nil
 	}
@@ -21,7 +21,7 @@ func MapStructDurationCaster(targetType reflect.Type, value interface{}) (interf
 	return cast.ToDurationE(value)
 }
 
-func MapStructTimeCaster(targetType reflect.Type, value interface{}) (interface{}, error) {
+func MapStructTimeCaster(targetType reflect.Type, value any) (any, error) {
 	if targetType != reflect.TypeOf(time.Time{}) {
 		return nil, nil
 	}
@@ -38,17 +38,17 @@ var mapStructSliceCasters = map[reflect.Kind]MapStructCaster{
 	reflect.String:  MapStructStringSliceCaster,
 }
 
-func MapStructStringSliceCaster(_ reflect.Type, value interface{}) (interface{}, error) {
+func MapStructStringSliceCaster(_ reflect.Type, value any) (any, error) {
 	return strings.Split(value.(string), ","), nil
 }
 
-func MapStructIntSliceCaster(_ reflect.Type, value interface{}) (interface{}, error) {
+func MapStructIntSliceCaster(_ reflect.Type, value any) (any, error) {
 	bits := strings.Split(value.(string), ",")
 
 	return cast.ToIntSliceE(bits)
 }
 
-func MapStructInt64SliceCaster(_ reflect.Type, value interface{}) (interface{}, error) {
+func MapStructInt64SliceCaster(_ reflect.Type, value any) (any, error) {
 	bits := strings.Split(value.(string), ",")
 	out := make([]int64, len(bits))
 	var err error
@@ -63,7 +63,7 @@ func MapStructInt64SliceCaster(_ reflect.Type, value interface{}) (interface{}, 
 	return out, nil
 }
 
-func MapStructFloat32SliceCaster(_ reflect.Type, value interface{}) (interface{}, error) {
+func MapStructFloat32SliceCaster(_ reflect.Type, value any) (any, error) {
 	bits := strings.Split(value.(string), ",")
 	out := make([]float32, len(bits))
 	var err error
@@ -78,7 +78,7 @@ func MapStructFloat32SliceCaster(_ reflect.Type, value interface{}) (interface{}
 	return out, nil
 }
 
-func MapStructFloat64SliceCaster(_ reflect.Type, value interface{}) (interface{}, error) {
+func MapStructFloat64SliceCaster(_ reflect.Type, value any) (any, error) {
 	bits := strings.Split(value.(string), ",")
 	out := make([]float64, len(bits))
 	var err error
@@ -93,14 +93,14 @@ func MapStructFloat64SliceCaster(_ reflect.Type, value interface{}) (interface{}
 	return out, nil
 }
 
-func MapStructBoolSliceCaster(_ reflect.Type, value interface{}) (interface{}, error) {
+func MapStructBoolSliceCaster(_ reflect.Type, value any) (any, error) {
 	bits := strings.Split(value.(string), ",")
 
 	return cast.ToBoolSliceE(bits)
 }
 
 // MapStructSliceCaster casts values to []T, based on casters in mapStructSliceCasters
-func MapStructSliceCaster(targetType reflect.Type, value interface{}) (interface{}, error) {
+func MapStructSliceCaster(targetType reflect.Type, value any) (any, error) {
 	if targetType.Kind() != reflect.Slice {
 		return nil, nil
 	}

--- a/pkg/mapx/struct_test.go
+++ b/pkg/mapx/struct_test.go
@@ -42,7 +42,7 @@ func TestMapStructIO_KeysBasic(t *testing.T) {
 	assert.Len(t, keys, 5)
 }
 
-// This tesst assumes that we can pass non-pointers of the same type for writing pointers to a mapStruct
+// This test assumes that we can pass non-pointers of the same type for writing pointers to a mapStruct
 // (env vars config values to ptr struct properties case)
 func TestMapStructIO_PointerTarget(t *testing.T) {
 	type sourceStruct struct {


### PR DESCRIPTION
Under certain circumstances you can trigger a `fatal error: concurrent map iteration and map write` within the config; especially when using multiple modules reading / writing in parallel.
This MR adds deepcopying to the basic `Get` to mitigate this issue.