### PR TITLE
httpserver, funk: handle validations and provide methods to box/unbox slice elements

### DIFF
--- a/pkg/funk/slice.go
+++ b/pkg/funk/slice.go
@@ -27,6 +27,14 @@ func CastSlice[T any, I ~[]any](sl I) ([]T, error) {
 	return result, nil
 }
 
+func BoxSlice[T any](sl []T) []*T {
+	return Map(sl, mdl.Box)
+}
+
+func UnboxSlice[T any](sl []*T) []T {
+	return Map(sl, mdl.EmptyIfNil)
+}
+
 func Partition[S ~[]T, T any, E comparable, F func(T) E](sl S, keyer F) map[E][]T {
 	result := make(map[E][]T)
 

--- a/pkg/funk/slice_test.go
+++ b/pkg/funk/slice_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/justtrackio/gosoline/pkg/funk"
+	"github.com/justtrackio/gosoline/pkg/mdl"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,6 +16,33 @@ func TestCastSlice(t *testing.T) {
 	target, err := funk.CastSlice[string](inputSlice)
 
 	assert.Equal(t, nil, err)
+	assert.Equal(t, expectedSlice, target)
+}
+
+func TestBoxSlice(t *testing.T) {
+	inputSlice := []string{"", ""}
+	expectedSlice := []*string{mdl.Box(""), mdl.Box("")}
+
+	target := funk.BoxSlice(inputSlice)
+
+	assert.Equal(t, expectedSlice, target)
+}
+
+func TestUnboxSlice(t *testing.T) {
+	inputSlice := []*string{mdl.Box(""), mdl.Box("")}
+	expectedSlice := []string{"", ""}
+
+	target := funk.UnboxSlice(inputSlice)
+
+	assert.Equal(t, expectedSlice, target)
+}
+
+func TestUnboxSlice_EmptyValue(t *testing.T) {
+	inputSlice := []*string{nil, nil}
+	expectedSlice := []string{"", ""}
+
+	target := funk.UnboxSlice(inputSlice)
+
 	assert.Equal(t, expectedSlice, target)
 }
 

--- a/pkg/httpserver/handler.go
+++ b/pkg/httpserver/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/justtrackio/gosoline/pkg/coffin"
 	"github.com/justtrackio/gosoline/pkg/exec"
+	"github.com/justtrackio/gosoline/pkg/validation"
 	"github.com/pkg/errors"
 	"github.com/spf13/cast"
 )
@@ -369,6 +370,17 @@ func handle(ginCtx *gin.Context, handler HandlerWithoutInput, input any, errHand
 	if exec.IsRequestCanceled(err) {
 		handleError(ginCtx, errHandler, HttpStatusClientWentAway, gin.Error{
 			Err:  err,
+			Type: gin.ErrorTypePrivate,
+		})
+
+		return
+	}
+
+	validErr := &validation.Error{}
+	if errors.As(err, &validErr) {
+		handleError(ginCtx, errHandler, http.StatusBadRequest, gin.Error{
+			// only pass the validation error in case it is wrapped in something else
+			Err:  validErr,
 			Type: gin.ErrorTypePrivate,
 		})
 

--- a/pkg/validation/error.go
+++ b/pkg/validation/error.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -32,4 +33,14 @@ func (e *Error) As(target interface{}) bool {
 	}
 
 	return ok
+}
+
+func NewError(errs ...error) *Error {
+	return &Error{Errors: errs}
+}
+
+func IsValidationError(err error) bool {
+	validErr := &Error{}
+
+	return errors.As(err, &validErr)
 }


### PR DESCRIPTION
For custom httpserver handlers it's good to unify the error handling as well; similar as for the crud handlers.
This release handles the validation.Error error and returns a HTTP 400 with the default error handling.
Additionally, some minor improvements for funk and validation are made to use them more comfortably.