### PR TITLE
log: introduce channel based log levels;

### DIFF
--- a/docs/docs/how-to/logging/implement-a-log-handler.mdx
+++ b/docs/docs/how-to/logging/implement-a-log-handler.mdx
@@ -65,8 +65,10 @@ This handler struct stores the log `channel`. To use your handler, you must impl
 Create a getter for the log channels:
 
 ```go
-func (h *MyCustomHandler) Channels() []string {
-	return []string{h.channel}
+func (h *MyCustomHandler) Channels() log.Channels {
+	return log.Channels{
+	    h.channel: log.PriorityInfo,
+	}
 }
 ```
 

--- a/docs/docs/how-to/logging/src/complex-logger/main.go
+++ b/docs/docs/how-to/logging/src/complex-logger/main.go
@@ -14,7 +14,7 @@ func main() {
 	ctx := context.Background()
 
 	// 2
-	handler := log.NewHandlerIoWriter(log.LevelDebug, []string{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
+	handler := log.NewHandlerIoWriter(log.LevelDebug, log.Channels{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
 	logger := log.NewLoggerWithInterfaces(clock.NewRealClock(), []log.Handler{handler})
 
 	if err := logger.Option(log.WithContextFieldsResolver(log.ContextFieldsResolver)); err != nil {

--- a/docs/docs/how-to/logging/src/config-logger/config.dist.yml
+++ b/docs/docs/how-to/logging/src/config-logger/config.dist.yml
@@ -10,7 +10,11 @@ log:
     handlers:
         main:
             type: iowriter
-            channels: []
+            channels:
+                metrics:
+                  level: error
+                formatter:
+                  level: error
             formatter: console
             level: info
             timestamp_format: 15:04:05.000

--- a/docs/docs/how-to/logging/src/log-handler/main.go
+++ b/docs/docs/how-to/logging/src/log-handler/main.go
@@ -16,8 +16,10 @@ type MyCustomHandler struct {
 	channel string
 }
 
-func (h *MyCustomHandler) Channels() []string {
-	return []string{h.channel}
+func (h *MyCustomHandler) Channels() log.Channels {
+	return log.Channels{
+		h.channel: log.PriorityDebug,
+	}
 }
 
 func (h *MyCustomHandler) Level() int {

--- a/docs/docs/how-to/logging/src/minimal-logger/main.go
+++ b/docs/docs/how-to/logging/src/minimal-logger/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	// 2
 	logHandler := log.NewHandlerIoWriter(
-		log.LevelInfo, []string{}, log.FormatterConsole, "", os.Stdout,
+		log.LevelInfo, log.Channels{}, log.FormatterConsole, "", os.Stdout,
 	)
 
 	// 3

--- a/docs/docs/reference/src/log/custom_handler.go
+++ b/docs/docs/reference/src/log/custom_handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 type MyCustomHandlerSettings struct {
-	Channel string `cfg:"channel"`
+	Channel log.Channels `cfg:"channel"`
 }
 
 func MyCustomHandlerFactory(config cfg.Config, name string) (log.Handler, error) {
@@ -17,16 +17,16 @@ func MyCustomHandlerFactory(config cfg.Config, name string) (log.Handler, error)
 	log.UnmarshalHandlerSettingsFromConfig(config, name, settings)
 
 	return &MyCustomHandler{
-		channel: settings.Channel,
+		channels: settings.Channel,
 	}, nil
 }
 
 type MyCustomHandler struct {
-	channel string
+	channels log.Channels
 }
 
-func (h *MyCustomHandler) Channels() []string {
-	return []string{h.channel}
+func (h *MyCustomHandler) Channels() log.Channels {
+	return h.channels
 }
 
 func (h *MyCustomHandler) Level() int {

--- a/docs/docs/reference/src/log/main.go
+++ b/docs/docs/reference/src/log/main.go
@@ -15,8 +15,8 @@ func main() {
 	handler := log.NewHandlerIoWriter(
 		// the min log level to write (trace, debug, info, warn, error)
 		log.LevelDebug,
-		// a list of channels to filter for, if empty nothing is filtered. []string{"http"} would write logs from http channel only
-		[]string{},
+		// configuration of channels to filter for, if empty handler default will be used
+		log.Channels{},
 		// how to format the message. this will format in a console friendly way. log.FormatterJson would format log message as json
 		log.FormatterConsole,
 		// how to format the log time. uses the structure of the `time` package

--- a/docs/docs/reference/src/log/usage.go
+++ b/docs/docs/reference/src/log/usage.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Usage() {
-	handler := log.NewHandlerIoWriter(log.LevelDebug, []string{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
+	handler := log.NewHandlerIoWriter(log.LevelDebug, log.Channels{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
 	logger := log.NewLoggerWithInterfaces(clock.NewRealClock(), []log.Handler{handler})
 
 	if err := logger.Option(log.WithContextFieldsResolver(log.ContextFieldsResolver)); err != nil {

--- a/pkg/application/error.go
+++ b/pkg/application/error.go
@@ -15,7 +15,7 @@ func withDefaultErrorHandler(handler ErrorHandler) {
 }
 
 var defaultErrorHandler = func(msg string, args ...interface{}) {
-	writerHandler := log.NewHandlerIoWriter(log.LevelInfo, []string{}, log.FormatterJson, "2006-01-02T15:04:05.999Z07:00", os.Stdout)
+	writerHandler := log.NewHandlerIoWriter(log.LevelInfo, log.Channels{}, log.FormatterJson, "2006-01-02T15:04:05.999Z07:00", os.Stdout)
 	metricHandler := metric.NewLoggerHandler()
 
 	logger := log.NewLoggerWithInterfaces(clock.Provider, []log.Handler{

--- a/pkg/cli/logger.go
+++ b/pkg/cli/logger.go
@@ -16,7 +16,7 @@ func newCliLogger() (log.Logger, error) {
 		return nil, fmt.Errorf("can not create io file writer for logger: %w", err)
 	}
 
-	handler := log.NewHandlerIoWriter(log.LevelInfo, []string{}, log.FormatterConsole, "", writer)
+	handler := log.NewHandlerIoWriter(log.LevelInfo, log.Channels{}, log.FormatterConsole, "", writer)
 	logger := log.NewLoggerWithInterfaces(clock.Provider, []log.Handler{handler})
 
 	return logger, nil

--- a/pkg/lambda/error.go
+++ b/pkg/lambda/error.go
@@ -15,7 +15,7 @@ func WithDefaultErrorHandler(handler ErrorHandler) {
 }
 
 var defaultErrorHandler = func(msg string, args ...interface{}) {
-	writerHandler := log.NewHandlerIoWriter(log.LevelInfo, []string{}, log.FormatterJson, "2006-01-02T15:04:05.999Z07:00", os.Stdout)
+	writerHandler := log.NewHandlerIoWriter(log.LevelInfo, log.Channels{}, log.FormatterJson, "2006-01-02T15:04:05.999Z07:00", os.Stdout)
 	metricHandler := metric.NewLoggerHandler()
 
 	logger := log.NewLoggerWithInterfaces(clock.Provider, []log.Handler{

--- a/pkg/log/builtin.go
+++ b/pkg/log/builtin.go
@@ -13,5 +13,5 @@ func NewCliLogger() Logger {
 }
 
 func NewCliHandler() Handler {
-	return NewHandlerIoWriter(LevelInfo, []string{}, FormatterConsole, "15:04:05.000", os.Stdout)
+	return NewHandlerIoWriter(LevelInfo, Channels{}, FormatterConsole, "15:04:05.000", os.Stdout)
 }

--- a/pkg/log/handler.go
+++ b/pkg/log/handler.go
@@ -8,10 +8,12 @@ import (
 )
 
 type Handler interface {
-	Channels() []string
+	Channels() Channels
 	Level() int
 	Log(timestamp time.Time, level int, msg string, args []interface{}, err error, data Data) error
 }
+
+type Channels map[string]int
 
 type HandlerFactory func(config cfg.Config, name string) (Handler, error)
 

--- a/pkg/log/handler_sentry.go
+++ b/pkg/log/handler_sentry.go
@@ -39,8 +39,8 @@ func (h *HandlerSentry) WithContext(name string, context map[string]interface{})
 	})
 }
 
-func (h *HandlerSentry) Channels() []string {
-	return []string{}
+func (h *HandlerSentry) Channels() Channels {
+	return Channels{}
 }
 
 func (h *HandlerSentry) Level() int {

--- a/pkg/log/logger_context_enforce_test.go
+++ b/pkg/log/logger_context_enforce_test.go
@@ -23,7 +23,7 @@ func (s *ContextEnforcingLoggerTestSuite) SetupTest() {
 	s.clock = clock.NewFakeClock()
 	s.output = &bytes.Buffer{}
 	s.base = log.NewLoggerWithInterfaces(s.clock, []log.Handler{
-		log.NewHandlerIoWriter(log.LevelInfo, []string{}, log.FormatterConsole, "15:04:05.000", s.output),
+		log.NewHandlerIoWriter(log.LevelInfo, log.Channels{}, log.FormatterConsole, "15:04:05.000", s.output),
 	})
 
 	s.logger = log.NewContextEnforcingLoggerWithInterfaces(s.base, log.GetMockedStackTrace, s.base)
@@ -45,8 +45,8 @@ func (s *ContextEnforcingLoggerTestSuite) TestInfoWithoutContext() {
 }
 
 func (s *ContextEnforcingLoggerTestSuite) TestInfoWithoutContextWithChannel() {
-	s.logger.WithChannel("channel").Info("this is a info message")
-	s.Equal("00:00:00.000 context_missing warn    you should add the context to your logger: mocked trace\n00:00:00.000 channel info    this is a info message\n", s.output.String())
+	s.logger.WithChannel("Channel").Info("this is a info message")
+	s.Equal("00:00:00.000 context_missing warn    you should add the context to your logger: mocked trace\n00:00:00.000 Channel info    this is a info message\n", s.output.String())
 }
 
 func (s *ContextEnforcingLoggerTestSuite) TestInfoWithoutContextWithFields() {

--- a/pkg/log/testdata/config.yml
+++ b/pkg/log/testdata/config.yml
@@ -1,7 +1,11 @@
 log:
-  level: warn
   handlers:
     main:
       type: iowriter
       level: debug
+      channels:
+        metrics:
+          level: error
+      formatter: json
+      timestamp_format: 2006-01-02T15:04:05Z07:00
       writer: stdout

--- a/pkg/metric/logger_handler.go
+++ b/pkg/metric/logger_handler.go
@@ -28,8 +28,8 @@ type LoggerHandler struct {
 	writer Writer
 }
 
-func (h LoggerHandler) Channels() []string {
-	return []string{}
+func (h LoggerHandler) Channels() log.Channels {
+	return log.Channels{}
 }
 
 func (h LoggerHandler) Level() int {

--- a/pkg/test/env/logging.go
+++ b/pkg/test/env/logging.go
@@ -70,7 +70,7 @@ func NewRecordingConsoleLogger(options ...LoggerOption) (RecordingLogger, error)
 	}
 
 	cl := clock.NewRealClock()
-	handler := log.NewHandlerIoWriter(settings.Level, []string{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
+	handler := log.NewHandlerIoWriter(settings.Level, log.Channels{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
 
 	logger := log.NewLoggerWithInterfaces(cl, []log.Handler{handler})
 
@@ -110,8 +110,8 @@ func (r recordingLogger) Reset() {
 	}
 }
 
-func (h handlerInMemoryWriter) Channels() []string {
-	return []string{}
+func (h handlerInMemoryWriter) Channels() log.Channels {
+	return log.Channels{}
 }
 
 func (h handlerInMemoryWriter) Level() int {

--- a/pkg/tracing/logging.go
+++ b/pkg/tracing/logging.go
@@ -33,8 +33,8 @@ func NewLoggerErrorHandler() *LoggerErrorHandler {
 	return &LoggerErrorHandler{}
 }
 
-func (h *LoggerErrorHandler) Channels() []string {
-	return []string{}
+func (h *LoggerErrorHandler) Channels() log.Channels {
+	return log.Channels{}
 }
 
 func (h *LoggerErrorHandler) Level() int {

--- a/test/httpserver/eof_bind_test.go
+++ b/test/httpserver/eof_bind_test.go
@@ -47,7 +47,7 @@ type bindHandler struct {
 	suite.Suite
 }
 
-func (b bindHandler) Channels() []string {
+func (b bindHandler) Channels() log.Channels {
 	return nil
 }
 


### PR DESCRIPTION
We identified a use case where we need finer control over log levels for specific channels to prevent excessive logging while maintaining observability. Previously, the logger configuration allowed defining a set of channels per handler but enforced a single log level for all of them.

This PR introduces per-channel log level configuration

Previously
```yaml
log:
  handlers:
    main:
      type: iowriter
      level: debug
      channels: [metrics]
      formatter: json
      timestamp_format: 2006-01-02T15:04:05Z07:00
      writer: stdout
``` 

With the change
```yaml
log:
  handlers:
    main:
      type: iowriter
      level: debug
      channels:
        - name: metrics
          level: error
      formatter: json
      timestamp_format: 2006-01-02T15:04:05Z07:00
      writer: stdout
```

With this change, the metrics channel can be configured to log only error level messages, even if the handler’s default level is debug. 

Important note: This is a breaking change, we could come up with a solution/dirty hack to make this a non-breaking change too if needed.