### PR TITLE
httpserver: graceful server shutdown

### DIFF
--- a/pkg/cloud/aws/ssm/systems_manager.go
+++ b/pkg/cloud/aws/ssm/systems_manager.go
@@ -25,8 +25,8 @@ type simpleSystemsManager struct {
 	client Client
 }
 
-func NewSimpleSystemsManager(ctx context.Context, config cfg.Config, logger log.Logger, clientName string) (*simpleSystemsManager, error) {
-	client, err := ProvideClient(ctx, config, logger, clientName)
+func NewSimpleSystemsManager(ctx context.Context, config cfg.Config, logger log.Logger, clientName string, optFns ...ClientOption) (*simpleSystemsManager, error) {
+	client, err := ProvideClient(ctx, config, logger, clientName, optFns...)
 	if err != nil {
 		return nil, fmt.Errorf("can not create ssm client: %w", err)
 	}

--- a/pkg/reslife/settings_test.go
+++ b/pkg/reslife/settings_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSettingsDefaults(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name     string
 		config   map[string]any
 		expected *reslife.Settings

--- a/pkg/test/suite/testcase_httpserver_extended_test.go
+++ b/pkg/test/suite/testcase_httpserver_extended_test.go
@@ -63,6 +63,10 @@ func (s *GatewayTestSuite) SetupApiDefinitions() httpserver.Definer {
 	return func(ctx context.Context, config cfg.Config, logger log.Logger) (*httpserver.Definitions, error) {
 		d := &httpserver.Definitions{}
 
+		d.GET("/noop", func(ginCtx *gin.Context) {
+			ginCtx.String(http.StatusOK, "{}")
+		})
+
 		d.POST("/echo", func(ginCtx *gin.Context) {
 			body, err := io.ReadAll(ginCtx.Request.Body)
 			s.NoError(err)
@@ -162,7 +166,7 @@ func (s *GatewayTestSuite) TestMultipleTestsWithNil() []*suite.HttpserverTestCas
 func (s *GatewayTestSuite) createTestCase() *suite.HttpserverTestCase {
 	return &suite.HttpserverTestCase{
 		Method:             http.MethodGet,
-		Url:                "/health",
+		Url:                "/noop",
 		Headers:            map[string]string{},
 		Body:               struct{}{},
 		ExpectedStatusCode: http.StatusOK,


### PR DESCRIPTION
The current httpserver gets closed once the kernel gets stopped which can result in connection issues if there are still open connections or if the app still gets new connections.  

This release enables more graceful shutdown behaviour for the httpserver by implementing 2 additional timeouts:
```yaml
httpserver:
  default:
    timeout:
      drain: 30s
      shutdown: 30s
```
On kernel stop, the httpserver module will get unhealthy but won't close the server until the configured *drain* timeout runs out. In this time frame the orchestrator can adjust the traffic flow, so that the app won't get any new connections. After draining, the http server shuts down and will wait for at most the configured *shutdown* timeout to handle all remaining open connections. 
