### PR TITLE
reslife: resource exclude patterns

### DIFF
--- a/pkg/reslife/settings.go
+++ b/pkg/reslife/settings.go
@@ -1,0 +1,25 @@
+package reslife
+
+import "github.com/justtrackio/gosoline/pkg/cfg"
+
+type Settings struct {
+	Create   SettingsCycle `cfg:"create"`
+	Init     SettingsCycle `cfg:"init"`
+	Register SettingsCycle `cfg:"register"`
+	Purge    SettingsCycle `cfg:"purge"`
+}
+
+type SettingsCycle struct {
+	Enabled  bool     `cfg:"enabled"`
+	Excludes []string `cfg:"excludes"`
+}
+
+func ReadSettings(config cfg.Config) *Settings {
+	settings := &Settings{}
+	config.UnmarshalKey("resource_lifecycles", settings, []cfg.UnmarshalDefaults{
+		cfg.UnmarshalWithDefaultForKey("init.enabled", true),
+		cfg.UnmarshalWithDefaultForKey("register.enabled", true),
+	}...)
+
+	return settings
+}

--- a/pkg/reslife/settings_test.go
+++ b/pkg/reslife/settings_test.go
@@ -1,0 +1,83 @@
+package reslife_test
+
+import (
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/reslife"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSettingsDefaults(t *testing.T) {
+	var tests = []struct {
+		name     string
+		config   map[string]any
+		expected *reslife.Settings
+	}{
+		{
+			name:   "all defaults",
+			config: map[string]any{},
+			expected: &reslife.Settings{
+				Create:   reslife.SettingsCycle{Enabled: false},
+				Init:     reslife.SettingsCycle{Enabled: true},
+				Register: reslife.SettingsCycle{Enabled: true},
+				Purge:    reslife.SettingsCycle{Enabled: false},
+			},
+		},
+		{
+			name: "all disabled",
+			config: map[string]any{
+				"create": map[string]any{
+					"enabled": false,
+				},
+				"init": map[string]any{
+					"enabled": false,
+				},
+				"register": map[string]any{
+					"enabled": false,
+				},
+				"purge": map[string]any{
+					"enabled": false,
+				},
+			},
+			expected: &reslife.Settings{
+				Create:   reslife.SettingsCycle{Enabled: false},
+				Init:     reslife.SettingsCycle{Enabled: false},
+				Register: reslife.SettingsCycle{Enabled: false},
+				Purge:    reslife.SettingsCycle{Enabled: false},
+			},
+		},
+		{
+			name: "all enabled",
+			config: map[string]any{
+				"create": map[string]any{
+					"enabled": true,
+				},
+				"init": map[string]any{
+					"enabled": true,
+				},
+				"register": map[string]any{
+					"enabled": true,
+				},
+				"purge": map[string]any{
+					"enabled": true,
+				},
+			},
+			expected: &reslife.Settings{
+				Create:   reslife.SettingsCycle{Enabled: true},
+				Init:     reslife.SettingsCycle{Enabled: true},
+				Register: reslife.SettingsCycle{Enabled: true},
+				Purge:    reslife.SettingsCycle{Enabled: true},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := cfg.NewWithInterfaces(cfg.NewMemoryEnvProvider(), map[string]any{"resource_lifecycles": test.config})
+			settings := reslife.ReadSettings(config)
+
+			assert.Equal(t, test.expected, settings)
+		})
+	}
+}


### PR DESCRIPTION
In some cases there is more fine grained control needed about which resources should get handled by the life cycle manager and which not. To enable this advanced control, this release adds exclude lists to all life cycles.  
These can be set via config:
```yaml
resource_lifecycles:
  create:
    enabled: true
    excludes: [db/.*]
  init:
    enabled: true
  register:
    enabled: true
  purge:
    enabled: false
```

The excludes setting is a list of strings which will get interpreted as regular expressions.  
If the id of a resource matches one of the patterns, it will get excluded of that specific life cycle management.  
In case of the previous example, the create life cycle will not get executed for all db resources. 