### PR TITLE
feat: Handle side by side metric collection for cloudwatch and promet…

### DIFF
--- a/pkg/metric/datum.go
+++ b/pkg/metric/datum.go
@@ -14,6 +14,7 @@ type Datum struct {
 	Dimensions Dimensions   `json:"dimensions"`
 	Value      float64      `json:"value"`
 	Unit       StandardUnit `json:"unit"`
+	Kind       Kind         `json:"-"`
 }
 
 func (d *Datum) Id() string {

--- a/pkg/metric/writer.go
+++ b/pkg/metric/writer.go
@@ -4,17 +4,31 @@ import (
 	"github.com/justtrackio/gosoline/pkg/clock"
 )
 
-//go:generate mockery --name Writer
-type Writer interface {
-	GetPriority() int
-	Write(batch Data)
-	WriteOne(data *Datum)
-}
+const (
+	PriorityLow  = 1
+	PriorityHigh = 2
 
-type writer struct {
-	clock   clock.Clock
-	channel *metricChannel
-}
+	KindTotal   = "total"
+	KindDefault = ""
+
+	DimensionDefault = "{{default}}"
+)
+
+//go:generate mockery --name Writer
+type (
+	Writer interface {
+		GetPriority() int
+		Write(batch Data)
+		WriteOne(data *Datum)
+	}
+
+	writer struct {
+		clock   clock.Clock
+		channel *metricChannel
+	}
+
+	Kind string
+)
 
 func NewWriter(defaults ...*Datum) Writer {
 	channel := providerMetricChannel(func(*metricChannel) {})

--- a/pkg/metric/writer_es.go
+++ b/pkg/metric/writer_es.go
@@ -17,6 +17,8 @@ func init() {
 	RegisterWriterFactory(WriterTypeElasticsearch, ProvideElasticsearchWriter)
 }
 
+var _ Writer = &elasticsearchWriter{}
+
 type esMetricDatum struct {
 	*Datum
 	Namespace string `json:"namespace"`

--- a/pkg/metric/writer_prometheus.go
+++ b/pkg/metric/writer_prometheus.go
@@ -140,7 +140,7 @@ func (w *prometheusWriter) writeMetricFromDatum(datum *Datum) {
 	}()
 
 	if strings.Contains(datum.MetricName, "-") {
-		w.logger.Warn("metric name %s is invalid, as it contains a - characters, gracefully replacing with an _ character", datum.MetricName)
+		w.logger.Error("metric name %s is invalid, as it contains a - characters, gracefully replacing with an _ character", datum.MetricName)
 		datum.MetricName = replacer.Replace(datum.MetricName)
 	}
 

--- a/pkg/reslife/settings_test.go
+++ b/pkg/reslife/settings_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSettingsDefaults(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name     string
 		config   map[string]any
 		expected *reslife.Settings


### PR DESCRIPTION
…heus

In cloudwatch we are writing 'total metric timeseries' for metrics which exhibit dimensions. We write this timeseries on the same metric name as the dimension timeseries but without dimensions. We do this such that we have an aggregation over all dimension values which is otherwise not possible in cloudwatch. This is however against prometheus best practices and actually clashes with the metric registration. Typically we have the default metric written (eg a count with value 0) also without any dimensions. Later on we write the actual values with the dimensions. This clashes in prometheus, as the metric that was registered (the first one) was written without labels. This commit introduces a way to flag metric datums as KindTotal, allowing us to filter these out in the prometheus writer. Also we are removing any dimensions with the new DimensionDefault for cloudwatch, allowing us to initialize metrics in prometheus without affecting the behaviour in cloudwatch.

The impact is now:
``` go
// The old way a default metric was defined
		{
			Priority:   metric.PriorityHigh,
			MetricName: "foo",
			Unit:  metric.UnitCount,
			Value: 0.0,
		}

// And how we are sending it
		{
			Priority:   metric.PriorityHigh,
			MetricName: "foo",
			Dimensions: map[string]string{
				"bar": "foobar",
			},
			Unit:  metric.UnitCount,
			Value: 1.0,
		},
		{
			Priority:   metric.PriorityHigh,
			MetricName: "foo",
			Unit:  metric.UnitCount,
			Value: 1.0,
		}


// After this change we define a default metric like this
		{
			Priority:   metric.PriorityHigh,
			MetricName: "foo",
			Dimensions: map[string]string{
				"bar": metric.DimensionDefault,
			},
			Unit:  metric.UnitCount,
			Value: 0.0,
		}

// And how we send it
		{
			Priority:   metric.PriorityHigh,
			MetricName: "foo",
			Dimensions: map[string]string{
				"bar": "foobar",
			},
			Unit:  metric.UnitCount,
			Value: 1.0,
		},
		{
			Priority:   metric.PriorityHigh,
			MetricName: "foo",
			Unit:  metric.UnitCount,
			Kind: metric.KindTotal,
			Value: 1.0,
		}		

```