### PR TITLE
[limit]: update metric name for prometheus compatability;

### DIFF
--- a/pkg/limit/middleware_metrics.go
+++ b/pkg/limit/middleware_metrics.go
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	MetricNameRateLimitRelease  = "rate-limit-release"
-	MetricNameRateLimitTake     = "rate-limit-take"
-	MetricNameRateLimitThrottle = "rate-limit-throttle"
-	MetricNameRateLimitError    = "rate-limit-error"
+	MetricNameRateLimitRelease  = "rate_limit_release"
+	MetricNameRateLimitTake     = "rate_limit_take"
+	MetricNameRateLimitThrottle = "rate_limit_throttle"
+	MetricNameRateLimitError    = "rate_limit_error"
 )
 
 type metricMiddleware struct {


### PR DESCRIPTION
The existing metric names for the limit package are not compatible with Prometheus - they contain dashes.
This MR exchanges them for underscores.