### PR TITLE
clock: make timer and ticker threadsafe

### DIFF
--- a/pkg/stream/input_configurable.go
+++ b/pkg/stream/input_configurable.go
@@ -91,6 +91,7 @@ func newInMemoryInputFromConfig(_ context.Context, config cfg.Config, _ log.Logg
 
 func newKafkaInputFromConfig(ctx context.Context, config cfg.Config, logger log.Logger, name string) (Input, error) {
 	key := ConfigurableInputKey(name)
+
 	return NewKafkaInput(ctx, config, logger, key)
 }
 


### PR DESCRIPTION
The `Reset` and `Stop` methods of tickers and timers used to be non-threadsafe. However, as this is prone to errors and can easily be fixed, this PR changes them to be safe to call from multiple threads (for example, when using a ticker to implement some basic concurrent rate limiting).