### PR TITLE
test/suite: fix race condition between subscriber and app stop

### DIFF
--- a/pkg/test/suite/testcase_subscriber.go
+++ b/pkg/test/suite/testcase_subscriber.go
@@ -117,7 +117,6 @@ func buildTestCaseSubscriber(_ TestingSuite, method reflect.Method) (TestCaseRun
 			inputName := mdlsub.GetSubscriberFQN(tc.GetName(), sourceModel)
 			suite.Env().StreamInput(inputName).PublishAndStop(tc.GetInput(), attrs)
 
-			app.Stop()
 			app.WaitDone()
 
 			config := suite.Env().Config()


### PR DESCRIPTION
The subscriber test case runner erroneously calls app.Stop. This was okay to do in the past, but now it races with the subscriber actually processing the message. As we already stopped the input, removing the call is enough to fix the issue and get the tests working reliable again.