### PR TITLE
cloud/aws: add assumerolewithwebidentity support;

### DIFF
--- a/pkg/cloud/aws/awsv2.go
+++ b/pkg/cloud/aws/awsv2.go
@@ -37,6 +37,11 @@ type CredentialsCacheOptions struct {
 	ExpiryWindowJitterFrac float64       `cfg:"expiry_window_jitter_frac" default:"0.1"`
 }
 
+type WebIdentitySettings struct {
+	TokenFilePath string `cfg:"web_identity_token_file"`
+	RoleARN       string `cfg:"role_arn"`
+}
+
 type ClientHttpSettings struct {
 	Timeout time.Duration `cfg:"timeout" default:"0"`
 }
@@ -45,6 +50,7 @@ type ClientSettings struct {
 	Region               string                  `cfg:"region" default:"eu-central-1"`
 	Endpoint             string                  `cfg:"endpoint" default:"http://localhost:4566"`
 	AssumeRole           string                  `cfg:"assume_role"`
+	UseWebIdentity       bool                    `cfg:"use_web_identity"`
 	Profile              string                  `cfg:"profile"`
 	Credentials          Credentials             `cfg:"credentials"`
 	CredentialsCacheOpts CredentialsCacheOptions `cfg:"credentials_cache"`
@@ -61,6 +67,7 @@ func (s *ClientSettings) LogFields() log.Fields {
 		"settings_region":                          s.Region,
 		"settings_endpoint":                        s.Endpoint,
 		"settings_assume_role":                     s.AssumeRole,
+		"settings_use_web_identity":                s.UseWebIdentity,
 		"settings_credentials_cache_expiry_window": s.CredentialsCacheOpts.ExpiryWindow,
 		"settings_credentials_cache_jitter_frac":   s.CredentialsCacheOpts.ExpiryWindowJitterFrac,
 		"settings_http_client_timeout":             s.HttpClient.Timeout,
@@ -97,6 +104,7 @@ func UnmarshalClientSettings(config cfg.Config, settings ClientSettingsAware, se
 		cfg.UnmarshalWithDefaultsFromKey("cloud.aws.defaults.http_client", "http_client"),
 		cfg.UnmarshalWithDefaultsFromKey("cloud.aws.defaults.assume_role", "assume_role"),
 		cfg.UnmarshalWithDefaultsFromKey("cloud.aws.defaults.profile", "profile"),
+		cfg.UnmarshalWithDefaultsFromKey("cloud.aws.defaults.use_web_identity", "use_web_identity"),
 		cfg.UnmarshalWithDefaultsFromKey(defaultsKey, "."),
 		cfg.UnmarshalWithDefaultsFromKey(clientDefaultsKey, "."),
 		cfg.UnmarshalWithDefaultsFromKey(defaultClientKey, "."),

--- a/pkg/cloud/aws/credentials_test.go
+++ b/pkg/cloud/aws/credentials_test.go
@@ -2,6 +2,7 @@ package aws_test
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -216,6 +217,18 @@ func (s *CredentialsTestSuite) TestCredentialsCacheOptions() {
 			s.Equal(test.expected.ExpiryWindowJitterFrac, settings.CredentialsCacheOpts.ExpiryWindowJitterFrac)
 		})
 	}
+}
+
+func (s *CredentialsTestSuite) TestWebIdentityRoleProvider() {
+	s.NoError(os.Setenv("AWS_ROLE_ARN", "arn:aws:iam::0000000000:role/test"))
+	s.NoError(os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "var/path/to/token"))
+
+	provider, err := gosoAws.GetCredentialsProvider(s.ctx, gosoAws.ClientSettings{
+		UseWebIdentity: true,
+	})
+
+	s.NoError(err)
+	s.IsType(&aws.CredentialsCache{}, provider, "the provider should be a assume role one")
 }
 
 func (s *CredentialsTestSuite) unmarshalClientSettings(values map[string]any) gosoAws.ClientSettings {


### PR DESCRIPTION
## Add support for AWS Web Identity (IRSA) credentials on EKS

### Motivation
For service accounts annotated with IAM roles (IRSA), AWS automatically injects a projected token file and environment variables. Following is required to be able to use service accounts in EKS.

### Configuration Example
```yaml
cloud:
  aws:
    s3:
      clients:
        default:
          region: eu-central-1
          use_web_identity: true
```

### Runtime Environment (EKS / IRSA)
IRSA sets:
```
AWS_ROLE_ARN=<role arn>
AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/.../token
```
No further config needed besides `use_web_identity: true`.

### Migration
No action required unless adopting IRSA. To enable: add `use_web_identity: true` and deploy with a properly annotated service account.

Related document from AWS: https://docs.aws.amazon.com/eks/latest/userguide/pod-configuration.html

We have been using this in production for 2 years. Only difference is following line:
```go
    cfg.UnmarshalWithDefaultsFromKey("cloud.aws.defaults.use_web_identity", "use_web_identity"),
```

Please let me know if any part needs further clarification.
